### PR TITLE
feat(game): looping medieval background music with HUD toggle

### DIFF
--- a/components/game/game-shell.tsx
+++ b/components/game/game-shell.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/lib/game/map/generate-map"
 
 import { GameHud } from "./game-hud"
+import { MusicPlayer } from "./music-player"
 import { DEFAULT_TREE_DENSITY } from "./trees"
 
 /**
@@ -135,6 +136,7 @@ export function GameShell({
         onReroll={() => setSeed(randomSeed())}
         onSeedChange={setSeed}
       />
+      <MusicPlayer />
     </div>
   )
 }

--- a/components/game/music-player.tsx
+++ b/components/game/music-player.tsx
@@ -1,0 +1,159 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+
+/**
+ * Placeholder background music: a long medieval lute recording streamed via the
+ * YouTube IFrame API from an invisible player. Meant to be replaced by a real
+ * audio pipeline later — swap VIDEO_ID for a different track, or swap this
+ * whole component out.
+ */
+
+const VIDEO_ID = "5F5dgg1eeGE"
+/** 0–100. Quiet enough to sit under the game rather than in front of it. */
+const VOLUME = 20
+const MUSIC_STORAGE_KEY = "pilgrimage.music"
+
+interface YouTubePlayer {
+  playVideo: () => void
+  pauseVideo: () => void
+  setVolume: (volume: number) => void
+  destroy: () => void
+}
+
+declare global {
+  interface Window {
+    YT?: {
+      Player: new (
+        element: HTMLElement,
+        options: {
+          videoId: string
+          playerVars: Record<string, string | number>
+          events: { onReady: (event: { target: YouTubePlayer }) => void }
+        },
+      ) => YouTubePlayer
+    }
+    onYouTubeIframeAPIReady?: () => void
+  }
+}
+
+/** Null when nothing is saved or outside a browser. Call from effects, not render. */
+function loadMusicEnabled(): boolean | null {
+  if (typeof window === "undefined") return null
+  const raw = window.localStorage.getItem(MUSIC_STORAGE_KEY)
+  return raw === null ? null : raw === "on"
+}
+
+function saveMusicEnabled(enabled: boolean): void {
+  if (typeof window === "undefined") return
+  window.localStorage.setItem(MUSIC_STORAGE_KEY, enabled ? "on" : "off")
+}
+
+export function MusicPlayer() {
+  const hostRef = useRef<HTMLDivElement>(null)
+  const playerRef = useRef<YouTubePlayer | null>(null)
+  const [ready, setReady] = useState(false)
+  // Browsers refuse un-gestured audio, so playback waits for any interaction.
+  const [interacted, setInteracted] = useState(false)
+  const [enabled, setEnabled] = useState(true)
+
+  useEffect(() => {
+    setEnabled(loadMusicEnabled() ?? true)
+  }, [])
+
+  useEffect(() => {
+    const host = hostRef.current
+    if (!host) return
+    let cancelled = false
+
+    const create = () => {
+      if (cancelled || !window.YT) return
+      // The API replaces the host element with the player iframe in place.
+      playerRef.current = new window.YT.Player(host, {
+        videoId: VIDEO_ID,
+        // Looping a single video requires naming it as its own playlist.
+        playerVars: { controls: 0, disablekb: 1, loop: 1, playlist: VIDEO_ID },
+        events: {
+          onReady: (event) => {
+            event.target.setVolume(VOLUME)
+            setReady(true)
+          },
+        },
+      })
+    }
+
+    if (window.YT?.Player) {
+      create()
+    } else {
+      const previous = window.onYouTubeIframeAPIReady
+      window.onYouTubeIframeAPIReady = () => {
+        previous?.()
+        create()
+      }
+      if (!document.querySelector('script[src="https://www.youtube.com/iframe_api"]')) {
+        const script = document.createElement("script")
+        script.src = "https://www.youtube.com/iframe_api"
+        document.head.append(script)
+      }
+    }
+
+    return () => {
+      cancelled = true
+      playerRef.current?.destroy()
+      playerRef.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    if (interacted) return
+    const mark = () => setInteracted(true)
+    window.addEventListener("pointerdown", mark)
+    window.addEventListener("keydown", mark)
+    return () => {
+      window.removeEventListener("pointerdown", mark)
+      window.removeEventListener("keydown", mark)
+    }
+  }, [interacted])
+
+  useEffect(() => {
+    const player = playerRef.current
+    if (!ready || !interacted || !player) return
+    if (enabled) player.playVideo()
+    else player.pauseVideo()
+  }, [ready, interacted, enabled])
+
+  // The game falls silent with the tab, like it would if it paused.
+  useEffect(() => {
+    const onVisibilityChange = () => {
+      const player = playerRef.current
+      if (!ready || !interacted || !player) return
+      if (document.hidden) player.pauseVideo()
+      else if (enabled) player.playVideo()
+    }
+    document.addEventListener("visibilitychange", onVisibilityChange)
+    return () => document.removeEventListener("visibilitychange", onVisibilityChange)
+  }, [ready, interacted, enabled])
+
+  const toggle = () => {
+    const next = !enabled
+    setEnabled(next)
+    saveMusicEnabled(next)
+  }
+
+  return (
+    <>
+      {/* Kept 1px and transparent rather than display:none so playback isn't suppressed. */}
+      <div aria-hidden className="pointer-events-none fixed bottom-0 left-0 h-px w-px overflow-hidden opacity-0">
+        <div ref={hostRef} />
+      </div>
+      <button
+        type="button"
+        onClick={toggle}
+        aria-pressed={enabled}
+        className="pointer-events-auto absolute bottom-5 left-1/2 z-10 -translate-x-1/2 border border-rule bg-parchment/95 px-4 py-2 font-display text-[10px] uppercase tracking-[2px] text-ink shadow-[0_2px_16px_rgba(0,0,0,0.6)] transition-colors hover:border-gold hover:text-red"
+      >
+        ♪ Music {enabled ? "On" : "Off"}
+      </button>
+    </>
+  )
+}


### PR DESCRIPTION
Adds placeholder background music to the play view: a long medieval lute recording streamed through a hidden, looping YouTube IFrame player, kept quiet (20% volume) so it sits under the game. Playback starts on the player's first click or keypress to satisfy browser autoplay policies, pauses while the tab is hidden, and a parchment-styled "♪ Music On/Off" toggle at the bottom-center of the HUD persists the preference in localStorage. The track and player are contained in the new `music-player.tsx`, so swapping in real audio later touches one file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)