### PR TITLE
feat(game): dense forest with glades, trails, and passable clearings

### DIFF
--- a/app/play/page.tsx
+++ b/app/play/page.tsx
@@ -23,13 +23,13 @@ export default async function PlayPage({
   const initialSettings: Partial<MapSettings> = {}
   const size = parseIntParam(params.size)
   const coverage = parseIntParam(params.forest)
-  const clusters = parseIntParam(params.clusters)
-  const groves = parseIntParam(params.groves)
+  const glades = parseIntParam(params.glades)
+  const clearings = parseIntParam(params.clearings)
   const treeDensity = parseIntParam(params.trees)
   if (size !== undefined) initialSettings.size = size
   if (coverage !== undefined) initialSettings.coverage = coverage
-  if (clusters !== undefined) initialSettings.clusters = clusters
-  if (groves !== undefined) initialSettings.groves = groves
+  if (glades !== undefined) initialSettings.glades = glades
+  if (clearings !== undefined) initialSettings.clearings = clearings
   if (treeDensity !== undefined) initialSettings.treeDensity = treeDensity
 
   return <GameShell initialSeed={parseIntParam(params.seed)} initialSettings={initialSettings} />

--- a/components/game/game-hud.tsx
+++ b/components/game/game-hud.tsx
@@ -262,25 +262,25 @@ export function GameHud({
             label="Coverage"
             value={settings.coverage}
             display={`${settings.coverage}%`}
-            min={0}
-            max={50}
+            min={30}
+            max={90}
             onChange={(coverage) => set({ coverage })}
           />
           <Tuner
-            label="Forests"
-            value={settings.clusters}
-            display={String(settings.clusters)}
+            label="Glades"
+            value={settings.glades}
+            display={String(settings.glades)}
             min={1}
-            max={8}
-            onChange={(clusters) => set({ clusters })}
+            max={12}
+            onChange={(glades) => set({ glades })}
           />
           <Tuner
-            label="Groves"
-            value={settings.groves}
-            display={String(settings.groves)}
+            label="Clearings"
+            value={settings.clearings}
+            display={String(settings.clearings)}
             min={0}
             max={30}
-            onChange={(groves) => set({ groves })}
+            onChange={(clearings) => set({ clearings })}
           />
           <Tuner
             label="Trees per tile"

--- a/components/game/game-shell.tsx
+++ b/components/game/game-shell.tsx
@@ -6,9 +6,9 @@ import { useEffect, useMemo, useState } from "react"
 import { useCameraStore } from "@/lib/game/camera-store"
 import { loadSavedSeed } from "@/lib/game/seed-storage"
 import {
-  DEFAULT_CLUSTER_COUNT,
+  DEFAULT_CLEARING_COUNT,
   DEFAULT_FOREST_COVERAGE,
-  DEFAULT_GROVE_COUNT,
+  DEFAULT_GLADE_COUNT,
   DEFAULT_MAP_WIDTH,
   generateMap,
 } from "@/lib/game/map/generate-map"
@@ -35,12 +35,12 @@ const GameCanvas = dynamic(() => import("./game-canvas").then((m) => m.GameCanva
 export interface MapSettings {
   /** Map edge length in tiles; maps are square. */
   size: number
-  /** % of the map covered by large forest clusters. */
+  /** % of the map left as forest after the glades are carved. */
   coverage: number
-  /** How many large clusters that coverage is split across. */
-  clusters: number
-  /** Number of small scattered groves. */
-  groves: number
+  /** Number of open grass glades carved out of the forest. */
+  glades: number
+  /** Number of small forest-floor clearings scattered through the woods. */
+  clearings: number
   /** Trees drawn per forest tile. */
   treeDensity: number
 }
@@ -48,8 +48,8 @@ export interface MapSettings {
 export const DEFAULT_SETTINGS: MapSettings = {
   size: DEFAULT_MAP_WIDTH,
   coverage: Math.round(DEFAULT_FOREST_COVERAGE * 100),
-  clusters: DEFAULT_CLUSTER_COUNT,
-  groves: DEFAULT_GROVE_COUNT,
+  glades: DEFAULT_GLADE_COUNT,
+  clearings: DEFAULT_CLEARING_COUNT,
   treeDensity: DEFAULT_TREE_DENSITY,
 }
 
@@ -89,8 +89,8 @@ export function GameShell({
       seed: String(seed),
       size: String(settings.size),
       forest: String(settings.coverage),
-      clusters: String(settings.clusters),
-      groves: String(settings.groves),
+      glades: String(settings.glades),
+      clearings: String(settings.clearings),
       trees: String(settings.treeDensity),
     })
     window.history.replaceState(null, "", `?${query}`)
@@ -105,10 +105,10 @@ export function GameShell({
             width: settings.size,
             depth: settings.size,
             forestCoverage: settings.coverage / 100,
-            clusterCount: settings.clusters,
-            groveCount: settings.groves,
+            gladeCount: settings.glades,
+            clearingCount: settings.clearings,
           }),
-    [seed, settings.size, settings.coverage, settings.clusters, settings.groves],
+    [seed, settings.size, settings.coverage, settings.glades, settings.clearings],
   )
 
   // The camera's pan clamp follows the loaded map's extent.

--- a/components/game/trees.tsx
+++ b/components/game/trees.tsx
@@ -20,7 +20,7 @@ import {
  */
 const TREE_COLOR = new THREE.Color("#40542e")
 
-export const DEFAULT_TREE_DENSITY = 3
+export const DEFAULT_TREE_DENSITY = 1
 
 export function Trees({ map, density = DEFAULT_TREE_DENSITY }: { map: GameMap; density?: number }) {
   const meshRef = useRef<THREE.InstancedMesh>(null)

--- a/lib/game/map/generate-map.test.ts
+++ b/lib/game/map/generate-map.test.ts
@@ -70,13 +70,13 @@ describe("generateMap", () => {
     }
   })
 
-  it("grows forests in clusters rather than scattering lone trees", () => {
+  it("is densely forested by default, in one connected mass rather than islands", () => {
     for (const seed of SEEDS) {
       const map = generateMap({ seed })
       const forest = countTerrain(map, "forest")
-      expect(forest, `seed ${seed} grew forests`).toBeGreaterThanOrEqual(30)
+      expect(forest / map.tiles.length, `seed ${seed} is mostly forest`).toBeGreaterThan(0.5)
 
-      // Compactness: in a blob, most forest tiles touch other forest tiles.
+      // Compactness: in dense woods, most forest tiles touch other forest tiles.
       let neighbourSum = 0
       for (let z = 0; z < map.depth; z++) {
         for (let x = 0; x < map.width; x++) {
@@ -86,66 +86,96 @@ describe("generateMap", () => {
           }
         }
       }
-      expect(neighbourSum / forest, `seed ${seed} forests are clustered`).toBeGreaterThan(1.5)
+      expect(neighbourSum / forest, `seed ${seed} forest is compact`).toBeGreaterThan(2.5)
     }
   })
 
-  it("threads the road through the woods, never blocked by them", () => {
+  it("carves open grass glades out of the woods", () => {
     for (const seed of SEEDS) {
       const map = generateMap({ seed })
-      let pathBesideForest = 0
-      for (let z = 0; z < map.depth; z++) {
-        for (let x = 0; x < map.width; x++) {
-          if (tileAt(map, x, z) !== "path") continue
-          for (const [dx, dz] of [[1, 0], [-1, 0], [0, 1], [0, -1]]) {
-            if (tileAt(map, x + dx, z + dz) === "forest") pathBesideForest++
+      const grass = countTerrain(map, "grass")
+      expect(grass / map.tiles.length, `seed ${seed} has glades`).toBeGreaterThan(0.15)
+      expect(grass / map.tiles.length, `seed ${seed} stays forest-dominant`).toBeLessThan(0.5)
+    }
+  })
+
+  it("threads the woods with clearings and trails", () => {
+    for (const seed of SEEDS) {
+      const map = generateMap({ seed })
+      const clearing = countTerrain(map, "clearing")
+      expect(clearing, `seed ${seed} has forest-floor passage`).toBeGreaterThan(20)
+    }
+  })
+
+  it("keeps every passable tile reachable from every other, every seed", () => {
+    for (const seed of SEEDS) {
+      const map = generateMap({ seed })
+      const passable = map.tiles.filter((t) => TERRAIN[t].passable).length
+
+      // Flood-fill from any passable tile; it must reach all passable land.
+      const seen = new Uint8Array(map.tiles.length)
+      const start = map.tiles.findIndex((t) => TERRAIN[t].passable)
+      const queue = [start]
+      seen[start] = 1
+      let reached = 0
+      while (queue.length) {
+        const i = queue.pop()!
+        reached++
+        const x = i % map.width
+        const z = Math.floor(i / map.width)
+        for (const [dx, dz] of [[1, 0], [-1, 0], [0, 1], [0, -1]]) {
+          const terrain = tileAt(map, x + dx, z + dz)
+          if (terrain === null || !TERRAIN[terrain].passable) continue
+          const n = (z + dz) * map.width + (x + dx)
+          if (!seen[n]) {
+            seen[n] = 1
+            queue.push(n)
           }
         }
       }
-      // The waypoint routing sends the road through cluster interiors, so
-      // carved road with trees alongside must exist on every seed.
-      expect(pathBesideForest, `seed ${seed} road passes through forest`).toBeGreaterThan(0)
+      expect(reached, `seed ${seed} passable land is one region`).toBe(passable)
     }
   })
 
-  it("leaves a generous share of buildable land at default coverage", () => {
+  it("leaves buildable land for settling at default coverage", () => {
     for (const seed of SEEDS) {
       const map = generateMap({ seed })
       const buildable = map.tiles.filter((t) => TERRAIN[t].buildable).length
-      expect(buildable / map.tiles.length, `seed ${seed} is buildable`).toBeGreaterThan(0.5)
+      expect(buildable / map.tiles.length, `seed ${seed} is settleable`).toBeGreaterThan(0.15)
     }
   })
 
   it("scales forest area with the coverage knob", () => {
     for (const seed of SEEDS.slice(0, 10)) {
-      const sparse = generateMap({ seed, forestCoverage: 0.12 })
-      const dense = generateMap({ seed, forestCoverage: 0.45 })
+      const sparse = generateMap({ seed, forestCoverage: 0.45 })
+      const dense = generateMap({ seed, forestCoverage: 0.85 })
       const fraction = (m: GameMap) => countTerrain(m, "forest") / m.tiles.length
       expect(fraction(dense), `seed ${seed} dense > sparse`).toBeGreaterThan(fraction(sparse))
-      expect(fraction(dense), `seed ${seed} dense is dense`).toBeGreaterThan(0.3)
-      expect(fraction(sparse), `seed ${seed} sparse is sparse`).toBeLessThan(0.25)
+      expect(fraction(dense), `seed ${seed} dense is dense`).toBeGreaterThan(0.6)
+      expect(fraction(sparse), `seed ${seed} sparse is sparse`).toBeLessThan(0.5)
     }
   })
 
-  it("scatters small groves when asked, even with zero cluster coverage", () => {
+  it("scatters more clearings when asked", () => {
     for (const seed of SEEDS.slice(0, 10)) {
-      const map = generateMap({ seed, forestCoverage: 0, groveCount: 10 })
-      const forest = countTerrain(map, "forest")
-      // 10 groves of 2–5 tiles, minus path carving and blob overlap.
-      expect(forest, `seed ${seed} has grove trees`).toBeGreaterThanOrEqual(8)
-      expect(forest, `seed ${seed} groves stay small`).toBeLessThanOrEqual(50)
+      const few = generateMap({ seed, clearingCount: 0 })
+      const many = generateMap({ seed, clearingCount: 25 })
+      expect(
+        countTerrain(many, "clearing"),
+        `seed ${seed} clearings scale`,
+      ).toBeGreaterThan(countTerrain(few, "clearing"))
     }
   })
 
   it("keeps the road identical when only forest knobs change", () => {
     for (const seed of SEEDS.slice(0, 10)) {
-      // With no clusters there are no waypoints, so the road depends only on
-      // its own RNG stream — forest knobs must not disturb it.
-      const bare = generateMap({ seed, forestCoverage: 0, groveCount: 0 })
-      const grovey = generateMap({ seed, forestCoverage: 0, groveCount: 15 })
+      // The road runs on its own RNG stream with no forest waypoints, so no
+      // forest knob may disturb it.
+      const a = generateMap({ seed, forestCoverage: 0.5, gladeCount: 3, clearingCount: 0 })
+      const b = generateMap({ seed, forestCoverage: 0.85, gladeCount: 8, clearingCount: 20 })
       const roadOf = (m: GameMap) =>
         m.tiles.map((t, i) => (t === "path" ? i : -1)).filter((i) => i >= 0)
-      expect(roadOf(grovey), `seed ${seed} road is stable`).toEqual(roadOf(bare))
+      expect(roadOf(b), `seed ${seed} road is stable`).toEqual(roadOf(a))
     }
   })
 })

--- a/lib/game/map/generate-map.ts
+++ b/lib/game/map/generate-map.ts
@@ -3,20 +3,27 @@ import type { TerrainId } from "./terrain"
 import type { GameMap } from "./types"
 
 /**
- * Seeded map generation. Flat grass, clustered forests, and one road running
- * from the west edge to the east edge. The same seed always produces the
- * identical map, so a seed number is a complete, shareable description of a
- * world — buildings are the player's job and are never generated.
+ * Seeded map generation. The world is dense forest by default: the map starts
+ * as solid woods, then open grass glades are carved out of it, small
+ * forest-floor clearings are scattered through it, and winding trails link
+ * everything together. One road runs from the west edge to the east edge. The
+ * same seed always produces the identical map, so a seed number is a complete,
+ * shareable description of a world — buildings are the player's job and are
+ * never generated.
  *
- * Forests come in two kinds: large clusters, sized so that together they cover
- * `forestCoverage` of the map, and small scattered groves. The road is routed
- * with A* after the forests exist, through the two clusters nearest its
- * latitude, carving forest into path wherever it crosses — which is what
- * guarantees it threads through the woods and can never be blocked.
+ * Two kinds of openness, on purpose:
+ *  - "grass" glades are true open land — buildable, the places to settle.
+ *  - "clearing" tiles are still forest in character (no trees drawn on them,
+ *    but not buildable) — the trails and small clearings that let units pass
+ *    through woods that would otherwise be a solid wall of trees.
  *
- * Forest and road randomness come from separate streams derived from the seed,
- * so tuning forest knobs never moves the road's endpoints or wander (and vice
- * versa) — tuning stays comparable across renders of the same seed.
+ * Every glade and clearing is joined into one trail network (nearest-neighbour
+ * spanning tree), and that network is tied into the road, so every passable
+ * tile on a generated map is reachable from every other.
+ *
+ * Forest, trail, and road randomness come from separate streams derived from
+ * the seed, so tuning forest knobs never moves the road's endpoints or wander
+ * (and vice versa) — tuning stays comparable across renders of the same seed.
  */
 
 export const DEFAULT_MAP_WIDTH = 96
@@ -26,22 +33,22 @@ export interface GenerateMapOptions {
   seed: number
   width?: number
   depth?: number
-  /** Fraction of the map covered by large forest clusters (0–~0.5). */
+  /** Fraction of the map left as forest after the glades are carved (0–1). */
   forestCoverage?: number
-  /** How many large clusters that coverage is split across. */
-  clusterCount?: number
-  /** Number of small scattered groves. */
-  groveCount?: number
-  /** Grove footprint in tiles. */
-  groveSizeMin?: number
-  groveSizeMax?: number
+  /** Number of open grass glades carved out of the forest. */
+  gladeCount?: number
+  /** Number of small forest-floor clearings scattered through the woods. */
+  clearingCount?: number
+  /** Clearing footprint in tiles. */
+  clearingSizeMin?: number
+  clearingSizeMax?: number
 }
 
-export const DEFAULT_FOREST_COVERAGE = 0.3
-export const DEFAULT_CLUSTER_COUNT = 4
-export const DEFAULT_GROVE_COUNT = 6
+export const DEFAULT_FOREST_COVERAGE = 0.6
+export const DEFAULT_GLADE_COUNT = 12
+export const DEFAULT_CLEARING_COUNT = 22
 
-/** Keep cluster centres and road endpoints off the extreme edge tiles. */
+/** Keep glade centres and road endpoints off the extreme edge tiles. */
 const EDGE_MARGIN = 2
 
 /**
@@ -49,6 +56,9 @@ const EDGE_MARGIN = 2
  * straight roads; much higher and the route degenerates into noise.
  */
 const PATH_WANDER = 2.0
+
+/** Trails meander more than the road — they're desire lines, not engineering. */
+const TRAIL_WANDER = 3.0
 
 const DIRS: ReadonlyArray<readonly [number, number]> = [
   [1, 0],
@@ -63,93 +73,193 @@ export function generateMap(options: GenerateMapOptions): GameMap {
     width = DEFAULT_MAP_WIDTH,
     depth = DEFAULT_MAP_DEPTH,
     forestCoverage = DEFAULT_FOREST_COVERAGE,
-    clusterCount = DEFAULT_CLUSTER_COUNT,
-    groveCount = DEFAULT_GROVE_COUNT,
-    groveSizeMin = 2,
-    groveSizeMax = 5,
+    gladeCount = DEFAULT_GLADE_COUNT,
+    clearingCount = DEFAULT_CLEARING_COUNT,
+    clearingSizeMin = 2,
+    clearingSizeMax = 6,
   } = options
 
   // Independent streams (constants are arbitrary odd numbers) so each part of
   // the map only reacts to its own knobs.
   const rngForest = makeRng(seed ^ 0x1b873593)
   const rngRoad = makeRng(seed ^ 0x85ebca6b)
+  const rngTrail = makeRng(seed ^ 0xc2b2ae35)
 
-  const tiles: TerrainId[] = new Array<TerrainId>(width * depth).fill("grass")
+  const tiles: TerrainId[] = new Array<TerrainId>(width * depth).fill("forest")
 
-  const wander = new Float64Array(width * depth)
-  for (let i = 0; i < wander.length; i++) wander[i] = rngRoad() * PATH_WANDER
+  const roadWander = new Float64Array(width * depth)
+  for (let i = 0; i < roadWander.length; i++) roadWander[i] = rngRoad() * PATH_WANDER
   const entryZ = EDGE_MARGIN + Math.floor(rngRoad() * (depth - EDGE_MARGIN * 2))
   const exitZ = EDGE_MARGIN + Math.floor(rngRoad() * (depth - EDGE_MARGIN * 2))
 
-  // --- Large forest clusters: grown until they hit the coverage target -------
-  const clusterBudget = Math.floor(forestCoverage * width * depth)
+  const trailWander = new Float64Array(width * depth)
+  for (let i = 0; i < trailWander.length; i++) trailWander[i] = rngTrail() * TRAIL_WANDER
+
+  // --- Glades: grass carved out of the forest until the openness target ------
+  // Centres are picked best-of-k for distance from earlier glades, so the
+  // openness reads as separate glades in the woods instead of one merged plain.
   const centers: Array<{ x: number; z: number }> = []
-  let forestCount = 0
-  for (let c = 0; c < clusterCount; c++) {
-    // Split what's left of the budget across the remaining clusters, with some
-    // variation so the forests differ in size. Budgeting the *remainder* keeps
-    // total coverage honest even when clusters grow into each other.
-    const share = Math.round(
-      ((clusterBudget - forestCount) / (clusterCount - c)) * (0.6 + rngForest() * 0.8),
-    )
-    const blob = growBlob(tiles, width, depth, share, EDGE_MARGIN, rngForest)
+  const pickGladeCenter = (): { x: number; z: number } => {
+    let best = { x: 0, z: 0 }
+    let bestScore = -1
+    for (let k = 0; k < 8; k++) {
+      const x = EDGE_MARGIN + Math.floor(rngForest() * (width - EDGE_MARGIN * 2))
+      const z = EDGE_MARGIN + Math.floor(rngForest() * (depth - EDGE_MARGIN * 2))
+      let score = Infinity
+      for (const c of centers) score = Math.min(score, Math.abs(x - c.x) + Math.abs(z - c.z))
+      if (score > bestScore) {
+        bestScore = score
+        best = { x, z }
+      }
+    }
+    return best
+  }
+
+  const gladeBudget = Math.floor((1 - forestCoverage) * width * depth)
+  let carved = 0
+  for (let g = 0; g < gladeCount; g++) {
+    // Split what's left of the budget across the remaining glades, with some
+    // variation so they differ in size — except the last glade, which takes the
+    // exact remainder so total openness stays honest even when the random
+    // factors all ran small.
+    const variation = g === gladeCount - 1 ? 1 : 0.6 + rngForest() * 0.8
+    const share = Math.round(((gladeBudget - carved) / (gladeCount - g)) * variation)
+    const blob = growBlob(tiles, width, depth, share, pickGladeCenter(), rngForest, "grass")
     if (blob) {
       centers.push(blob.center)
-      forestCount += blob.added
+      carved += blob.added
     }
   }
 
-  // --- Small groves ----------------------------------------------------------
-  for (let g = 0; g < groveCount; g++) {
-    const size = groveSizeMin + Math.floor(rngForest() * (groveSizeMax - groveSizeMin + 1))
-    growBlob(tiles, width, depth, size, 1, rngForest)
+  // Blob growth stalls against map edges and earlier glades, so the planned
+  // glades can come up short. Top up with extra pockets until the openness
+  // budget is met — the cap keeps degenerate knob values terminating.
+  let topUps = 12
+  while (carved < gladeBudget && topUps-- > 0) {
+    const blob = growBlob(
+      tiles,
+      width,
+      depth,
+      gladeBudget - carved,
+      pickGladeCenter(),
+      rngForest,
+      "grass",
+    )
+    if (blob) {
+      centers.push(blob.center)
+      carved += blob.added
+    }
   }
 
-  // --- Road: west edge to east edge, threaded through the woods --------------
-  // Waypoints guarantee the road passes through clusters instead of always
-  // skirting them: the two centres nearest the road's overall latitude, visited
-  // in west-to-east order.
-  const midZ = (entryZ + exitZ) / 2
-  const waypoints = centers
-    .map((c, i) => ({ ...c, rank: Math.abs(c.z - midZ), i }))
-    .sort((a, b) => a.rank - b.rank || a.i - b.i)
-    .slice(0, Math.min(2, centers.length))
-    .sort((a, b) => a.x - b.x)
-
-  const stops = [{ x: 0, z: entryZ }, ...waypoints, { x: width - 1, z: exitZ }]
-  for (let s = 0; s < stops.length - 1; s++) {
-    for (const i of routeSegment(stops[s], stops[s + 1], width, depth, wander)) {
-      tiles[i] = "path"
+  // --- Small clearings: forest floor, passable but still woods ---------------
+  for (let c = 0; c < clearingCount; c++) {
+    const size =
+      clearingSizeMin + Math.floor(rngForest() * (clearingSizeMax - clearingSizeMin + 1))
+    const center = {
+      x: 1 + Math.floor(rngForest() * (width - 2)),
+      z: 1 + Math.floor(rngForest() * (depth - 2)),
     }
+    const blob = growBlob(tiles, width, depth, size, center, rngForest, "clearing")
+    if (blob) centers.push(blob.center)
+  }
+
+  // --- Trails: join every glade and clearing into one network ----------------
+  // Nearest-neighbour spanning tree over the centres, each edge routed with the
+  // wandering A* and carved as forest-floor clearing. This is what guarantees
+  // the woods are threaded with passage instead of being a solid wall.
+  const carveTrail = (a: { x: number; z: number }, b: { x: number; z: number }) => {
+    for (const i of routeSegment(a, b, width, depth, trailWander)) {
+      if (tiles[i] === "forest") tiles[i] = "clearing"
+    }
+  }
+
+  const connected: number[] = centers.length > 0 ? [0] : []
+  const pending = centers.map((_, i) => i).slice(1)
+  while (pending.length > 0) {
+    let bestPending = 0
+    let bestConnected = connected[0]
+    let bestDist = Infinity
+    for (let p = 0; p < pending.length; p++) {
+      for (const c of connected) {
+        const dist =
+          Math.abs(centers[pending[p]].x - centers[c].x) +
+          Math.abs(centers[pending[p]].z - centers[c].z)
+        if (dist < bestDist) {
+          bestDist = dist
+          bestPending = p
+          bestConnected = c
+        }
+      }
+    }
+    const next = pending[bestPending]
+    pending.splice(bestPending, 1)
+    carveTrail(centers[next], centers[bestConnected])
+    connected.push(next)
+  }
+
+  // --- Road: west edge to east edge ------------------------------------------
+  // Terrain is ignored while routing — forest in the way gets carved, which is
+  // what guarantees the road can never be blocked.
+  const roadTiles: number[] = []
+  for (const i of routeSegment(
+    { x: 0, z: entryZ },
+    { x: width - 1, z: exitZ },
+    width,
+    depth,
+    roadWander,
+  )) {
+    tiles[i] = "path"
+    roadTiles.push(i)
+  }
+
+  // --- Tie the trail network into the road -----------------------------------
+  // One trail from the road's nearest centre keeps every passable tile on the
+  // map reachable from every other, even when the road misses all the glades.
+  if (centers.length > 0) {
+    let bestCenter = centers[0]
+    let bestRoad = roadTiles[0]
+    let bestDist = Infinity
+    for (const center of centers) {
+      for (const i of roadTiles) {
+        const dist = Math.abs((i % width) - center.x) + Math.abs(Math.floor(i / width) - center.z)
+        if (dist < bestDist) {
+          bestDist = dist
+          bestCenter = center
+          bestRoad = i
+        }
+      }
+    }
+    carveTrail(bestCenter, { x: bestRoad % width, z: Math.floor(bestRoad / width) })
   }
 
   return { width, depth, tiles, buildings: [], seed }
 }
 
 /**
- * Grow one organic forest blob from a random centre by repeatedly expanding a
- * random edge of what's grown so far, until roughly `target` tiles have been
- * newly converted to forest — overlap with existing forest doesn't count, so
- * budgets stay honest. Returns the centre and the conversion count, or null
- * when target is zero.
+ * Grow one organic blob of `paint` terrain from `center` by repeatedly
+ * expanding a random edge of what's grown so far, until roughly `target` tiles
+ * have been newly converted — tiles that are already `paint` (or otherwise not
+ * forest) don't count, so budgets stay honest and glades never erase each
+ * other. Returns the centre and the conversion count, or null when target is
+ * zero.
  */
 function growBlob(
   tiles: TerrainId[],
   width: number,
   depth: number,
   target: number,
-  margin: number,
+  center: { x: number; z: number },
   rng: () => number,
+  paint: TerrainId,
 ): { center: { x: number; z: number }; added: number } | null {
   if (target <= 0) return null
-  const cx = margin + Math.floor(rng() * (width - margin * 2))
-  const cz = margin + Math.floor(rng() * (depth - margin * 2))
+  const { x: cx, z: cz } = center
 
   const blob = [cz * width + cx]
   const inBlob = new Set(blob)
   let added = 0
-  if (tiles[blob[0]] !== "forest") {
-    tiles[blob[0]] = "forest"
+  if (tiles[blob[0]] === "forest") {
+    tiles[blob[0]] = paint
     added++
   }
 
@@ -166,8 +276,8 @@ function growBlob(
     if (inBlob.has(n)) continue
     inBlob.add(n)
     blob.push(n)
-    if (tiles[n] !== "forest") {
-      tiles[n] = "forest"
+    if (tiles[n] === "forest") {
+      tiles[n] = paint
       added++
     }
   }
@@ -176,8 +286,8 @@ function growBlob(
 
 /**
  * A* over the full grid, 4-connected, cost 1 + wander per step. Terrain is
- * deliberately ignored — forest in the way gets carved, which is the "never
- * blocked" guarantee. Linear-scan open list; fine at prototype map sizes.
+ * deliberately ignored — whatever needs carving gets carved by the caller.
+ * Linear-scan open list; fine at prototype map sizes.
  */
 function routeSegment(
   start: { x: number; z: number },

--- a/lib/game/map/terrain.ts
+++ b/lib/game/map/terrain.ts
@@ -6,7 +6,7 @@
  * isometric camera without needing a real heightmap yet.
  */
 
-export type TerrainId = "grass" | "dirt" | "path" | "forest" | "hills"
+export type TerrainId = "grass" | "dirt" | "path" | "forest" | "clearing" | "hills"
 
 export interface TerrainDef {
   id: TerrainId
@@ -19,6 +19,8 @@ export interface TerrainDef {
   jitter: number
   /** Can buildings be placed here without clearing first? */
   buildable: boolean
+  /** Can player-controlled units walk here? Forest proper is solid trees. */
+  passable: boolean
 }
 
 export const TERRAIN: Record<TerrainId, TerrainDef> = {
@@ -29,6 +31,7 @@ export const TERRAIN: Record<TerrainId, TerrainDef> = {
     height: 0.2,
     jitter: 0.14,
     buildable: true,
+    passable: true,
   },
   dirt: {
     id: "dirt",
@@ -37,6 +40,7 @@ export const TERRAIN: Record<TerrainId, TerrainDef> = {
     height: 0.17,
     jitter: 0.1,
     buildable: true,
+    passable: true,
   },
   path: {
     id: "path",
@@ -45,6 +49,7 @@ export const TERRAIN: Record<TerrainId, TerrainDef> = {
     height: 0.13,
     jitter: 0.08,
     buildable: false,
+    passable: true,
   },
   forest: {
     id: "forest",
@@ -53,6 +58,16 @@ export const TERRAIN: Record<TerrainId, TerrainDef> = {
     height: 0.24,
     jitter: 0.16,
     buildable: false,
+    passable: false,
+  },
+  clearing: {
+    id: "clearing",
+    label: "Forest clearing",
+    color: "#69763f",
+    height: 0.21,
+    jitter: 0.12,
+    buildable: false,
+    passable: true,
   },
   hills: {
     id: "hills",
@@ -61,6 +76,7 @@ export const TERRAIN: Record<TerrainId, TerrainDef> = {
     height: 0.62,
     jitter: 0.12,
     buildable: true,
+    passable: true,
   },
 }
 
@@ -70,5 +86,6 @@ export const TERRAIN_CHARS: Record<string, TerrainId> = {
   ",": "dirt",
   "=": "path",
   F: "forest",
+  o: "clearing",
   "^": "hills",
 }


### PR DESCRIPTION
Inverts map generation so the world starts as solid forest and openness is carved out of it, replacing the old grow-forest-blobs-on-grass approach that left huge empty gaps between woods. Spread-apart grass glades are carved to a coverage budget, and a new passable `clearing` terrain (forest floor, no trees, not buildable) forms small clearings plus a trail network that joins every glade and clearing to each other and to the road — a new test proves all passable land is one connected region on every seed. `TerrainDef` gains an explicit `passable` flag for the future unit-movement system, and the road is now a pure function of its own RNG stream, so forest knobs can never move it. Generator knobs, HUD sliders, and URL params change from clusters/groves to glades/clearings, with defaults set to the confirmed ideal tuning: 60% coverage, 12 glades, 22 clearings, 1 tree per tile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)