### PR TITLE
ci: bump checkout and setup-node to v5

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -21,9 +21,9 @@ jobs:
       VERCEL_ORG_ID: team_x3HIt7dbvbPsM9RKoYwAntcq
       VERCEL_PROJECT_ID: prj_G39IsnKLmJqSmAYFjBQLSAj6qWzc
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
 


### PR DESCRIPTION
Clears the Node.js 20 deprecation warning emitted by the new deploy workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)