### PR TITLE
ci: deploy to Vercel production on merge to main

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,41 @@
+name: Deploy to Vercel Production
+
+# A merged PR lands as a push to main, so this is the "PR merged" trigger.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Never run two production deploys at once; let an in-flight one finish.
+concurrency:
+  group: vercel-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: Production
+      url: ${{ steps.deploy.outputs.url }}
+    env:
+      VERCEL_ORG_ID: team_x3HIt7dbvbPsM9RKoYwAntcq
+      VERCEL_PROJECT_ID: prj_G39IsnKLmJqSmAYFjBQLSAj6qWzc
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - run: npm install -g vercel@latest
+
+      # Source is uploaded and built on Vercel, so the project's own build
+      # settings and environment variables apply — same as a Git-triggered deploy.
+      - name: Deploy
+        id: deploy
+        run: |
+          url=$(vercel deploy --prod --yes --token="$VERCEL_TOKEN")
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "Deployed $GITHUB_SHA to $url" >> "$GITHUB_STEP_SUMMARY"
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
The Vercel GitHub App connection for this repo has been silently broken since 2026-04-12 — `vercel[bot]` has not created a deployment for any merge since then, including PRs #3 and #4. The Vercel project is still linked (production branch `main`), but nothing fires.

This adds `.github/workflows/deploy-production.yml`, which deploys production on every push to `main` (i.e. every merged PR) plus manual dispatch:

- Source is uploaded and built on Vercel, so the project's build settings and environment variables apply exactly as with a Git-triggered deploy.
- Concurrency-guarded so overlapping merges can't deploy over each other.
- The deployment URL lands in the job summary and the GitHub "Production" environment.

`VERCEL_TOKEN` is set as a repo secret; org and project IDs are inlined (not sensitive).

Note: if the native Git integration is ever reconnected, disable one of the two paths or every merge will deploy twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)