### PR TITLE
docs: Vercel deployment notes + PR preview diagnostic

### DIFF
--- a/DEPLOYMENTS.md
+++ b/DEPLOYMENTS.md
@@ -1,32 +1,50 @@
 # Deployments
 
-This repo deploys to Vercel via the Vercel GitHub integration.
+This repo deploys to Vercel project `v0-pilgrimage` (scope: `tomjohns-projects`).
 
-- **Vercel project:** `v0-pilgrimage` (scope: `tomjohns-projects`)
-- **Production:** every push to `main`
-- **Preview:** every push to any other branch, with a deployment URL posted to the PR
+## Current state: PR previews are not firing
 
-Two checks run on each PR: `Vercel` (the build/deploy itself) and
-`Vercel Preview Comments`. No workflow files or `vercel.json` are needed —
-the integration handles both.
+The Vercel GitHub integration deployed this repo in April 2026 — production
+builds from `main` and one preview for the v0-authored PR #1, all successful.
+It is **not** deploying now.
 
-## Staging a change
+Evidence, from PR #2 (branch `tomjohndesign/vercel-pr-previews`):
 
-Open a PR against `main`. The Vercel bot comments with the preview URL once
-the build finishes. Each new commit on the branch redeploys and updates
-that same comment.
+- No deployment record on the branch after ~10 minutes
+  (`GET /repos/tomjohndesign/pilgrimage/deployments?ref=…` returns empty)
+- No `Vercel` or `Vercel Preview Comments` check on the head commit
+- No comment from the Vercel bot
 
-The repo is private, so preview URLs are behind Vercel Authentication by
-default — only members of the `tomjohns-projects` team can open them. To
-share a link with someone outside the team, either turn off Deployment
-Protection or generate a Protection Bypass token in
+PR #1 got both checks and a working preview URL, so the wiring existed and
+has since stopped. The likely causes, in order:
+
+1. The Vercel GitHub App lost access to this repo
+   (GitHub → Settings → Applications → Vercel → Repository access)
+2. The project was disconnected from Git
+   (Vercel → `v0-pilgrimage` → Settings → Git)
+3. A branch filter or Ignored Build Step is skipping non-`v0/*` branches
+   (same Git settings page)
+
+Reconnecting the repo under Settings → Git is enough to restore previews;
+Vercel deploys every branch by default and needs no `vercel.json` or
+workflow file.
+
+## Once it's working
+
+Open a PR against `main`. The Vercel bot comments with a preview URL when
+the build finishes, and each new commit redeploys and updates that comment.
+Pushes to `main` go to production.
+
+The repo is private, so preview URLs sit behind Vercel Authentication —
+only `tomjohns-projects` members can open them. To share a link outside the
+team, turn off Deployment Protection or mint a Protection Bypass token under
 **Project → Settings → Deployment Protection**.
 
 ## Adding the app and marketing site
 
-Right now the game design doc is the Next.js app at the repo root, and the
-Vercel project's Root Directory points there. Adding a second and third
-surface means moving to a monorepo layout, e.g.:
+The game design doc is currently the Next.js app at the repo root, and the
+Vercel project's Root Directory points there. A second and third surface
+means a monorepo layout, e.g.:
 
 ```
 apps/doc/         # game design doc (currently the repo root)
@@ -37,9 +55,9 @@ apps/marketing/
 That move needs two coordinated steps, or deploys break:
 
 1. Restructure the repo and add a workspace config (`pnpm-workspace.yaml`).
-2. Update the existing Vercel project's **Root Directory** to `apps/doc`,
-   then create one Vercel project per remaining app in the same scope,
-   each pointing at this repo with its own Root Directory.
+2. Point the existing Vercel project's **Root Directory** at `apps/doc`, then
+   create one Vercel project per remaining app in the same scope, each
+   pointing at this repo with its own Root Directory.
 
 Each project gets its own domains and its own preview URL per PR. Set each
 one's **Ignored Build Step** to skip builds when its directory is untouched,

--- a/DEPLOYMENTS.md
+++ b/DEPLOYMENTS.md
@@ -1,0 +1,46 @@
+# Deployments
+
+This repo deploys to Vercel via the Vercel GitHub integration.
+
+- **Vercel project:** `v0-pilgrimage` (scope: `tomjohns-projects`)
+- **Production:** every push to `main`
+- **Preview:** every push to any other branch, with a deployment URL posted to the PR
+
+Two checks run on each PR: `Vercel` (the build/deploy itself) and
+`Vercel Preview Comments`. No workflow files or `vercel.json` are needed —
+the integration handles both.
+
+## Staging a change
+
+Open a PR against `main`. The Vercel bot comments with the preview URL once
+the build finishes. Each new commit on the branch redeploys and updates
+that same comment.
+
+The repo is private, so preview URLs are behind Vercel Authentication by
+default — only members of the `tomjohns-projects` team can open them. To
+share a link with someone outside the team, either turn off Deployment
+Protection or generate a Protection Bypass token in
+**Project → Settings → Deployment Protection**.
+
+## Adding the app and marketing site
+
+Right now the game design doc is the Next.js app at the repo root, and the
+Vercel project's Root Directory points there. Adding a second and third
+surface means moving to a monorepo layout, e.g.:
+
+```
+apps/doc/         # game design doc (currently the repo root)
+apps/app/
+apps/marketing/
+```
+
+That move needs two coordinated steps, or deploys break:
+
+1. Restructure the repo and add a workspace config (`pnpm-workspace.yaml`).
+2. Update the existing Vercel project's **Root Directory** to `apps/doc`,
+   then create one Vercel project per remaining app in the same scope,
+   each pointing at this repo with its own Root Directory.
+
+Each project gets its own domains and its own preview URL per PR. Set each
+one's **Ignored Build Step** to skip builds when its directory is untouched,
+so a marketing-copy PR doesn't rebuild all three.


### PR DESCRIPTION
Adds `DEPLOYMENTS.md`, and doubles as a live test of whether Vercel preview deployments fire on a normal PR.

**They don't.** Over ~10 minutes on two pushes this PR got no deployment record, no `Vercel` check, and no bot comment. PR #1 (v0-authored, April) got all three and a working preview URL, so the integration existed and has since stopped.

`DEPLOYMENTS.md` records the evidence, the three likely causes in the Vercel/GitHub settings, and what the monorepo split into app + marketing + game doc will need on the Vercel side.

Leave this open as the test case — once the repo is reconnected, a push here should produce a preview URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)