### PR TITLE
Isometric camera and map prototype at /play

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ next.user-config.*
 node_modules
 .next/
 .DS_Store
+tsconfig.tsbuildinfo

--- a/app/play/page.tsx
+++ b/app/play/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next"
+
+import { GameShell } from "@/components/game/game-shell"
+
+export const metadata: Metadata = {
+  title: "Pilgrimage — Prototype",
+  description: "Isometric camera and map prototype for Pilgrimage.",
+}
+
+export default function PlayPage() {
+  return <GameShell />
+}

--- a/components/game/buildings.tsx
+++ b/components/game/buildings.tsx
@@ -1,0 +1,44 @@
+"use client"
+
+import { TERRAIN } from "@/lib/game/map/terrain"
+import { tileAt, tileToWorldX, tileToWorldZ, type GameMap } from "@/lib/game/map/types"
+
+/** Shrink the body slightly so neighbouring footprints don't visually merge. */
+const BODY_INSET = 0.86
+const ROOF_INSET = 0.98
+const ROOF_THICKNESS = 0.18
+
+/**
+ * Placeholder structures. A body box plus a thin contrasting cap — enough to
+ * read as a building at this camera angle and to prove footprint placement.
+ */
+export function Buildings({ map }: { map: GameMap }) {
+  return (
+    <group>
+      {map.buildings.map((building) => {
+        // Footprint centre: the origin tile's centre, offset by half the extra tiles.
+        const centreX = tileToWorldX(map, building.x) + (building.w - 1) / 2
+        const centreZ = tileToWorldZ(map, building.z) + (building.d - 1) / 2
+        const groundTerrain = tileAt(map, building.x, building.z)
+        const baseY = groundTerrain ? TERRAIN[groundTerrain].height : 0
+
+        return (
+          <group key={building.id} position={[centreX, baseY, centreZ]}>
+            <mesh position={[0, building.height / 2, 0]} castShadow receiveShadow>
+              <boxGeometry
+                args={[building.w * BODY_INSET, building.height, building.d * BODY_INSET]}
+              />
+              <meshLambertMaterial color={building.color} />
+            </mesh>
+            <mesh position={[0, building.height + ROOF_THICKNESS / 2, 0]} castShadow receiveShadow>
+              <boxGeometry
+                args={[building.w * ROOF_INSET, ROOF_THICKNESS, building.d * ROOF_INSET]}
+              />
+              <meshLambertMaterial color={building.roofColor} />
+            </mesh>
+          </group>
+        )
+      })}
+    </group>
+  )
+}

--- a/components/game/camera-rig.tsx
+++ b/components/game/camera-rig.tsx
@@ -1,0 +1,253 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import { useFrame, useThree } from "@react-three/fiber"
+import * as THREE from "three"
+
+import { useCameraStore } from "@/lib/game/camera-store"
+import { PROTOTYPE_MAP } from "@/lib/game/map/prototype-map"
+import { worldToTileX, worldToTileZ } from "@/lib/game/map/types"
+import {
+  CAM_FAR,
+  CAM_NEAR,
+  cameraOffset,
+  panDelta,
+  screenBasis,
+  worldPerPixel,
+  yawForView,
+} from "@/lib/game/render/iso"
+
+/** How fast the yaw and zoom tweens converge. Higher = snappier. */
+const TWEEN_LAMBDA = 9
+
+/** Keyboard pan speed, in world units per second at the default zoom. */
+const KEY_PAN_SPEED = 18
+
+/**
+ * Height of the plane used for cursor picking. Most tiles top out around 0.2,
+ * so picking against that plane keeps the tile cursor aligned with what the
+ * player sees. Hills read slightly off until real height-aware picking lands.
+ */
+const PICK_PLANE_Y = 0.2
+
+export function CameraRig() {
+  const { camera, gl, size } = useThree()
+
+  const displayYaw = useRef(yawForView(useCameraStore.getState().viewIndex))
+  const displayViewSize = useRef(useCameraStore.getState().viewSize)
+  const heldKeys = useRef(new Set<string>())
+
+  const pickPlane = useRef(new THREE.Plane(new THREE.Vector3(0, 1, 0), -PICK_PLANE_Y))
+  const raycaster = useRef(new THREE.Raycaster())
+  const hitPoint = useRef(new THREE.Vector3())
+  const ndc = useRef(new THREE.Vector2())
+
+  // --- Pointer: drag to pan, move to hover ------------------------------------
+  useEffect(() => {
+    const canvas = gl.domElement
+    const { pan, setHovered } = useCameraStore.getState()
+
+    let dragPointerId: number | null = null
+    let lastX = 0
+    let lastY = 0
+
+    const updateHover = (event: PointerEvent) => {
+      const rect = canvas.getBoundingClientRect()
+      ndc.current.set(
+        ((event.clientX - rect.left) / rect.width) * 2 - 1,
+        -((event.clientY - rect.top) / rect.height) * 2 + 1,
+      )
+      raycaster.current.setFromCamera(ndc.current, camera)
+      const hit = raycaster.current.ray.intersectPlane(pickPlane.current, hitPoint.current)
+      if (!hit) {
+        setHovered(null)
+        return
+      }
+      const tx = worldToTileX(PROTOTYPE_MAP, hit.x)
+      const tz = worldToTileZ(PROTOTYPE_MAP, hit.z)
+      if (tx < 0 || tz < 0 || tx >= PROTOTYPE_MAP.width || tz >= PROTOTYPE_MAP.depth) {
+        setHovered(null)
+        return
+      }
+      setHovered({ x: tx, z: tz })
+    }
+
+    const onPointerDown = (event: PointerEvent) => {
+      if (dragPointerId !== null) return
+      dragPointerId = event.pointerId
+      lastX = event.clientX
+      lastY = event.clientY
+      canvas.setPointerCapture(event.pointerId)
+    }
+
+    const onPointerMove = (event: PointerEvent) => {
+      if (event.pointerId === dragPointerId) {
+        const dx = event.clientX - lastX
+        const dy = event.clientY - lastY
+        lastX = event.clientX
+        lastY = event.clientY
+        if (dx !== 0 || dy !== 0) {
+          canvas.style.cursor = "grabbing"
+          const scale = worldPerPixel(displayViewSize.current, canvas.clientHeight)
+          const delta = panDelta(displayYaw.current, dx, dy, scale)
+          pan(delta.dx, delta.dz)
+        }
+        // Panning moves the world under a stationary cursor, so re-pick.
+        updateHover(event)
+        return
+      }
+      updateHover(event)
+    }
+
+    const endDrag = (event: PointerEvent) => {
+      if (event.pointerId !== dragPointerId) return
+      canvas.releasePointerCapture(event.pointerId)
+      dragPointerId = null
+      canvas.style.cursor = "grab"
+    }
+
+    const onPointerLeave = () => {
+      if (dragPointerId === null) setHovered(null)
+    }
+
+    // Suppress the context menu so right-drag panning stays available later.
+    const onContextMenu = (event: Event) => event.preventDefault()
+
+    canvas.style.cursor = "grab"
+    canvas.addEventListener("pointerdown", onPointerDown)
+    canvas.addEventListener("pointermove", onPointerMove)
+    canvas.addEventListener("pointerup", endDrag)
+    canvas.addEventListener("pointercancel", endDrag)
+    canvas.addEventListener("pointerleave", onPointerLeave)
+    canvas.addEventListener("contextmenu", onContextMenu)
+
+    return () => {
+      canvas.removeEventListener("pointerdown", onPointerDown)
+      canvas.removeEventListener("pointermove", onPointerMove)
+      canvas.removeEventListener("pointerup", endDrag)
+      canvas.removeEventListener("pointercancel", endDrag)
+      canvas.removeEventListener("pointerleave", onPointerLeave)
+      canvas.removeEventListener("contextmenu", onContextMenu)
+    }
+  }, [camera, gl])
+
+  // --- Wheel: zoom ------------------------------------------------------------
+  useEffect(() => {
+    const canvas = gl.domElement
+    const { zoomBy } = useCameraStore.getState()
+
+    const onWheel = (event: WheelEvent) => {
+      event.preventDefault()
+      // Normalise line-mode deltas so a mouse wheel and a trackpad feel similar.
+      const delta = event.deltaMode === 1 ? event.deltaY * 16 : event.deltaY
+      zoomBy(Math.exp(delta * 0.0015))
+    }
+
+    canvas.addEventListener("wheel", onWheel, { passive: false })
+    return () => canvas.removeEventListener("wheel", onWheel)
+  }, [gl])
+
+  // --- Keyboard: pan, rotate, zoom, reset -------------------------------------
+  useEffect(() => {
+    const { rotate, zoomBy, reset } = useCameraStore.getState()
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null
+      if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA")) return
+
+      const key = event.key.toLowerCase()
+      heldKeys.current.add(key)
+
+      // Rotation and zoom fire once per press, not on auto-repeat.
+      if (event.repeat) return
+      switch (key) {
+        case "q":
+        case ",":
+          rotate(-1)
+          break
+        case "e":
+        case ".":
+          rotate(1)
+          break
+        case "=":
+        case "+":
+          zoomBy(1 / 1.25)
+          break
+        case "-":
+        case "_":
+          zoomBy(1.25)
+          break
+        case "0":
+          reset()
+          break
+      }
+    }
+
+    const onKeyUp = (event: KeyboardEvent) => heldKeys.current.delete(event.key.toLowerCase())
+    const onBlur = () => heldKeys.current.clear()
+
+    window.addEventListener("keydown", onKeyDown)
+    window.addEventListener("keyup", onKeyUp)
+    window.addEventListener("blur", onBlur)
+    return () => {
+      window.removeEventListener("keydown", onKeyDown)
+      window.removeEventListener("keyup", onKeyUp)
+      window.removeEventListener("blur", onBlur)
+    }
+  }, [])
+
+  // --- Per-frame: tween and drive the camera ----------------------------------
+  useFrame((_, delta) => {
+    const { targetX, targetZ, viewIndex, viewSize, pan } = useCameraStore.getState()
+    // A background tab can hand us a huge delta; clamp so tweens don't overshoot.
+    const dt = Math.min(delta, 0.1)
+
+    displayYaw.current = THREE.MathUtils.damp(
+      displayYaw.current,
+      yawForView(viewIndex),
+      TWEEN_LAMBDA,
+      dt,
+    )
+    displayViewSize.current = THREE.MathUtils.damp(
+      displayViewSize.current,
+      viewSize,
+      TWEEN_LAMBDA,
+      dt,
+    )
+
+    // Keyboard panning is screen-relative, so it follows the current rotation.
+    const keys = heldKeys.current
+    const up = keys.has("w") || keys.has("arrowup")
+    const down = keys.has("s") || keys.has("arrowdown")
+    const left = keys.has("a") || keys.has("arrowleft")
+    const right = keys.has("d") || keys.has("arrowright")
+    if (up || down || left || right) {
+      const basis = screenBasis(displayYaw.current)
+      // Scale with zoom so panning feels the same at every zoom level.
+      const speed = KEY_PAN_SPEED * (displayViewSize.current / 26) * dt
+      const forward = (up ? 1 : 0) - (down ? 1 : 0)
+      const strafe = (right ? 1 : 0) - (left ? 1 : 0)
+      pan(
+        basis.fwdX * forward * speed + basis.rightX * strafe * speed,
+        basis.fwdZ * forward * speed + basis.rightZ * strafe * speed,
+      )
+    }
+
+    const cam = camera as THREE.OrthographicCamera
+    const halfHeight = displayViewSize.current / 2
+    const aspect = size.width / Math.max(1, size.height)
+    cam.left = -halfHeight * aspect
+    cam.right = halfHeight * aspect
+    cam.top = halfHeight
+    cam.bottom = -halfHeight
+    cam.near = CAM_NEAR
+    cam.far = CAM_FAR
+
+    const [ox, oy, oz] = cameraOffset(displayYaw.current)
+    cam.position.set(targetX + ox, oy, targetZ + oz)
+    cam.lookAt(targetX, 0, targetZ)
+    cam.updateProjectionMatrix()
+  })
+
+  return null
+}

