### PR TITLE
feat(game): fade forests into grassland and flatten the ground

### DIFF
--- a/components/game/buildings.tsx
+++ b/components/game/buildings.tsx
@@ -3,8 +3,8 @@
 import { useMemo } from "react"
 import * as THREE from "three"
 
-import { TERRAIN } from "@/lib/game/map/terrain"
-import { tileAt, tileToWorldX, tileToWorldZ, type GameMap } from "@/lib/game/map/types"
+import { TILE_HEIGHT } from "@/lib/game/map/terrain"
+import { tileToWorldX, tileToWorldZ, type GameMap } from "@/lib/game/map/types"
 import {
   buildingObjectId,
   encodeObjectId,
@@ -38,8 +38,7 @@ export function Buildings({ map }: { map: GameMap }) {
         // Footprint centre: the origin tile's centre, offset by half the extra tiles.
         const centreX = tileToWorldX(map, building.x) + (building.w - 1) / 2
         const centreZ = tileToWorldZ(map, building.z) + (building.d - 1) / 2
-        const groundTerrain = tileAt(map, building.x, building.z)
-        const baseY = groundTerrain ? TERRAIN[groundTerrain].height : 0
+        const baseY = TILE_HEIGHT
 
         const bodyArgs: [number, number, number] = [
           building.w * BODY_INSET,

--- a/components/game/game-canvas.tsx
+++ b/components/game/game-canvas.tsx
@@ -17,7 +17,16 @@ import { Trees } from "./trees"
 
 const BACKGROUND = "#14100a"
 
-export function GameCanvas({ map, treeDensity }: { map: GameMap; treeDensity?: number }) {
+export function GameCanvas({
+  map,
+  treeDensity,
+  showGrid = false,
+}: {
+  map: GameMap
+  treeDensity?: number
+  /** Draw the global tile lattice over the ground. Off by default. */
+  showGrid?: boolean
+}) {
   return (
     <Canvas
       orthographic
@@ -40,7 +49,7 @@ export function GameCanvas({ map, treeDensity }: { map: GameMap; treeDensity?: n
 
       {/* The terrain suspends while the dirt texture loads. */}
       <Suspense fallback={null}>
-        <TerrainTiles map={map} />
+        <TerrainTiles map={map} showGrid={showGrid} />
       </Suspense>
       <Trees map={map} density={treeDensity} />
       <Buildings map={map} />

--- a/components/game/terrain-tiles.tsx
+++ b/components/game/terrain-tiles.tsx
@@ -1,11 +1,12 @@
 "use client"
 
-import { useLayoutEffect, useMemo, useRef } from "react"
+import { useEffect, useLayoutEffect, useMemo, useRef } from "react"
 import { useLoader } from "@react-three/fiber"
 import * as THREE from "three"
 
 import { deriveSeed, makeRng, SEED_STREAM } from "@/lib/game/rng"
-import { TERRAIN } from "@/lib/game/map/terrain"
+import { computeForestShade } from "@/lib/game/map/forest-field"
+import { TERRAIN, TILE_HEIGHT } from "@/lib/game/map/terrain"
 import { tileToWorldX, tileToWorldZ, type GameMap } from "@/lib/game/map/types"
 import { OUTLINE_ID_LAYER_MASK } from "@/lib/game/render/outline"
 
@@ -25,53 +26,69 @@ const SLAB_EXPAND = 0.1
 const DIRT_TEXTURE_URL = "/textures/dirt-side.png"
 
 /**
- * Tiles are a hair under 1 unit so neighbouring boxes of different heights
- * never share a face plane (coplanar faces shimmer). The 0.002 seam is well
- * under a pixel at every zoom, and the grid line sits on top of it anyway.
- */
-const TILE_EPS = 0.998
-
-/**
- * Grid lines are drawn in the tile shader, not as gaps between tiles. Each tile
- * darkens a band this wide (in world units) along the edges of its top face;
- * two adjacent tiles together produce one line centred on the shared boundary.
+ * The optional grid is one global lattice projected onto the terrain, not a
+ * border on each tile. The shader darkens a band this wide (in world units) on
+ * either side of every integer world-space line on the tiles' top faces, so
+ * the lines run continuously across the map and never depend on the
+ * individual boxes under them.
  */
 const GRID_HALF_WIDTH = 0.025
 /** How much a grid line darkens the tile colour underneath it. */
 const GRID_DARKEN = 0.8
 
+/**
+ * Anchor tints for the forest-shade gradient. Every tile's colour is pulled
+ * (by its terrain's `shadeBlend`) toward a point on the ramp between these two,
+ * chosen by how deep in the woods it sits — so the ground darkens under the
+ * forest cluster and brightens continuously toward open meadow, instead of
+ * snapping between two flat greens at the tree line.
+ */
+const DEEP_WOOD_TINT = new THREE.Color("#36452a")
+const OPEN_MEADOW_TINT = new THREE.Color("#94a158")
+
 
 /**
- * A Lambert material with the grid overlay injected. The unit box's UVs span
- * 0–1 per face and instances never rotate, so `uv` measures across the tile and
- * `normal.y` picks out the top face. fwidth-based smoothing keeps the lines
- * from shimmering at far zooms.
+ * A Lambert material with the global grid overlay injected. The line position
+ * comes from world-space XZ, not from each box's UVs, so the overlay is one
+ * continuous lattice over the whole map rather than a border drawn per tile.
+ * Tile boundaries sit at `k - width/2` in world units, so `origin` shifts the
+ * lattice to land on them for any map size. `normal.y` picks out the top
+ * face. fwidth-based smoothing keeps the lines from shimmering at far zooms.
  */
-function makeGridMaterial(): THREE.MeshLambertMaterial {
+function makeGridMaterial(origin: { x: number; z: number }): THREE.MeshLambertMaterial {
   const material = new THREE.MeshLambertMaterial()
   material.onBeforeCompile = (shader) => {
     shader.vertexShader = shader.vertexShader
       .replace(
         "#include <common>",
-        "varying vec2 vGridUv;\nvarying float vGridTop;\n#include <common>",
+        "varying vec2 vGridWorld;\nvarying float vGridTop;\n#include <common>",
       )
       .replace(
-        "#include <uv_vertex>",
-        "#include <uv_vertex>\nvGridUv = uv;\nvGridTop = step(0.5, normal.y);",
+        "#include <project_vertex>",
+        `#include <project_vertex>
+        {
+          vec4 gridPos = vec4(transformed, 1.0);
+          #ifdef USE_INSTANCING
+            gridPos = instanceMatrix * gridPos;
+          #endif
+          gridPos = modelMatrix * gridPos;
+          vGridWorld = gridPos.xz;
+          vGridTop = step(0.5, normal.y);
+        }`,
       )
     shader.fragmentShader = shader.fragmentShader
       .replace(
         "#include <common>",
-        "varying vec2 vGridUv;\nvarying float vGridTop;\n#include <common>",
+        "varying vec2 vGridWorld;\nvarying float vGridTop;\n#include <common>",
       )
       .replace(
         "#include <color_fragment>",
         `#include <color_fragment>
         {
-          float gridDist = min(
-            min(vGridUv.x, 1.0 - vGridUv.x),
-            min(vGridUv.y, 1.0 - vGridUv.y)
-          );
+          // Distance to the nearest lattice line along each axis.
+          vec2 cell = fract(vGridWorld + vec2(${origin.x.toFixed(3)}, ${origin.z.toFixed(3)}));
+          vec2 axisDist = 0.5 - abs(cell - 0.5);
+          float gridDist = min(axisDist.x, axisDist.y);
           float aa = fwidth(gridDist);
           float line = (1.0 - smoothstep(${GRID_HALF_WIDTH} - aa, ${GRID_HALF_WIDTH} + aa, gridDist)) * vGridTop;
           diffuseColor.rgb *= mix(1.0, ${GRID_DARKEN}, line);
@@ -81,12 +98,29 @@ function makeGridMaterial(): THREE.MeshLambertMaterial {
   return material
 }
 
-export function TerrainTiles({ map }: { map: GameMap }) {
+export function TerrainTiles({
+  map,
+  showGrid = false,
+}: {
+  map: GameMap
+  /** Draw the global tile lattice over the ground. Off by default. */
+  showGrid?: boolean
+}) {
   const meshRef = useRef<THREE.InstancedMesh>(null)
   const idMeshRef = useRef<THREE.InstancedMesh>(null)
   const count = map.width * map.depth
 
-  const gridMaterial = useMemo(makeGridMaterial, [])
+  // Tile boundaries sit at integer offsets from -width/2, so the lattice
+  // origin is that half-extent modulo one tile. Without the grid the ground
+  // is a plain Lambert surface — no overlay, no per-tile edge of any kind.
+  const groundMaterial = useMemo(
+    () =>
+      showGrid
+        ? makeGridMaterial({ x: (map.width / 2) % 1, z: (map.depth / 2) % 1 })
+        : new THREE.MeshLambertMaterial(),
+    [showGrid, map.width, map.depth],
+  )
+  useEffect(() => () => groundMaterial.dispose(), [groundMaterial])
 
   useLayoutEffect(() => {
     const mesh = meshRef.current
@@ -98,24 +132,30 @@ export function TerrainTiles({ map }: { map: GameMap }) {
     const quaternion = new THREE.Quaternion()
     const scale = new THREE.Vector3()
     const color = new THREE.Color()
+    const tint = new THREE.Color()
     // Colour grain is a function of the map's own seed, one stream per consumer.
     const rng = makeRng(deriveSeed(map.seed ?? 0, SEED_STREAM.tileJitter))
+    const shade = computeForestShade(map)
 
     for (let z = 0; z < map.depth; z++) {
       for (let x = 0; x < map.width; x++) {
         const index = z * map.width + x
         const def = TERRAIN[map.tiles[index]]
 
-        // Box base sits at y=0 and the top at the terrain height, so tiles sink
-        // into the slab and never show a gap from a low camera angle. Full-size
-        // footprints — the grid comes from the shader overlay, not from gaps.
-        position.set(tileToWorldX(map, x), def.height / 2, tileToWorldZ(map, z))
-        scale.set(TILE_EPS, def.height, TILE_EPS)
+        // Box base sits at y=0 and the top at the shared tile height, so tiles
+        // sink into the slab and never show a gap from a low camera angle.
+        // Full-size footprints: every top face is coplanar with its
+        // neighbours, so the ground reads as one continuous surface with no
+        // seams or steps; the only visible edge is the optional grid overlay.
+        position.set(tileToWorldX(map, x), TILE_HEIGHT / 2, tileToWorldZ(map, z))
+        scale.set(1, TILE_HEIGHT, 1)
         matrix.compose(position, quaternion, scale)
         mesh.setMatrixAt(index, matrix)
         idMesh.setMatrixAt(index, matrix)
 
         color.set(def.color)
+        tint.copy(OPEN_MEADOW_TINT).lerp(DEEP_WOOD_TINT, shade[index])
+        color.lerp(tint, def.shadeBlend)
         color.multiplyScalar(1 + (rng() - 0.5) * def.jitter)
         mesh.setColorAt(index, color)
       }
@@ -158,7 +198,7 @@ export function TerrainTiles({ map }: { map: GameMap }) {
         args={[undefined as unknown as THREE.BufferGeometry, undefined as unknown as THREE.Material, count]}
       >
         <boxGeometry args={[1, 1, 1]} />
-        <primitive object={gridMaterial} attach="material" />
+        <primitive object={groundMaterial} attach="material" />
       </instancedMesh>
 
       {/*

--- a/components/game/tile-cursor.tsx
+++ b/components/game/tile-cursor.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useCameraStore } from "@/lib/game/camera-store"
-import { TERRAIN } from "@/lib/game/map/terrain"
+import { TILE_HEIGHT } from "@/lib/game/map/terrain"
 import { tileAt, tileToWorldX, tileToWorldZ, type GameMap } from "@/lib/game/map/types"
 
 /**
@@ -12,10 +12,9 @@ export function TileCursor({ map }: { map: GameMap }) {
   const hovered = useCameraStore((s) => s.hovered)
   if (!hovered) return null
 
-  const terrain = tileAt(map, hovered.x, hovered.z)
-  if (!terrain) return null
+  if (!tileAt(map, hovered.x, hovered.z)) return null
 
-  const y = TERRAIN[terrain].height
+  const y = TILE_HEIGHT
 
   return (
     <mesh position={[tileToWorldX(map, hovered.x), y + 0.015, tileToWorldZ(map, hovered.z)]}>

--- a/components/game/trees.tsx
+++ b/components/game/trees.tsx
@@ -4,7 +4,8 @@ import { useLayoutEffect, useMemo, useRef } from "react"
 import * as THREE from "three"
 
 import { deriveSeed, makeRng, SEED_STREAM } from "@/lib/game/rng"
-import { TERRAIN } from "@/lib/game/map/terrain"
+import { computeForestShade } from "@/lib/game/map/forest-field"
+import { TILE_HEIGHT } from "@/lib/game/map/terrain"
 import { tileToWorldX, tileToWorldZ, type GameMap } from "@/lib/game/map/types"
 import {
   encodeObjectId,
@@ -13,30 +14,84 @@ import {
 } from "@/lib/game/render/outline"
 
 /**
- * Placeholder trees: jittered boxes on every forest tile, drawn in one batch.
- * `density` is trees per tile — 1 reads as open woodland, 4+ as black forest.
- * Jitter derives from the map seed (via its own stream so trees and tiles never
- * share RNG state), keeping the whole look a function of one number.
+ * Placeholder trees: jittered boxes on forest tiles, drawn in one batch.
+ * `density` is trees per tile at the forest core. The stand fades at its
+ * edges: tree count, height, and colour all follow the forest-shade field, so
+ * the outermost trees are sparser, shorter, and lighter and the woods taper
+ * into grassland instead of stopping at a wall. Every forest tile keeps at
+ * least one tree — forest is impassable, and a treeless tile would lie about
+ * that. Jitter derives from the map seed (via its own stream so trees and
+ * tiles never share RNG state), keeping the whole look a function of one
+ * number.
  */
 const TREE_COLOR = new THREE.Color("#40542e")
 
 export const DEFAULT_TREE_DENSITY = 1
 
+/** Edge trees scale down to this fraction of a core tree's size. */
+const EDGE_SIZE_SCALE = 0.55
+
+/** How deep in the woods a tile must be before extra core trees can appear. */
+const CORE_SHADE = 0.75
+
+interface TreePlacement {
+  x: number
+  z: number
+  offsetX: number
+  offsetZ: number
+  height: number
+  width: number
+  rotation: number
+  brightness: number
+}
+
 export function Trees({ map, density = DEFAULT_TREE_DENSITY }: { map: GameMap; density?: number }) {
   const meshRef = useRef<THREE.InstancedMesh>(null)
   const idMeshRef = useRef<THREE.InstancedMesh>(null)
 
-  const forestTiles = useMemo(() => {
-    const tiles: Array<{ x: number; z: number }> = []
+  // The plan is pure data derived from the map seed, built up front because the
+  // instance count must be known before the meshes mount.
+  const placements = useMemo<TreePlacement[]>(() => {
+    const shade = computeForestShade(map)
+    const rng = makeRng(deriveSeed(map.seed ?? 0, SEED_STREAM.trees))
+    const trees: TreePlacement[] = []
+
+    // Slimmer trunks as the packing increases, so canopies overlap instead of
+    // merging into one solid block.
+    const widthScale = 1 / Math.sqrt(Math.max(1, density))
+
     for (let z = 0; z < map.depth; z++) {
       for (let x = 0; x < map.width; x++) {
-        if (map.tiles[z * map.width + x] === "forest") tiles.push({ x, z })
+        const index = z * map.width + x
+        if (map.tiles[index] !== "forest") continue
+        const depth = shade[index]
+
+        // Edge tiles thin out to a single tree; the deep core occasionally
+        // packs one extra so the middle of the stand reads denser than its rim.
+        let count = Math.max(1, Math.round(density * (0.5 + 0.5 * depth)))
+        if (depth > CORE_SHADE && rng() < (depth - CORE_SHADE) * 2) count += 1
+
+        const sizeScale = EDGE_SIZE_SCALE + (1 - EDGE_SIZE_SCALE) * depth
+        for (let t = 0; t < count; t++) {
+          trees.push({
+            x,
+            z,
+            height: (0.65 + rng() * 0.85) * sizeScale,
+            width: (0.34 + rng() * 0.16) * widthScale * sizeScale,
+            // Spread across the tile so a packed tile reads as many trees, not a lattice.
+            offsetX: (rng() - 0.5) * 0.8,
+            offsetZ: (rng() - 0.5) * 0.8,
+            rotation: rng() * Math.PI,
+            // Edge growth reads younger and sunlit — a touch lighter than the core.
+            brightness: (0.75 + rng() * 0.5) * (1.12 - 0.18 * depth),
+          })
+        }
       }
     }
-    return tiles
-  }, [map])
+    return trees
+  }, [map, density])
 
-  const count = forestTiles.length * density
+  const count = placements.length
 
   useLayoutEffect(() => {
     const mesh = meshRef.current
@@ -50,50 +105,36 @@ export function Trees({ map, density = DEFAULT_TREE_DENSITY }: { map: GameMap; d
     const scale = new THREE.Vector3()
     const color = new THREE.Color()
     const idColor = new THREE.Color()
-    const rng = makeRng(deriveSeed(map.seed ?? 0, SEED_STREAM.trees))
-    const baseY = TERRAIN.forest.height
+    const baseY = TILE_HEIGHT
 
-    // Slimmer trunks as the packing increases, so canopies overlap instead of
-    // merging into one solid block.
-    const widthScale = 1 / Math.sqrt(density)
+    for (let index = 0; index < placements.length; index++) {
+      const tree = placements[index]
+      position.set(
+        tileToWorldX(map, tree.x) + tree.offsetX,
+        baseY + tree.height / 2,
+        tileToWorldZ(map, tree.z) + tree.offsetZ,
+      )
+      euler.set(0, tree.rotation, 0)
+      quaternion.setFromEuler(euler)
+      scale.set(tree.width, tree.height, tree.width)
+      matrix.compose(position, quaternion, scale)
+      mesh.setMatrixAt(index, matrix)
+      idMesh.setMatrixAt(index, matrix)
 
-    let index = 0
-    for (const tile of forestTiles) {
-      for (let t = 0; t < density; t++) {
-        const height = 0.65 + rng() * 0.85
-        const width = (0.34 + rng() * 0.16) * widthScale
-        // Spread across the tile so a packed tile reads as many trees, not a lattice.
-        const offsetX = (rng() - 0.5) * 0.8
-        const offsetZ = (rng() - 0.5) * 0.8
+      color.copy(TREE_COLOR).multiplyScalar(tree.brightness)
+      mesh.setColorAt(index, color)
 
-        position.set(
-          tileToWorldX(map, tile.x) + offsetX,
-          baseY + height / 2,
-          tileToWorldZ(map, tile.z) + offsetZ,
-        )
-        euler.set(0, rng() * Math.PI, 0)
-        quaternion.setFromEuler(euler)
-        scale.set(width, height, width)
-        matrix.compose(position, quaternion, scale)
-        mesh.setMatrixAt(index, matrix)
-        idMesh.setMatrixAt(index, matrix)
-
-        color.copy(TREE_COLOR).multiplyScalar(0.75 + rng() * 0.5)
-        mesh.setColorAt(index, color)
-
-        // One ID per tree, so overlapping trees separate from each other too.
-        const [r, g, b] = encodeObjectId(treeObjectId(map.buildings.length, index))
-        idColor.setRGB(r, g, b)
-        idMesh.setColorAt(index, idColor)
-        index++
-      }
+      // One ID per tree, so overlapping trees separate from each other too.
+      const [r, g, b] = encodeObjectId(treeObjectId(map.buildings.length, index))
+      idColor.setRGB(r, g, b)
+      idMesh.setColorAt(index, idColor)
     }
 
     mesh.instanceMatrix.needsUpdate = true
     if (mesh.instanceColor) mesh.instanceColor.needsUpdate = true
     idMesh.instanceMatrix.needsUpdate = true
     if (idMesh.instanceColor) idMesh.instanceColor.needsUpdate = true
-  }, [map, forestTiles, density])
+  }, [map, placements])
 
   if (count === 0) return null
 

--- a/lib/game/map/forest-field.test.ts
+++ b/lib/game/map/forest-field.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest"
+
+import { computeForestShade, FOREST_SHADE_RADIUS } from "./forest-field"
+import { generateMap } from "./generate-map"
+import type { TerrainId } from "./terrain"
+import type { GameMap } from "./types"
+
+/** A width×depth map whose left `forestCols` columns are forest, rest grass. */
+function splitMap(width: number, depth: number, forestCols: number): GameMap {
+  const tiles: TerrainId[] = []
+  for (let z = 0; z < depth; z++) {
+    for (let x = 0; x < width; x++) {
+      tiles.push(x < forestCols ? "forest" : "grass")
+    }
+  }
+  return { width, depth, tiles, buildings: [] }
+}
+
+describe("computeForestShade", () => {
+  it("stays within 0–1 and matches the map size", () => {
+    const map = generateMap({ seed: 42 })
+    const shade = computeForestShade(map)
+    expect(shade).toHaveLength(map.width * map.depth)
+    for (const v of shade) {
+      expect(v).toBeGreaterThanOrEqual(0)
+      expect(v).toBeLessThanOrEqual(1)
+    }
+  })
+
+  it("reads 1 deep in the woods and 0 in open land beyond the fade", () => {
+    const map = splitMap(32, 8, 16)
+    const shade = computeForestShade(map)
+    const mid = 4
+    // Column well inside the forest half, farther than the window reaches.
+    expect(shade[mid * 32 + 4]).toBe(1)
+    // Column well into the grass half.
+    expect(shade[mid * 32 + 28]).toBe(0)
+  })
+
+  it("ramps down monotonically across the tree line", () => {
+    const map = splitMap(32, 8, 16)
+    const shade = computeForestShade(map)
+    const mid = 4
+    for (let x = 16 - FOREST_SHADE_RADIUS; x < 16 + FOREST_SHADE_RADIUS; x++) {
+      expect(shade[mid * 32 + x]).toBeGreaterThan(shade[mid * 32 + x + 1])
+    }
+  })
+
+  it("is not skewed open at the map border", () => {
+    // All-forest map: even corner tiles, whose blur window is clipped, read 1.
+    const tiles: TerrainId[] = new Array<TerrainId>(16 * 16).fill("forest")
+    const shade = computeForestShade({ width: 16, depth: 16, tiles, buildings: [] })
+    expect(shade[0]).toBe(1)
+    expect(shade[shade.length - 1]).toBe(1)
+  })
+})

--- a/lib/game/map/forest-field.ts
+++ b/lib/game/map/forest-field.ts
@@ -1,0 +1,59 @@
+import type { GameMap } from "./types"
+
+/**
+ * Forest shade: a smooth 0–1 field over the map measuring how deep in the
+ * woods each tile sits. 1 is the heart of a forest cluster, 0 is open land far
+ * from any tree. It is the fraction of forest tiles in a square window around
+ * the tile, pushed through a smoothstep so both ends of the ramp ease out.
+ *
+ * Pure data — no three.js, no React — and a single source of truth: tile
+ * colours and tree placement both read it, so the ground gradient and the
+ * thinning tree line fade in lockstep and the forest edge never looks like a
+ * wall. Computed with a summed-area table, so cost is linear in map size and
+ * independent of the radius.
+ */
+
+/**
+ * Window half-width in tiles. The visible gradient spans roughly twice this,
+ * so 4 gives a fade about 8 tiles wide — wide enough to read across a glade,
+ * narrow enough that big glades still reach fully open meadow in the middle.
+ */
+export const FOREST_SHADE_RADIUS = 4
+
+export function computeForestShade(
+  map: GameMap,
+  radius: number = FOREST_SHADE_RADIUS,
+): Float32Array {
+  const { width, depth, tiles } = map
+  const stride = width + 1
+
+  // sat[(z+1)*stride + (x+1)] = count of forest tiles in the rect [0..x, 0..z].
+  const sat = new Float64Array(stride * (depth + 1))
+  for (let z = 0; z < depth; z++) {
+    for (let x = 0; x < width; x++) {
+      const forest = tiles[z * width + x] === "forest" ? 1 : 0
+      sat[(z + 1) * stride + (x + 1)] =
+        forest + sat[z * stride + (x + 1)] + sat[(z + 1) * stride + x] - sat[z * stride + x]
+    }
+  }
+
+  const shade = new Float32Array(width * depth)
+  for (let z = 0; z < depth; z++) {
+    const z0 = Math.max(0, z - radius)
+    const z1 = Math.min(depth - 1, z + radius)
+    for (let x = 0; x < width; x++) {
+      const x0 = Math.max(0, x - radius)
+      const x1 = Math.min(width - 1, x + radius)
+      const sum =
+        sat[(z1 + 1) * stride + (x1 + 1)] -
+        sat[z0 * stride + (x1 + 1)] -
+        sat[(z1 + 1) * stride + x0] +
+        sat[z0 * stride + x0]
+      // Normalise by the clamped window's real area so edge-of-map tiles
+      // aren't read as artificially open.
+      const density = sum / ((x1 - x0 + 1) * (z1 - z0 + 1))
+      shade[z * width + x] = density * density * (3 - 2 * density)
+    }
+  }
+  return shade
+}

--- a/lib/game/map/terrain.ts
+++ b/lib/game/map/terrain.ts
@@ -1,10 +1,14 @@
 /**
  * Terrain vocabulary for the map. Pure data — no three.js, no React.
  *
- * `height` is the world-space height of the tile's top surface above the base
- * slab. Varying it slightly per terrain gives the map readable relief under an
- * isometric camera without needing a real heightmap yet.
+ * Every tile shares one height: the ground is a flat plane and terrain reads
+ * through colour alone. Per-terrain relief was tried and dropped — a step
+ * between neighbouring tiles exposes a dark side face that outlines every
+ * terrain boundary, which is exactly the tiled look the map is meant to avoid.
  */
+
+/** World-space height of every tile's top surface above the base slab. */
+export const TILE_HEIGHT = 0.2
 
 export type TerrainId = "grass" | "dirt" | "path" | "forest" | "clearing" | "hills"
 
@@ -13,10 +17,14 @@ export interface TerrainDef {
   label: string
   /** Base tile colour, before per-tile jitter. */
   color: string
-  /** Top surface height in world units. */
-  height: number
   /** How much per-tile brightness variation to apply (0 = flat, 0.1 = subtle). */
   jitter: number
+  /**
+   * How strongly the forest-shade gradient tints this tile (0 = ignore it,
+   * 1 = fully repainted). The greens take it strongly so woods fade into
+   * grassland; worked surfaces like the road mostly hold their own colour.
+   */
+  shadeBlend: number
   /** Can buildings be placed here without clearing first? */
   buildable: boolean
   /** Can player-controlled units walk here? Forest proper is solid trees. */
@@ -28,8 +36,8 @@ export const TERRAIN: Record<TerrainId, TerrainDef> = {
     id: "grass",
     label: "Clear land",
     color: "#77864b",
-    height: 0.2,
     jitter: 0.14,
+    shadeBlend: 0.55,
     buildable: true,
     passable: true,
   },
@@ -37,8 +45,8 @@ export const TERRAIN: Record<TerrainId, TerrainDef> = {
     id: "dirt",
     label: "Bare earth",
     color: "#a58658",
-    height: 0.17,
     jitter: 0.1,
+    shadeBlend: 0.3,
     buildable: true,
     passable: true,
   },
@@ -46,8 +54,8 @@ export const TERRAIN: Record<TerrainId, TerrainDef> = {
     id: "path",
     label: "Road",
     color: "#c9ab7a",
-    height: 0.13,
     jitter: 0.08,
+    shadeBlend: 0.15,
     buildable: false,
     passable: true,
   },
@@ -55,8 +63,8 @@ export const TERRAIN: Record<TerrainId, TerrainDef> = {
     id: "forest",
     label: "Forest",
     color: "#4b5c33",
-    height: 0.24,
     jitter: 0.16,
+    shadeBlend: 0.5,
     buildable: false,
     passable: false,
   },
@@ -64,8 +72,8 @@ export const TERRAIN: Record<TerrainId, TerrainDef> = {
     id: "clearing",
     label: "Forest clearing",
     color: "#69763f",
-    height: 0.21,
     jitter: 0.12,
+    shadeBlend: 0.55,
     buildable: false,
     passable: true,
   },
@@ -73,8 +81,8 @@ export const TERRAIN: Record<TerrainId, TerrainDef> = {
     id: "hills",
     label: "Hills",
     color: "#8d8460",
-    height: 0.62,
     jitter: 0.12,
+    shadeBlend: 0.25,
     buildable: true,
     passable: true,
   },


### PR DESCRIPTION
Forest edges now taper into grassland instead of stopping at a wall. A new forest-shade field (`lib/game/map/forest-field.ts`, with tests) measures how deep in the woods each tile sits, and both the ground colour and the tree line read it: tiles blend continuously from a deep-wood tint under the forest cluster to a sunlit-meadow tint in open land, and edge-of-stand trees are sparser, shorter, and lighter than the core while every forest tile keeps at least one tree.

The ground is now one flat plane: per-terrain relief exposed a dark side face at every terrain boundary that outlined tiles, so all tiles share a single `TILE_HEIGHT` with full-width footprints and no seams. The grid is an optional world-space lattice behind a `showGrid` prop on `TerrainTiles` and `GameCanvas`, off by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)