### PR TITLE
ci: restore PR preview deployments

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "main": false
+    }
+  }
+}


### PR DESCRIPTION
The Vercel Git connection was still holding the credential v0 created back in April (`cred_289e82…`), which had gone stale — GitHub events stopped reaching Vercel and no preview or production deployment had been created since 2026-04-12. Reconnecting the repo issued a fresh credential (`cred_ac6b1e…`), so preview deployments on PRs work again.

This PR adds `vercel.json` disabling Git deployments for `main` only. Previews still deploy from PR branches; production stays on the Actions workflow, which is the path we've actually verified. Without this, every merge would deploy to production twice.

**This PR is also the test** — if `vercel[bot]` comments a preview URL below, previews are working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)