--- a/components/game/debug-handle.tsx
+++ b/components/game/debug-handle.tsx
@@ -1,0 +1,47 @@
+"use client"
+
+import { useEffect } from "react"
+import { useThree } from "@react-three/fiber"
+
+import { useCameraStore } from "@/lib/game/camera-store"
+import { PROTOTYPE_MAP } from "@/lib/game/map/prototype-map"
+
+/**
+ * Exposes a small handle on `window` so the scene can be driven deterministically
+ * from Playwright or the console — set a camera pose, screenshot, compare.
+ * Development only; it is never mounted in a production build.
+ */
+export function DebugHandle() {
+  const { gl, camera, scene } = useThree()
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === "production") return
+
+    const handle = {
+      map: PROTOTYPE_MAP,
+      camera: () => useCameraStore.getState(),
+      /** Jump straight to a pose. The rig still tweens toward it over a few frames. */
+      setView: (viewIndex: number) =>
+        useCameraStore.setState({ viewIndex: Math.round(viewIndex) }),
+      setTarget: (x: number, z: number) => useCameraStore.setState({ targetX: x, targetZ: z }),
+      setZoom: (viewSize: number) => useCameraStore.setState({ viewSize }),
+      reset: () => useCameraStore.getState().reset(),
+      /**
+       * Data URL of the current frame. Renders first so the drawing buffer is
+       * populated — without that, reading it back returns a blank image unless
+       * the context was created with `preserveDrawingBuffer`.
+       */
+      screenshot: () => {
+        gl.render(scene, camera)
+        return gl.domElement.toDataURL("image/png")
+      },
+    }
+
+    ;(window as unknown as Record<string, unknown>).__pilgrimage = handle
+    return () => {
+      delete (window as unknown as Record<string, unknown>).__pilgrimage
+    }
+  }, [gl, camera, scene])
+
+  return null
+}

--- a/components/game/game-canvas.tsx
+++ b/components/game/game-canvas.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import { Canvas } from "@react-three/fiber"
+
+import { PROTOTYPE_MAP } from "@/lib/game/map/prototype-map"
+import { CAM_FAR, CAM_NEAR } from "@/lib/game/render/iso"
+
+import { Buildings } from "./buildings"
+import { CameraRig } from "./camera-rig"
+import { DebugHandle } from "./debug-handle"
+import { TerrainTiles } from "./terrain-tiles"
+import { TileCursor } from "./tile-cursor"
+import { Trees } from "./trees"
+
+const BACKGROUND = "#14100a"
+
+/** Half-extent of the shadow camera. Must cover the whole map plus a margin. */
+const SHADOW_EXTENT = 30
+
+export function GameCanvas() {
+  return (
+    <Canvas
+      orthographic
+      shadows
+      dpr={[1, 2]}
+      gl={{ antialias: true }}
+      camera={{ position: [20, 20, 20], near: CAM_NEAR, far: CAM_FAR }}
+    >
+      <color attach="background" args={[BACKGROUND]} />
+
+      {/*
+        Light stays fixed to the world, so shadows swing as the view rotates.
+        Fill is kept low deliberately — the sun has to do most of the work or
+        the boxes lose their form and the cast shadows stop reading.
+      */}
+      <ambientLight intensity={0.5} />
+      <hemisphereLight args={["#bcd0f0", "#3a2a16", 0.45]} />
+      <directionalLight
+        position={[26, 40, 18]}
+        intensity={2.7}
+        castShadow
+        shadow-mapSize-width={2048}
+        shadow-mapSize-height={2048}
+        shadow-camera-left={-SHADOW_EXTENT}
+        shadow-camera-right={SHADOW_EXTENT}
+        shadow-camera-top={SHADOW_EXTENT}
+        shadow-camera-bottom={-SHADOW_EXTENT}
+        shadow-camera-near={1}
+        shadow-camera-far={120}
+        shadow-bias={-0.0012}
+        shadow-normalBias={0.02}
+      />
+
+      <TerrainTiles map={PROTOTYPE_MAP} />
+      <Trees map={PROTOTYPE_MAP} />
+      <Buildings map={PROTOTYPE_MAP} />
+      <TileCursor map={PROTOTYPE_MAP} />
+
+      <CameraRig />
+      <DebugHandle />
+    </Canvas>
+  )
+}

--- a/components/game/game-hud.tsx
+++ b/components/game/game-hud.tsx
@@ -1,0 +1,126 @@
+"use client"
+
+import { useCameraStore } from "@/lib/game/camera-store"
+import { PROTOTYPE_MAP } from "@/lib/game/map/prototype-map"
+import { TERRAIN } from "@/lib/game/map/terrain"
+import { tileAt } from "@/lib/game/map/types"
+import {
+  DEFAULT_VIEW_SIZE,
+  MAX_VIEW_SIZE,
+  MIN_VIEW_SIZE,
+  normalizeViewIndex,
+} from "@/lib/game/render/iso"
+
+const CONTROLS: Array<[string, string]> = [
+  ["Drag", "Pan"],
+  ["Scroll", "Zoom"],
+  ["Q / E", "Rotate view"],
+  ["W A S D", "Pan"],
+  ["0", "Reset camera"],
+]
+
+function Panel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="pointer-events-none border border-rule bg-parchment/95 px-4 py-3 shadow-[0_2px_16px_rgba(0,0,0,0.6)]">
+      {children}
+    </div>
+  )
+}
+
+function Label({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="font-display text-[9px] uppercase tracking-[2px] text-gold">{children}</div>
+  )
+}
+
+export function GameHud() {
+  const viewIndex = useCameraStore((s) => s.viewIndex)
+  const viewSize = useCameraStore((s) => s.viewSize)
+  const hovered = useCameraStore((s) => s.hovered)
+
+  const view = normalizeViewIndex(viewIndex)
+  // Relative to the default zoom, so 100% is where the camera starts and
+  // bigger reads as closer.
+  const zoomPercent = Math.round((DEFAULT_VIEW_SIZE / viewSize) * 100)
+  const hoveredTerrain = hovered ? tileAt(PROTOTYPE_MAP, hovered.x, hovered.z) : null
+
+  return (
+    <>
+      <div className="absolute left-5 top-5 z-10">
+        <Panel>
+          <div className="font-display text-sm font-bold tracking-[3px] text-ink">PILGRIMAGE</div>
+          <div className="font-display text-[9px] uppercase tracking-[2px] text-gold">
+            Prototype — Camera &amp; Map
+          </div>
+        </Panel>
+      </div>
+
+      <div className="absolute right-5 top-5 z-10 flex flex-col gap-2">
+        <Panel>
+          <Label>View</Label>
+          <div className="flex items-center gap-1.5 pt-1">
+            {[0, 1, 2, 3].map((index) => (
+              <span
+                key={index}
+                className={`flex h-5 w-5 items-center justify-center border font-display text-[10px] ${
+                  index === view
+                    ? "border-gold bg-gold text-parchment"
+                    : "border-rule bg-parchment-dark text-ink-light"
+                }`}
+              >
+                {index + 1}
+              </span>
+            ))}
+          </div>
+        </Panel>
+
+        <Panel>
+          <Label>Zoom</Label>
+          <div className="pt-1 font-display text-xs text-ink">{zoomPercent}%</div>
+          <div className="mt-1.5 h-1 w-28 bg-parchment-dark">
+            <div
+              className="h-full bg-gold"
+              style={{
+                width: `${
+                  ((MAX_VIEW_SIZE - viewSize) / (MAX_VIEW_SIZE - MIN_VIEW_SIZE)) * 100
+                }%`,
+              }}
+            />
+          </div>
+        </Panel>
+      </div>
+
+      <div className="absolute bottom-5 left-5 z-10">
+        <Panel>
+          <Label>Tile</Label>
+          {hovered && hoveredTerrain ? (
+            <div className="pt-1">
+              <div className="font-display text-xs text-ink">
+                {hovered.x}, {hovered.z}
+              </div>
+              <div className="text-[13px] italic text-ink-light">
+                {TERRAIN[hoveredTerrain].label}
+              </div>
+            </div>
+          ) : (
+            <div className="pt-1 text-[13px] italic text-ink-light">—</div>
+          )}
+        </Panel>
+      </div>
+
+      <div className="absolute bottom-5 right-5 z-10">
+        <Panel>
+          <Label>Controls</Label>
+          <dl className="mt-1 grid grid-cols-[auto_auto] gap-x-3 gap-y-0.5">
+            {CONTROLS.map(([key, action]) => (
+              <div key={key} className="contents">
+                <dt className="font-display text-[10px] text-gold">{key}</dt>
+                <dd className="text-[13px] text-ink-light">{action}</dd>
+              </div>
+            ))}
+          </dl>
+        </Panel>
+      </div>
+    </>
+  )
+}

--- a/components/game/game-shell.tsx
+++ b/components/game/game-shell.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import dynamic from "next/dynamic"
+
+import { GameHud } from "./game-hud"
+
+/**
+ * WebGL has no meaningful server render, and three.js touches browser globals on
+ * import, so the canvas is client-only. The HUD is plain DOM and renders normally.
+ */
+const GameCanvas = dynamic(() => import("./game-canvas").then((m) => m.GameCanvas), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-full w-full items-center justify-center">
+      <span className="font-display text-[10px] uppercase tracking-[3px] text-gold">
+        Surveying the land…
+      </span>
+    </div>
+  ),
+})
+
+export function GameShell() {
+  return (
+    <div className="fixed inset-0 overflow-hidden bg-[#14100a] select-none">
+      <GameCanvas />
+      <GameHud />
+    </div>
+  )
+}

--- a/components/game/terrain-tiles.tsx
+++ b/components/game/terrain-tiles.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import { useLayoutEffect, useMemo, useRef } from "react"
+import * as THREE from "three"
+
+import { makeRng } from "@/lib/game/rng"
+import { TERRAIN } from "@/lib/game/map/terrain"
+import { tileToWorldX, tileToWorldZ, type GameMap } from "@/lib/game/map/types"
+
+/**
+ * Tiles are drawn slightly smaller than 1 unit so the gaps between them read as
+ * grid lines against the darker slab underneath.
+ */
+const TILE_INSET = 0.94
+
+/** Top of the base slab. Must sit below the shortest terrain height. */
+export const SLAB_TOP = 0.08
+
+const SLAB_THICKNESS = 1.2
+const SLAB_COLOR = "#241a10"
+
+/** Deterministic, so the map looks identical on every load and in screenshots. */
+const TILE_JITTER_SEED = 20250805
+
+export function TerrainTiles({ map }: { map: GameMap }) {
+  const meshRef = useRef<THREE.InstancedMesh>(null)
+  const count = map.width * map.depth
+
+  useLayoutEffect(() => {
+    const mesh = meshRef.current
+    if (!mesh) return
+
+    const matrix = new THREE.Matrix4()
+    const position = new THREE.Vector3()
+    const quaternion = new THREE.Quaternion()
+    const scale = new THREE.Vector3()
+    const color = new THREE.Color()
+    const rng = makeRng(TILE_JITTER_SEED)
+
+    for (let z = 0; z < map.depth; z++) {
+      for (let x = 0; x < map.width; x++) {
+        const index = z * map.width + x
+        const def = TERRAIN[map.tiles[index]]
+
+        // Box base sits at y=0 and the top at the terrain height, so tiles sink
+        // into the slab and never show a gap from a low camera angle.
+        position.set(tileToWorldX(map, x), def.height / 2, tileToWorldZ(map, z))
+        scale.set(TILE_INSET, def.height, TILE_INSET)
+        matrix.compose(position, quaternion, scale)
+        mesh.setMatrixAt(index, matrix)
+
+        color.set(def.color)
+        color.multiplyScalar(1 + (rng() - 0.5) * def.jitter)
+        mesh.setColorAt(index, color)
+      }
+    }
+
+    mesh.instanceMatrix.needsUpdate = true
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true
+  }, [map])
+
+  const slabPosition = useMemo<[number, number, number]>(
+    () => [0, SLAB_TOP - SLAB_THICKNESS / 2, 0],
+    [],
+  )
+
+  return (
+    <group>
+      <mesh position={slabPosition} receiveShadow>
+        <boxGeometry args={[map.width, SLAB_THICKNESS, map.depth]} />
+        <meshLambertMaterial color={SLAB_COLOR} />
+      </mesh>
+
+      <instancedMesh
+        ref={meshRef}
+        args={[undefined as unknown as THREE.BufferGeometry, undefined as unknown as THREE.Material, count]}
+        castShadow
+        receiveShadow
+      >
+        <boxGeometry args={[1, 1, 1]} />
+        <meshLambertMaterial />
+      </instancedMesh>
+    </group>
+  )
+}

--- a/components/game/tile-cursor.tsx
+++ b/components/game/tile-cursor.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import { useCameraStore } from "@/lib/game/camera-store"
+import { TERRAIN } from "@/lib/game/map/terrain"
+import { tileAt, tileToWorldX, tileToWorldZ, type GameMap } from "@/lib/game/map/types"
+
+/**
+ * Highlight for the tile under the cursor. Mostly here to prove the
+ * screen-to-grid mapping holds up across all four rotations and zoom levels.
+ */
+export function TileCursor({ map }: { map: GameMap }) {
+  const hovered = useCameraStore((s) => s.hovered)
+  if (!hovered) return null
+
+  const terrain = tileAt(map, hovered.x, hovered.z)
+  if (!terrain) return null
+
+  const y = TERRAIN[terrain].height
+
+  return (
+    <mesh position={[tileToWorldX(map, hovered.x), y + 0.015, tileToWorldZ(map, hovered.z)]}>
+      <boxGeometry args={[1, 0.03, 1]} />
+      <meshBasicMaterial color="#f2e8d5" transparent opacity={0.4} depthWrite={false} />
+    </mesh>
+  )
+}

--- a/components/game/trees.tsx
+++ b/components/game/trees.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import { useLayoutEffect, useMemo, useRef } from "react"
+import * as THREE from "three"
+
+import { makeRng } from "@/lib/game/rng"
+import { TERRAIN } from "@/lib/game/map/terrain"
+import { tileToWorldX, tileToWorldZ, type GameMap } from "@/lib/game/map/types"
+
+/** Placeholder trees: one jittered box per forest tile, drawn in a single batch. */
+const TREE_SEED = 774411
+const TREE_COLOR = new THREE.Color("#40542e")
+
+export function Trees({ map }: { map: GameMap }) {
+  const meshRef = useRef<THREE.InstancedMesh>(null)
+
+  const forestTiles = useMemo(() => {
+    const tiles: Array<{ x: number; z: number }> = []
+    for (let z = 0; z < map.depth; z++) {
+      for (let x = 0; x < map.width; x++) {
+        if (map.tiles[z * map.width + x] === "forest") tiles.push({ x, z })
+      }
+    }
+    return tiles
+  }, [map])
+
+  useLayoutEffect(() => {
+    const mesh = meshRef.current
+    if (!mesh) return
+
+    const matrix = new THREE.Matrix4()
+    const position = new THREE.Vector3()
+    const quaternion = new THREE.Quaternion()
+    const euler = new THREE.Euler()
+    const scale = new THREE.Vector3()
+    const color = new THREE.Color()
+    const rng = makeRng(TREE_SEED)
+    const baseY = TERRAIN.forest.height
+
+    forestTiles.forEach((tile, index) => {
+      const height = 0.7 + rng() * 0.7
+      const width = 0.34 + rng() * 0.16
+      // Nudge off-centre so the canopy doesn't look like a regular lattice.
+      const offsetX = (rng() - 0.5) * 0.34
+      const offsetZ = (rng() - 0.5) * 0.34
+
+      position.set(
+        tileToWorldX(map, tile.x) + offsetX,
+        baseY + height / 2,
+        tileToWorldZ(map, tile.z) + offsetZ,
+      )
+      euler.set(0, rng() * Math.PI, 0)
+      quaternion.setFromEuler(euler)
+      scale.set(width, height, width)
+      matrix.compose(position, quaternion, scale)
+      mesh.setMatrixAt(index, matrix)
+
+      color.copy(TREE_COLOR).multiplyScalar(0.8 + rng() * 0.45)
+      mesh.setColorAt(index, color)
+    })
+
+    mesh.instanceMatrix.needsUpdate = true
+    if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true
+  }, [map, forestTiles])
+
+  if (forestTiles.length === 0) return null
+
+  return (
+    <instancedMesh
+      ref={meshRef}
+      args={[
+        undefined as unknown as THREE.BufferGeometry,
+        undefined as unknown as THREE.Material,
+        forestTiles.length,
+      ]}
+      castShadow
+      receiveShadow
+    >
+      <boxGeometry args={[1, 1, 1]} />
+      <meshLambertMaterial />
+    </instancedMesh>
+  )
+}

--- a/components/two-column-grid.tsx
+++ b/components/two-column-grid.tsx
@@ -1,7 +1,8 @@
 interface TwoColumnGridProps {
-  leftTitle: string
+  /** Optional — some grids are plain paired lists with no headings. */
+  leftTitle?: string
   leftItems: string[]
-  rightTitle: string
+  rightTitle?: string
   rightItems: string[]
 }
 
@@ -14,9 +15,11 @@ export function TwoColumnGrid({
   return (
     <div className="grid grid-cols-1 md:grid-cols-2 gap-6 my-4">
       <div>
-        <h3 className="font-display text-[13px] font-semibold tracking-[1px] text-ink mb-2">
-          {leftTitle}
-        </h3>
+        {leftTitle && (
+          <h3 className="font-display text-[13px] font-semibold tracking-[1px] text-ink mb-2">
+            {leftTitle}
+          </h3>
+        )}
         <ul className="list-none p-0 m-0">
           {leftItems.map((item, index) => (
             <li
@@ -29,9 +32,11 @@ export function TwoColumnGrid({
         </ul>
       </div>
       <div>
-        <h3 className="font-display text-[13px] font-semibold tracking-[1px] text-ink mb-2">
-          {rightTitle}
-        </h3>
+        {rightTitle && (
+          <h3 className="font-display text-[13px] font-semibold tracking-[1px] text-ink mb-2">
+            {rightTitle}
+          </h3>
+        )}
         <ul className="list-none p-0 m-0">
           {rightItems.map((item, index) => (
             <li

--- a/lib/game/camera-store.ts
+++ b/lib/game/camera-store.ts
@@ -1,0 +1,65 @@
+import { create } from "zustand"
+
+import { PROTOTYPE_MAP } from "./map/prototype-map"
+import { clampViewSize, DEFAULT_VIEW_SIZE } from "./render/iso"
+
+/** How far past the map edge the camera target may travel. */
+const PAN_MARGIN = 6
+
+const MAX_X = PROTOTYPE_MAP.width / 2 + PAN_MARGIN
+const MAX_Z = PROTOTYPE_MAP.depth / 2 + PAN_MARGIN
+
+export interface HoveredTile {
+  x: number
+  z: number
+}
+
+interface CameraState {
+  /** Camera focus point on the ground plane. */
+  targetX: number
+  targetZ: number
+  /** Unbounded integer so rotation tweens can wrap without spinning backwards. */
+  viewIndex: number
+  /** Orthographic frustum height in world units. */
+  viewSize: number
+  hovered: HoveredTile | null
+
+  pan: (dx: number, dz: number) => void
+  rotate: (direction: 1 | -1) => void
+  zoomBy: (factor: number) => void
+  setHovered: (tile: HoveredTile | null) => void
+  reset: () => void
+}
+
+const INITIAL = {
+  // Start looking at the plaza rather than the map centre.
+  targetX: 4,
+  targetZ: -4,
+  viewIndex: 0,
+  viewSize: DEFAULT_VIEW_SIZE,
+  hovered: null,
+}
+
+export const useCameraStore = create<CameraState>((set) => ({
+  ...INITIAL,
+
+  pan: (dx, dz) =>
+    set((s) => ({
+      targetX: Math.min(MAX_X, Math.max(-MAX_X, s.targetX + dx)),
+      targetZ: Math.min(MAX_Z, Math.max(-MAX_Z, s.targetZ + dz)),
+    })),
+
+  rotate: (direction) => set((s) => ({ viewIndex: s.viewIndex + direction })),
+
+  zoomBy: (factor) => set((s) => ({ viewSize: clampViewSize(s.viewSize * factor) })),
+
+  setHovered: (tile) =>
+    set((s) => {
+      // Avoid a store write (and re-render) on every mouse move within a tile.
+      if (tile === s.hovered) return s
+      if (tile && s.hovered && tile.x === s.hovered.x && tile.z === s.hovered.z) return s
+      return { hovered: tile }
+    }),
+
+  reset: () => set({ ...INITIAL }),
+}))

--- a/lib/game/game.test.ts
+++ b/lib/game/game.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest"
+
+import { PROTOTYPE_MAP } from "./map/prototype-map"
+import { TERRAIN } from "./map/terrain"
+import { tileAt, tileToWorldX, tileToWorldZ, worldToTileX, worldToTileZ } from "./map/types"
+import {
+  CAM_DISTANCE,
+  cameraOffset,
+  clampViewSize,
+  DEFAULT_VIEW_SIZE,
+  ISO_PITCH,
+  MAX_VIEW_SIZE,
+  MIN_VIEW_SIZE,
+  normalizeViewIndex,
+  panDelta,
+  screenBasis,
+  worldPerPixel,
+  yawForView,
+} from "./render/iso"
+import { makeRng } from "./rng"
+
+const DEG = 180 / Math.PI
+const TRUE_ISO_DEGREES = 35.264389682754654
+const VIEWS = [0, 1, 2, 3]
+
+describe("prototype map", () => {
+  it("parses to a full 32x32 grid", () => {
+    expect(PROTOTYPE_MAP.width).toBe(32)
+    expect(PROTOTYPE_MAP.depth).toBe(32)
+    expect(PROTOTYPE_MAP.tiles).toHaveLength(1024)
+    expect(PROTOTYPE_MAP.tiles.every(Boolean)).toBe(true)
+  })
+
+  it("carries a road from the west edge, through the plaza, to the east edge", () => {
+    const isPath = (x: number, z: number) => tileAt(PROTOTYPE_MAP, x, z) === "path"
+    expect(isPath(0, 17)).toBe(true)
+
+    // Flood fill the western run of road from the entry point.
+    const seen = new Set<string>()
+    const queue: Array<[number, number]> = [[0, 17]]
+    while (queue.length) {
+      const [x, z] = queue.pop()!
+      const key = `${x},${z}`
+      if (seen.has(key) || !isPath(x, z)) continue
+      seen.add(key)
+      queue.push([x + 1, z], [x - 1, z], [x, z + 1], [x, z - 1])
+    }
+
+    // The plaza's bare earth bridges the road at z=12, so the eastern leg is a
+    // separate run of path tiles. Both legs must terminate where expected.
+    expect(seen.has("16,12")).toBe(true)
+    expect(isPath(24, 12)).toBe(true)
+    expect(isPath(31, 12)).toBe(true)
+  })
+
+  it("places every building on buildable ground, clear of the road", () => {
+    for (const building of PROTOTYPE_MAP.buildings) {
+      for (let dz = 0; dz < building.d; dz++) {
+        for (let dx = 0; dx < building.w; dx++) {
+          const terrain = tileAt(PROTOTYPE_MAP, building.x + dx, building.z + dz)
+          expect(terrain, `${building.id} is in bounds`).toBeTruthy()
+          expect(terrain, `${building.id} is off the road`).not.toBe("path")
+          expect(TERRAIN[terrain!].buildable, `${building.id} is on buildable ground`).toBe(true)
+        }
+      }
+    }
+  })
+
+  it("has no overlapping building footprints", () => {
+    const occupied = new Set<string>()
+    for (const building of PROTOTYPE_MAP.buildings) {
+      for (let dz = 0; dz < building.d; dz++) {
+        for (let dx = 0; dx < building.w; dx++) {
+          const key = `${building.x + dx},${building.z + dz}`
+          expect(occupied.has(key), `overlap at ${key}`).toBe(false)
+          occupied.add(key)
+        }
+      }
+    }
+  })
+
+  it("round trips every tile through world space", () => {
+    for (let z = 0; z < PROTOTYPE_MAP.depth; z++) {
+      for (let x = 0; x < PROTOTYPE_MAP.width; x++) {
+        expect(worldToTileX(PROTOTYPE_MAP, tileToWorldX(PROTOTYPE_MAP, x))).toBe(x)
+        expect(worldToTileZ(PROTOTYPE_MAP, tileToWorldZ(PROTOTYPE_MAP, z))).toBe(z)
+      }
+    }
+  })
+})
+
+describe("isometric camera", () => {
+  it("uses a true isometric pitch", () => {
+    expect(ISO_PITCH * DEG).toBeCloseTo(TRUE_ISO_DEGREES, 6)
+  })
+
+  it("keeps one pitch and one distance across all four views", () => {
+    for (const view of VIEWS) {
+      const [ox, oy, oz] = cameraOffset(yawForView(view))
+      expect(Math.atan2(oy, Math.hypot(ox, oz)) * DEG).toBeCloseTo(TRUE_ISO_DEGREES, 6)
+      expect(Math.hypot(ox, oy, oz)).toBeCloseTo(CAM_DISTANCE, 6)
+    }
+  })
+
+  it("snaps views to 90 degree steps and wraps the index both ways", () => {
+    for (const view of VIEWS) {
+      expect((yawForView(view + 1) - yawForView(view)) * DEG).toBeCloseTo(90, 9)
+    }
+    expect(normalizeViewIndex(4)).toBe(0)
+    expect(normalizeViewIndex(-1)).toBe(3)
+    expect(normalizeViewIndex(7)).toBe(3)
+  })
+
+  it("derives an orthonormal screen basis at every view", () => {
+    for (const view of VIEWS) {
+      const b = screenBasis(yawForView(view))
+      expect(b.rightX * b.fwdX + b.rightZ * b.fwdZ).toBeCloseTo(0, 9)
+      expect(Math.hypot(b.rightX, b.rightZ)).toBeCloseTo(1, 9)
+      expect(Math.hypot(b.fwdX, b.fwdZ)).toBeCloseTo(1, 9)
+    }
+  })
+
+  it("clamps zoom to its range", () => {
+    expect(clampViewSize(1)).toBe(MIN_VIEW_SIZE)
+    expect(clampViewSize(9999)).toBe(MAX_VIEW_SIZE)
+    expect(clampViewSize(DEFAULT_VIEW_SIZE)).toBe(DEFAULT_VIEW_SIZE)
+  })
+})
+
+describe("drag to pan", () => {
+  /**
+   * Screen-space position of a ground point, derived independently of panDelta
+   * so the two can be checked against each other. Screen y grows downward.
+   */
+  function project(
+    pointX: number,
+    pointZ: number,
+    targetX: number,
+    targetZ: number,
+    yaw: number,
+    wpp: number,
+  ) {
+    const b = screenBasis(yaw)
+    const rx = pointX - targetX
+    const rz = pointZ - targetZ
+    return {
+      sx: (rx * b.rightX + rz * b.rightZ) / wpp,
+      sy: -((rx * b.fwdX + rz * b.fwdZ) * Math.sin(ISO_PITCH)) / wpp,
+    }
+  }
+
+  const DRAGS: Array<[number, number]> = [
+    [120, 0],
+    [0, 90],
+    [0, -90],
+    [-64, 37],
+    [200, -150],
+  ]
+
+  it("moves the ground exactly with the cursor, at every view and zoom", () => {
+    for (const view of VIEWS) {
+      const yaw = yawForView(view)
+      for (const [dxPixels, dyPixels] of DRAGS) {
+        for (const viewSize of [MIN_VIEW_SIZE, DEFAULT_VIEW_SIZE, MAX_VIEW_SIZE]) {
+          const wpp = worldPerPixel(viewSize, 800)
+          let targetX = 3.5
+          let targetZ = -2.25
+          const landmarkX = 7
+          const landmarkZ = 5
+
+          const before = project(landmarkX, landmarkZ, targetX, targetZ, yaw, wpp)
+          const delta = panDelta(yaw, dxPixels, dyPixels, wpp)
+          targetX += delta.dx
+          targetZ += delta.dz
+          const after = project(landmarkX, landmarkZ, targetX, targetZ, yaw, wpp)
+
+          expect(after.sx - before.sx).toBeCloseTo(dxPixels, 6)
+          expect(after.sy - before.sy).toBeCloseTo(dyPixels, 6)
+        }
+      }
+    }
+  })
+})
+
+describe("seeded rng", () => {
+  it("is deterministic for a given seed", () => {
+    const a = makeRng(42)
+    const b = makeRng(42)
+    for (let i = 0; i < 500; i++) expect(a()).toBe(b())
+  })
+
+  it("stays within [0, 1)", () => {
+    const rng = makeRng(7)
+    for (let i = 0; i < 20000; i++) {
+      const value = rng()
+      expect(value).toBeGreaterThanOrEqual(0)
+      expect(value).toBeLessThan(1)
+    }
+  })
+})

--- a/lib/game/map/prototype-map.ts
+++ b/lib/game/map/prototype-map.ts
@@ -1,0 +1,144 @@
+import { TERRAIN_CHARS, type TerrainId } from "./terrain"
+import type { BuildingDef, GameMap } from "./types"
+
+/**
+ * The prototype map, authored as ASCII so it stays hand-editable.
+ *
+ *   .  clear land (grass)     ,  bare earth (the plaza floor)
+ *   =  road                   F  forest
+ *   ^  hills
+ *
+ * The road enters from the west edge at z=17, runs east, turns north at x=9,
+ * then runs east again along z=12 through the plaza and off the east edge.
+ * Every row must be exactly as wide as the first — `parseAsciiMap` enforces it.
+ */
+export const PROTOTYPE_MAP_ROWS = [
+  "................................", // 0
+  "..FFFFFF........................", // 1
+  ".FFFFFFF........................", // 2
+  ".FFFFFF...................^^^^^.", // 3
+  "..FFFFFF.................^^^^^^.", // 4
+  "..FFFFF..................^^^^^^^", // 5
+  "...FFFF...................^^^^^^", // 6
+  "...FFF.....................^^^^^", // 7
+  "............................^^^^", // 8
+  ".................,,,,,,,........", // 9
+  ".................,,,,,,,........", // 10
+  ".................,,,,,,,........", // 11
+  ".........========,,,,,,,========", // 12
+  ".........=.......,,,,,,,........", // 13
+  ".........=.......,,,,,,,........", // 14
+  ".........=.......,,,,,,,........", // 15
+  ".........=......................", // 16
+  "==========......................", // 17
+  "................................", // 18
+  "................................", // 19
+  "................................", // 20
+  "................................", // 21
+  "................................", // 22
+  "................................", // 23
+  "........................FFFFFF..", // 24
+  ".......................FFFFFFF..", // 25
+  ".......................FFFFFFFF.", // 26
+  "........................FFFFFFF.", // 27
+  ".........................FFFFFF.", // 28
+  "..........................FFFF..", // 29
+  "................................", // 30
+  "................................", // 31
+]
+
+/**
+ * Placeholder structures. Everything is a box for now — the point is to prove
+ * the grid-to-world mapping and footprint sizing, not the art.
+ * All of these sit inside the plaza (x 17–23, z 9–15), clear of the road at z=12.
+ */
+export const PROTOTYPE_BUILDINGS: BuildingDef[] = [
+  {
+    id: "relic",
+    label: "Relic Shrine",
+    x: 19,
+    z: 9,
+    w: 2,
+    d: 2,
+    height: 2.6,
+    color: "#d6cbae",
+    roofColor: "#a07830",
+  },
+  {
+    id: "inn",
+    label: "Inn",
+    x: 17,
+    z: 14,
+    w: 2,
+    d: 2,
+    height: 1.5,
+    color: "#cbb894",
+    roofColor: "#8a4b2f",
+  },
+  {
+    id: "chapel",
+    label: "Chapel",
+    x: 22,
+    z: 14,
+    w: 1,
+    d: 1,
+    height: 1.9,
+    color: "#d2cbb4",
+    roofColor: "#6d5336",
+  },
+  {
+    id: "guard-post",
+    label: "Guard Post",
+    x: 22,
+    z: 10,
+    w: 1,
+    d: 1,
+    height: 1.2,
+    color: "#9a7550",
+    roofColor: "#5c3f28",
+  },
+  {
+    id: "market",
+    label: "Market Stall",
+    x: 17,
+    z: 10,
+    w: 1,
+    d: 1,
+    height: 0.8,
+    color: "#b08a5c",
+    roofColor: "#8b1a1a",
+  },
+]
+
+export function parseAsciiMap(rows: string[], buildings: BuildingDef[] = []): GameMap {
+  const width = rows[0].length
+  const depth = rows.length
+  const tiles: TerrainId[] = new Array(width * depth)
+
+  for (let z = 0; z < depth; z++) {
+    const row = rows[z]
+    if (row.length !== width) {
+      throw new Error(
+        `Map row ${z} is ${row.length} chars, expected ${width}. Rows must all be the same width.`,
+      )
+    }
+    for (let x = 0; x < width; x++) {
+      const char = row[x]
+      const terrain = TERRAIN_CHARS[char]
+      if (!terrain) {
+        throw new Error(`Unknown map character "${char}" at (${x}, ${z}).`)
+      }
+      tiles[z * width + x] = terrain
+    }
+  }
+
+  for (const b of buildings) {
+    if (b.x < 0 || b.z < 0 || b.x + b.w > width || b.z + b.d > depth) {
+      throw new Error(`Building "${b.id}" footprint falls outside the map.`)
+    }
+  }
+
+  return { width, depth, tiles, buildings }
+}
+
+export const PROTOTYPE_MAP: GameMap = parseAsciiMap(PROTOTYPE_MAP_ROWS, PROTOTYPE_BUILDINGS)

--- a/lib/game/map/terrain.ts
+++ b/lib/game/map/terrain.ts
@@ -1,0 +1,74 @@
+/**
+ * Terrain vocabulary for the map. Pure data — no three.js, no React.
+ *
+ * `height` is the world-space height of the tile's top surface above the base
+ * slab. Varying it slightly per terrain gives the map readable relief under an
+ * isometric camera without needing a real heightmap yet.
+ */
+
+export type TerrainId = "grass" | "dirt" | "path" | "forest" | "hills"
+
+export interface TerrainDef {
+  id: TerrainId
+  label: string
+  /** Base tile colour, before per-tile jitter. */
+  color: string
+  /** Top surface height in world units. */
+  height: number
+  /** How much per-tile brightness variation to apply (0 = flat, 0.1 = subtle). */
+  jitter: number
+  /** Can buildings be placed here without clearing first? */
+  buildable: boolean
+}
+
+export const TERRAIN: Record<TerrainId, TerrainDef> = {
+  grass: {
+    id: "grass",
+    label: "Clear land",
+    color: "#77864b",
+    height: 0.2,
+    jitter: 0.14,
+    buildable: true,
+  },
+  dirt: {
+    id: "dirt",
+    label: "Bare earth",
+    color: "#a58658",
+    height: 0.17,
+    jitter: 0.1,
+    buildable: true,
+  },
+  path: {
+    id: "path",
+    label: "Road",
+    color: "#c9ab7a",
+    height: 0.13,
+    jitter: 0.08,
+    buildable: false,
+  },
+  forest: {
+    id: "forest",
+    label: "Forest",
+    color: "#4b5c33",
+    height: 0.24,
+    jitter: 0.16,
+    buildable: false,
+  },
+  hills: {
+    id: "hills",
+    label: "Hills",
+    color: "#8d8460",
+    height: 0.62,
+    jitter: 0.12,
+    buildable: true,
+  },
+}
+
+/** Characters used in the ASCII map source. */
+export const TERRAIN_CHARS: Record<string, TerrainId> = {
+  ".": "grass",
+  ",": "dirt",
+  "=": "path",
+  F: "forest",
+  "^": "hills",
+}

--- a/lib/game/map/types.ts
+++ b/lib/game/map/types.ts
@@ -1,0 +1,46 @@
+import type { TerrainId } from "./terrain"
+
+export interface BuildingDef {
+  id: string
+  label: string
+  /** Origin tile — the minimum corner of the footprint. */
+  x: number
+  z: number
+  /** Footprint in tiles. */
+  w: number
+  d: number
+  /** Body height in world units. */
+  height: number
+  color: string
+  roofColor: string
+}
+
+export interface GameMap {
+  width: number
+  depth: number
+  /** Row-major, indexed by `z * width + x`. */
+  tiles: TerrainId[]
+  buildings: BuildingDef[]
+}
+
+export function tileAt(map: GameMap, x: number, z: number): TerrainId | null {
+  if (x < 0 || z < 0 || x >= map.width || z >= map.depth) return null
+  return map.tiles[z * map.width + x]
+}
+
+/** Tile centre in world space. The map is centred on the origin. */
+export function tileToWorldX(map: GameMap, x: number): number {
+  return x - map.width / 2 + 0.5
+}
+
+export function tileToWorldZ(map: GameMap, z: number): number {
+  return z - map.depth / 2 + 0.5
+}
+
+export function worldToTileX(map: GameMap, wx: number): number {
+  return Math.floor(wx + map.width / 2)
+}
+
+export function worldToTileZ(map: GameMap, wz: number): number {
+  return Math.floor(wz + map.depth / 2)
+}

--- a/lib/game/render/iso.ts
+++ b/lib/game/render/iso.ts
@@ -1,0 +1,97 @@
+/**
+ * Isometric camera math. Pure functions — no three.js, no React — so the
+ * projection and panning behaviour can be unit-tested headlessly.
+ *
+ * The camera is orthographic with a fixed pitch and one of four fixed yaws,
+ * RCT2-style. It orbits a `target` point on the ground plane (y = 0); panning
+ * moves that target, rotation snaps between the four views, zoom changes the
+ * orthographic frustum height.
+ */
+
+/** True isometric: atan(1/√2) ≈ 35.264°, so a cube's top face is a regular rhombus. */
+export const ISO_PITCH = Math.atan(1 / Math.SQRT2)
+
+/** View 0 looks down the +X/+Z diagonal, so grid lines run diagonally on screen. */
+export const ISO_YAW_BASE = Math.PI / 4
+
+export const VIEW_COUNT = 4
+
+/**
+ * Distance from target to camera. Irrelevant to scale under an orthographic
+ * projection — it only has to be far enough to keep the scene inside the near
+ * and far planes.
+ */
+export const CAM_DISTANCE = 120
+export const CAM_NEAR = 0.1
+export const CAM_FAR = 400
+
+/** Orthographic frustum height, in world units. Smaller = more zoomed in. */
+export const MIN_VIEW_SIZE = 8
+export const MAX_VIEW_SIZE = 56
+export const DEFAULT_VIEW_SIZE = 26
+
+/** Yaw in radians for a view index. The index is unbounded so tweens can wrap. */
+export function yawForView(viewIndex: number): number {
+  return ISO_YAW_BASE + viewIndex * (Math.PI / 2)
+}
+
+/** 0–3, for display and for keying view-dependent art later. */
+export function normalizeViewIndex(viewIndex: number): number {
+  return ((viewIndex % VIEW_COUNT) + VIEW_COUNT) % VIEW_COUNT
+}
+
+/** Camera position offset from its ground target. */
+export function cameraOffset(yaw: number): [number, number, number] {
+  const cp = Math.cos(ISO_PITCH)
+  const sp = Math.sin(ISO_PITCH)
+  return [CAM_DISTANCE * Math.sin(yaw) * cp, CAM_DISTANCE * sp, CAM_DISTANCE * Math.cos(yaw) * cp]
+}
+
+/**
+ * Ground-plane (XZ) unit vectors corresponding to screen right and screen up.
+ * `fwd` points away from the camera, which is "up" on screen.
+ */
+export function screenBasis(yaw: number) {
+  return {
+    rightX: Math.cos(yaw),
+    rightZ: -Math.sin(yaw),
+    fwdX: -Math.sin(yaw),
+    fwdZ: -Math.cos(yaw),
+  }
+}
+
+/**
+ * Convert a mouse drag in pixels into a change in the camera target, such that
+ * the terrain under the cursor stays under the cursor.
+ *
+ * The two axes carry opposite signs. Moving the target along `right` slides the
+ * fixed world left on screen, so a rightward drag needs a negative step. But
+ * screen y grows downward while `fwd` points up the screen, and those two
+ * inversions cancel — a downward drag needs a positive step along `fwd`.
+ *
+ * The vertical term is divided by sin(pitch) because ground movement toward or
+ * away from the camera is foreshortened by exactly that factor on screen.
+ */
+export function panDelta(
+  yaw: number,
+  dxPixels: number,
+  dyPixels: number,
+  worldPerPixel: number,
+): { dx: number; dz: number } {
+  const b = screenBasis(yaw)
+  const alongRight = dxPixels * worldPerPixel
+  const alongFwd = (dyPixels * worldPerPixel) / Math.sin(ISO_PITCH)
+  return {
+    dx: -alongRight * b.rightX + alongFwd * b.fwdX,
+    dz: -alongRight * b.rightZ + alongFwd * b.fwdZ,
+  }
+}
+
+/** World units covered by one screen pixel, given the frustum height. */
+export function worldPerPixel(viewSize: number, canvasHeightPx: number): number {
+  return viewSize / Math.max(1, canvasHeightPx)
+}
+
+export function clampViewSize(viewSize: number): number {
+  return Math.min(MAX_VIEW_SIZE, Math.max(MIN_VIEW_SIZE, viewSize))
+}

--- a/lib/game/rng.ts
+++ b/lib/game/rng.ts
@@ -1,0 +1,15 @@
+/**
+ * Seeded RNG (mulberry32). Everything random in the game must come from one of
+ * these, never from `Math.random()` — determinism is what makes the simulation
+ * replayable, testable, and saveable.
+ */
+export function makeRng(seed: number): () => number {
+  let a = seed >>> 0
+  return function next() {
+    a = (a + 0x6d2b79f5) >>> 0
+    let t = a
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // The dev overlay badge sits in the bottom-left corner, on top of the game HUD.
+  devIndicators: false,
   typescript: {
     ignoreBuildErrors: true,
   },

--- a/package.json
+++ b/package.json
@@ -6,11 +6,13 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
-    "@vercel/analytics": "1.6.1",
     "@radix-ui/react-accordion": "1.2.12",
     "@radix-ui/react-alert-dialog": "1.1.15",
     "@radix-ui/react-aspect-ratio": "1.1.8",
@@ -38,6 +40,8 @@
     "@radix-ui/react-toggle": "1.1.10",
     "@radix-ui/react-toggle-group": "1.1.11",
     "@radix-ui/react-tooltip": "1.2.8",
+    "@react-three/fiber": "^9.7.0",
+    "@vercel/analytics": "1.6.1",
     "autoprefixer": "^10.4.20",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -56,17 +60,21 @@
     "recharts": "2.15.0",
     "sonner": "^1.7.1",
     "tailwind-merge": "^3.3.1",
+    "three": "^0.185.1",
     "vaul": "^1.1.2",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "zustand": "^5.0.14"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.0",
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/three": "^0.185.4",
     "postcss": "^8.5",
     "tailwindcss": "^4.2.0",
     "tw-animate-css": "1.3.3",
-    "typescript": "5.7.3"
+    "typescript": "5.7.3",
+    "vitest": "^4.1.10"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: 1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@react-three/fiber':
+        specifier: ^9.7.0
+        version: 9.7.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(three@0.185.1)
       '@vercel/analytics':
         specifier: 1.6.1
         version: 1.6.1(next@16.2.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
@@ -149,12 +152,18 @@ importers:
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.5.0
+      three:
+        specifier: ^0.185.1
+        version: 0.185.1
       vaul:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       zod:
         specifier: ^3.24.1
         version: 3.25.76
+      zustand:
+        specifier: ^5.0.14
+        version: 5.0.14(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
     devDependencies:
       '@tailwindcss/postcss':
         specifier: ^4.2.0
@@ -168,6 +177,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.14)
+      '@types/three':
+        specifier: ^0.185.4
+        version: 0.185.4
       postcss:
         specifier: ^8.5
         version: 8.5.9
@@ -180,6 +192,9 @@ importers:
       typescript:
         specifier: 5.7.3
         version: 5.7.3
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@22.19.17)(vite@8.2.0(@types/node@22.19.17)(jiti@2.6.1))
 
 packages:
 
@@ -193,6 +208,9 @@ packages:
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
+
+  '@dimforge/rapier3d-compat@0.12.0':
+    resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
 
   '@emnapi/runtime@1.9.2':
     resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
@@ -440,6 +458,9 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@oxc-project/types@0.142.0':
+    resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -1097,6 +1118,127 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@react-three/fiber@9.7.0':
+    resolution: {integrity: sha512-EWm9FwcaOZQu/ExFW5rggoCMM1NJet5YbxVxKaOE+KSncrjU0Wx7017qSyGFvupviK89nMYGCWU3BIK4dI1clw==}
+    peerDependencies:
+      expo: '>=43.0'
+      expo-asset: '>=8.4'
+      expo-file-system: '>=11.0'
+      expo-gl: '>=11.0'
+      react: '>=19 <19.3'
+      react-dom: '>=19 <19.3'
+      react-native: '>=0.78'
+      three: '>=0.156'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+      expo-asset:
+        optional: true
+      expo-file-system:
+        optional: true
+      expo-gl:
+        optional: true
+      react-dom:
+        optional: true
+      react-native:
+        optional: true
+
+  '@rolldown/binding-android-arm64@1.2.2':
+    resolution: {integrity: sha512-l7x215OGvo1s52JWmR8U/DAVzEDWBCIbTm28aeJV/WDTSHgcKXaZTuBT0hJMs5NggilfJTW3clZVvd24yfKJxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.2.2':
+    resolution: {integrity: sha512-9u9Xv6c1AJZT0FfwH5vrMG5Jjcwhc1MlyrPu0XfTqkzsmqfks2M6W/o5XwAJgVVN/jHpqqngC1WevHKKTIUtIA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.2.2':
+    resolution: {integrity: sha512-9W1mbGZAfW3oqd85bhBkmpyHCCzL1TeG/zFFP3vg7b0rlly8cxOcre5nXwz+LHazCwac2MNWgPdPCHndABjpWQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.2.2':
+    resolution: {integrity: sha512-0p1lhiCSCyaerFwtrdZQUx7NqGk6LQnaRKWX7tFQqwQgvX0rjM15cIkm3pax1UpEakK14C4mOxx/jSqCBdBRqQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.2':
+    resolution: {integrity: sha512-e+cOJXrJ2L3zx6YzqPg+f6Wbk3V1cKB8bOhbaYdVYN3DdquzNdRAmrbETz1qnt5yp/c7JNlNjmITiA2cVneQ7w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.2':
+    resolution: {integrity: sha512-JsSMsj6sNat/MuhG5fnBD7QgbtpHKVe30x5/bAVirDHdhoQRXJkF6xc0Jqk8O4fiCUQAzMOoH9wZi3m60c8wtg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.2.2':
+    resolution: {integrity: sha512-B5G/zJdHaoJn9vD50eGHWkiWfmq8Uhi3IiLPJTzmZTrAalk1bztUikSXo0qga18ibE0IXboyeMUnhPjhAJ45wQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.2':
+    resolution: {integrity: sha512-6mC/awzKka8W6EoekjegpfGkjz8jXWDX63pqu/HYVpyKtZfu65Jsh4QAH3Kej3CAv/c1oGX7psTmFEbr0mDxLA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.2':
+    resolution: {integrity: sha512-412MX9fJLdA1IK28EZnc8jYv2HRTleOZgfLQumJ5zy7OeJLZlg/CETwFaXjNmGVxG51cFHpKLqb5LKvBC+HsHA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.2':
+    resolution: {integrity: sha512-Q/+HI/ToJafZ1iCqGgVQXUEkIjufHCTF0gBQ2a5o3cg7GJ2h0qyq3nvvSmU+bGda2/7ygXpTY4TM6gO9OhQ0ZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.2.2':
+    resolution: {integrity: sha512-ZKp/w41n6wCvxzxQHtQSbuphfX3Y4cCvbjkKHusrLx4lh+JWLTU7StSltO/DKARISzbj368d+qUaCjI8K2wzXw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.2.2':
+    resolution: {integrity: sha512-pxE6xD4KS3eAROkKK5yrhB9/3+vhlhVGMvlQLbdpzrBGDbKrnzx3RLwPaHvasLo6jgaiBLn7e04Df9C4tYhjmA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.2':
+    resolution: {integrity: sha512-4MqEue5re+xIZzAWsB8sj0P1kqZySWqIuN4t6QaIO/YA6SFwySOLruvWQFzfmqk8LBK2P30KCSJwf6mJCZZ5/A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.2':
+    resolution: {integrity: sha512-NweNxxD0Nf9t8v7kodun45Ijp3EIwYY+uydPP6qBEYvfBqhIjN6dZMzlQja3tqX/aLs3F3Uz+AxDpKgRhpOZQg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -1192,6 +1334,12 @@ packages:
   '@tailwindcss/postcss@4.2.2':
     resolution: {integrity: sha512-n4goKQbW8RVXIbNKRB/45LzyUqN451deQK0nzIeauVEqjlI49slUlgKYJM2QyUzap/PcpnS7kzSUmPb1sCRvYQ==}
 
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -1219,6 +1367,12 @@ packages:
   '@types/d3-timer@3.0.2':
     resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
   '@types/node@22.19.17':
     resolution: {integrity: sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==}
 
@@ -1227,8 +1381,22 @@ packages:
     peerDependencies:
       '@types/react': ^19.2.0
 
+  '@types/react-reconciler@0.28.9':
+    resolution: {integrity: sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==}
+    peerDependencies:
+      '@types/react': '*'
+
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
+  '@types/three@0.185.4':
+    resolution: {integrity: sha512-gAsBIC07NIFrxjbf7tH2t71c38uulFfk/RFoC7FNBSjMRAQ8J1x/RBvusX0N5PJouaYFJawXQqfCQ0RKUx/1nA==}
+
+  '@types/webxr@0.5.24':
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
   '@vercel/analytics@1.6.1':
     resolution: {integrity: sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==}
@@ -1256,9 +1424,42 @@ packages:
       vue-router:
         optional: true
 
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   autoprefixer@10.4.27:
     resolution: {integrity: sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==}
@@ -1266,6 +1467,9 @@ packages:
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
   baseline-browser-mapping@2.10.18:
     resolution: {integrity: sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==}
@@ -1277,8 +1481,15 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
   caniuse-lite@1.0.30001787:
     resolution: {integrity: sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -1295,6 +1506,9 @@ packages:
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -1382,19 +1596,46 @@ packages:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
 
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   fast-equals@5.4.0:
     resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
     engines: {node: '>=6.0.0'}
 
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
@@ -1402,6 +1643,9 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   input-otp@1.4.2:
     resolution: {integrity: sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA==}
@@ -1412,6 +1656,11 @@ packages:
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
+
+  its-fine@2.0.0:
+    resolution: {integrity: sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==}
+    peerDependencies:
+      react: ^19.0.0
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
@@ -1426,8 +1675,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-darwin-arm64@1.32.0:
     resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -1438,8 +1699,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
   lightningcss-freebsd-x64@1.32.0:
     resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -1450,8 +1723,21 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -1464,8 +1750,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -1478,8 +1778,21 @@ packages:
     os: [linux]
     libc: [musl]
 
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -1490,8 +1803,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   lightningcss@1.32.0:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
     engines: {node: '>= 12.0.0'}
 
   lodash@4.18.1:
@@ -1509,8 +1832,16 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  meshoptimizer@1.1.1:
+    resolution: {integrity: sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1548,14 +1879,29 @@ packages:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.9:
@@ -1636,6 +1982,15 @@ packages:
       react: '>=16.6.0'
       react-dom: '>=16.6.0'
 
+  react-use-measure@2.1.7:
+    resolution: {integrity: sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==}
+    peerDependencies:
+      react: '>=16.13'
+      react-dom: '>=16.13'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
@@ -1646,9 +2001,15 @@ packages:
   recharts@2.15.0:
     resolution: {integrity: sha512-cIvMxDfpAmqAmVgc4yb7pgm/O1tmmkl/CjrvXuW+62/+7jj/iF9Ykm+hb/UJt42TREHMyd3gb+pkgoa2MxgDIw==}
     engines: {node: '>=14'}
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  rolldown@1.2.2:
+    resolution: {integrity: sha512-opwpo1tQBAcpSUJDt94B7hhLNGOKjCdE//XXjeLrnx9b83bjnw45tXdg1b09yEw/VLFBJGZpwRULMmOZo7ol+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -1662,6 +2023,9 @@ packages:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   sonner@1.7.4:
     resolution: {integrity: sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw==}
     peerDependencies:
@@ -1671,6 +2035,12 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
@@ -1685,6 +2055,11 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  suspend-react@0.1.3:
+    resolution: {integrity: sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==}
+    peerDependencies:
+      react: '>=17.0'
+
   tailwind-merge@3.5.0:
     resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
@@ -1695,8 +2070,26 @@ packages:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
 
+  three@0.185.1:
+    resolution: {integrity: sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==}
+
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -1752,8 +2145,115 @@ packages:
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
+  vite@8.2.0:
+    resolution: {integrity: sha512-pn+CFpM0lwDeKwmOq1ZaBK/9sjorZcgqxki6MbY/jPEVd9vichIlmlD4HmQ5wdP5EgqQCFRaACBxMC7uEGc6lQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.4.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zustand@5.0.14:
+    resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -1762,6 +2262,8 @@ snapshots:
   '@babel/runtime@7.29.2': {}
 
   '@date-fns/tz@1.4.1': {}
+
+  '@dimforge/rapier3d-compat@0.12.0': {}
 
   '@emnapi/runtime@1.9.2':
     dependencies:
@@ -1930,6 +2432,8 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@16.2.0':
     optional: true
+
+  '@oxc-project/types@0.142.0': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -2626,6 +3130,72 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@react-three/fiber@9.7.0(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(three@0.185.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@types/webxr': 0.5.24
+      base64-js: 1.5.1
+      buffer: 6.0.3
+      its-fine: 2.0.0(@types/react@19.2.14)(react@19.2.5)
+      react: 19.2.5
+      react-use-measure: 2.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      scheduler: 0.27.0
+      suspend-react: 0.1.3(react@19.2.5)
+      three: 0.185.1
+      use-sync-external-store: 1.6.0(react@19.2.5)
+      zustand: 5.0.14(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
+    optionalDependencies:
+      react-dom: 19.2.5(react@19.2.5)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@rolldown/binding-android-arm64@1.2.2':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.2.2':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.2.2':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.2.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.2':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.2.2':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.2':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.2':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.2.2':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.2.2':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.2':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.2':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.2':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -2699,6 +3269,13 @@ snapshots:
       postcss: 8.5.9
       tailwindcss: 4.2.2
 
+  '@tweenjs/tween.js@23.1.3': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/d3-array@3.2.2': {}
 
   '@types/d3-color@3.1.3': {}
@@ -2723,6 +3300,10 @@ snapshots:
 
   '@types/d3-timer@3.0.2': {}
 
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
   '@types/node@22.19.17':
     dependencies:
       undici-types: 6.21.0
@@ -2731,18 +3312,78 @@ snapshots:
     dependencies:
       '@types/react': 19.2.14
 
+  '@types/react-reconciler@0.28.9(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/stats.js@0.17.4': {}
+
+  '@types/three@0.185.4':
+    dependencies:
+      '@dimforge/rapier3d-compat': 0.12.0
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.24
+      fflate: 0.8.3
+      meshoptimizer: 1.1.1
+
+  '@types/webxr@0.5.24': {}
 
   '@vercel/analytics@1.6.1(next@16.2.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
     optionalDependencies:
       next: 16.2.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
 
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.10(vite@8.2.0(@types/node@22.19.17)(jiti@2.6.1))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.2.0(@types/node@22.19.17)(jiti@2.6.1)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
+
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
+
+  assertion-error@2.0.1: {}
 
   autoprefixer@10.4.27(postcss@8.5.9):
     dependencies:
@@ -2752,6 +3393,8 @@ snapshots:
       picocolors: 1.1.1
       postcss: 8.5.9
       postcss-value-parser: 4.2.0
+
+  base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.18: {}
 
@@ -2763,7 +3406,14 @@ snapshots:
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   caniuse-lite@1.0.30001787: {}
+
+  chai@6.2.2: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -2784,6 +3434,8 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
+
+  convert-source-map@2.0.0: {}
 
   csstype@3.2.3: {}
 
@@ -2859,17 +3511,36 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.2
 
+  es-module-lexer@2.3.1: {}
+
   escalade@3.2.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
 
   eventemitter3@4.0.7: {}
 
+  expect-type@1.4.0: {}
+
   fast-equals@5.4.0: {}
 
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  fflate@0.8.3: {}
+
   fraction.js@5.3.4: {}
+
+  fsevents@2.3.3:
+    optional: true
 
   get-nonce@1.0.1: {}
 
   graceful-fs@4.2.11: {}
+
+  ieee754@1.2.1: {}
 
   input-otp@1.4.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
@@ -2878,6 +3549,13 @@ snapshots:
 
   internmap@2.0.3: {}
 
+  its-fine@2.0.0(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      '@types/react-reconciler': 0.28.9(@types/react@19.2.14)
+      react: 19.2.5
+    transitivePeerDependencies:
+      - '@types/react'
+
   jiti@2.6.1: {}
 
   js-tokens@4.0.0: {}
@@ -2885,34 +3563,67 @@ snapshots:
   lightningcss-android-arm64@1.32.0:
     optional: true
 
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
     optional: true
 
   lightningcss-darwin-x64@1.32.0:
     optional: true
 
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
   lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.32.0:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
   lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.32.0:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.32.0:
     optional: true
 
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.32.0:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
     optional: true
 
   lightningcss@1.32.0:
@@ -2931,6 +3642,22 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
+
   lodash@4.18.1: {}
 
   loose-envify@1.4.0:
@@ -2945,7 +3672,11 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  meshoptimizer@1.1.1: {}
+
   nanoid@3.3.11: {}
+
+  nanoid@3.3.17: {}
 
   next-themes@0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
@@ -2980,13 +3711,25 @@ snapshots:
 
   object-assign@4.1.1: {}
 
+  obug@2.1.4: {}
+
+  pathe@2.0.3: {}
+
   picocolors@1.1.1: {}
+
+  picomatch@4.0.5: {}
 
   postcss-value-parser@4.2.0: {}
 
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.25:
+    dependencies:
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -3071,6 +3814,12 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
+  react-use-measure@2.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+    optionalDependencies:
+      react-dom: 19.2.5(react@19.2.5)
+
   react@19.2.5: {}
 
   recharts-scale@0.4.5:
@@ -3089,6 +3838,26 @@ snapshots:
       recharts-scale: 0.4.5
       tiny-invariant: 1.3.3
       victory-vendor: 36.9.2
+
+  rolldown@1.2.2:
+    dependencies:
+      '@oxc-project/types': 0.142.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.2.2
+      '@rolldown/binding-darwin-arm64': 1.2.2
+      '@rolldown/binding-darwin-x64': 1.2.2
+      '@rolldown/binding-freebsd-x64': 1.2.2
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.2
+      '@rolldown/binding-linux-arm64-gnu': 1.2.2
+      '@rolldown/binding-linux-arm64-musl': 1.2.2
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.2
+      '@rolldown/binding-linux-s390x-gnu': 1.2.2
+      '@rolldown/binding-linux-x64-gnu': 1.2.2
+      '@rolldown/binding-linux-x64-musl': 1.2.2
+      '@rolldown/binding-openharmony-arm64': 1.2.2
+      '@rolldown/binding-win32-arm64-msvc': 1.2.2
+      '@rolldown/binding-win32-x64-msvc': 1.2.2
 
   scheduler@0.27.0: {}
 
@@ -3127,6 +3896,8 @@ snapshots:
       '@img/sharp-win32-x64': 0.34.5
     optional: true
 
+  siginfo@2.0.0: {}
+
   sonner@1.7.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       react: 19.2.5
@@ -3134,9 +3905,17 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
+
   styled-jsx@5.1.6(react@19.2.5):
     dependencies:
       client-only: 0.0.1
+      react: 19.2.5
+
+  suspend-react@0.1.3(react@19.2.5):
+    dependencies:
       react: 19.2.5
 
   tailwind-merge@3.5.0: {}
@@ -3145,7 +3924,20 @@ snapshots:
 
   tapable@2.3.2: {}
 
+  three@0.185.1: {}
+
   tiny-invariant@1.3.3: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@1.3.0: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.1: {}
 
   tslib@2.8.1: {}
 
@@ -3206,4 +3998,54 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite@8.2.0(@types/node@22.19.17)(jiti@2.6.1):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.25
+      rolldown: 1.2.2
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.19.17
+      fsevents: 2.3.3
+      jiti: 2.6.1
+
+  vitest@4.1.10(@types/node@22.19.17)(vite@8.2.0(@types/node@22.19.17)(jiti@2.6.1)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.2.0(@types/node@22.19.17)(jiti@2.6.1))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.0(@types/node@22.19.17)(jiti@2.6.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+    transitivePeerDependencies:
+      - msw
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   zod@3.25.76: {}
+
+  zustand@5.0.14(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5)):
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.5
+      use-sync-external-store: 1.6.0(react@19.2.5)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+# sharp is only needed for Next.js image optimisation, which this project turns
+# off via `images.unoptimized` in next.config.mjs. Skip its native build.
+allowBuilds:
+  sharp: false


### PR DESCRIPTION
Adds a three.js prototype for the settlement builder at `/play`, alongside the existing design document: an orthographic camera at a true isometric pitch (`atan(1/√2)`) with yaw locked to four fixed RCT2-style views, a hand-editable 32×32 ASCII map parsed into terrain with a road, plaza, forest and hills, and placeholder box assets covering 1×1 and 2×2 building footprints plus instanced trees. Camera math and map data are kept as pure modules with no three.js or React imports so they stay testable headlessly — 13 tests cover the projection, the 1:1 drag-to-pan invariant, road continuity and building placement. Adds `three`, `@react-three/fiber`, `zustand` and `vitest`, along with `test` and `typecheck` scripts, and disables the Next dev badge because it overlapped the game HUD. Also makes `TwoColumnGrid`'s titles optional, fixing three pre-existing type errors that `ignoreBuildErrors` was masking and stopping it rendering an empty heading. Verified with `pnpm test`, a clean `pnpm typecheck`, a successful production build, and 12 interaction checks driven against a real browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)