### PR TITLE
feat(site): Assets menu with textures and characters galleries, add peasants

### DIFF
--- a/app/assets/characters/page.tsx
+++ b/app/assets/characters/page.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+
+import { CharacterGallery } from "@/components/character-gallery"
+
+export const metadata: Metadata = {
+  title: "Pilgrimage — Characters",
+  description: "Every calling that walks the road, as it appears in game.",
+}
+
+export default function CharactersPage() {
+  return (
+    <main className="flex min-h-screen flex-col items-center bg-[#1a1208] px-5 py-14">
+      <header className="mb-10 text-center">
+        <Link
+          href="/assets"
+          className="mb-6 block font-display text-[10px] uppercase tracking-[3px] text-gold hover:text-gold-light"
+        >
+          ← Assets
+        </Link>
+        <h1 className="font-display text-3xl font-bold tracking-[6px] text-parchment md:text-4xl">
+          CHARACTERS
+        </h1>
+        <p className="mt-3 font-display text-[10px] uppercase tracking-[3px] text-gold">
+          Every calling on the road, and what it rolls
+        </p>
+      </header>
+
+      <CharacterGallery />
+    </main>
+  )
+}

--- a/app/assets/page.tsx
+++ b/app/assets/page.tsx
@@ -1,0 +1,49 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+
+import { SITE_MENU } from "@/lib/site-menu"
+
+export const metadata: Metadata = {
+  title: "Pilgrimage — Assets",
+  description: "Textures and characters, as they appear in the game.",
+}
+
+const ASSETS = SITE_MENU.find((item) => item.href === "/assets")?.children ?? []
+
+export default function AssetsPage() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-[#1a1208] px-5 py-16">
+      <header className="mb-14 text-center">
+        <Link
+          href="/"
+          className="mb-6 block font-display text-[10px] uppercase tracking-[3px] text-gold hover:text-gold-light"
+        >
+          ← Menu
+        </Link>
+        <h1 className="font-display text-3xl font-bold tracking-[6px] text-parchment md:text-4xl">
+          ASSETS
+        </h1>
+        <p className="mt-3 font-display text-[10px] uppercase tracking-[3px] text-gold">
+          Everything the game is drawn with
+        </p>
+      </header>
+
+      <nav className="flex w-full max-w-xs flex-col gap-6">
+        {ASSETS.map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            className="group border border-rule bg-parchment px-6 py-4 text-center shadow-[0_0_0_3px_var(--parchment-dark),0_0_0_4px_var(--rule),4px_4px_24px_rgba(0,0,0,0.6)] transition-colors hover:bg-parchment-dark"
+          >
+            <span className="font-display text-lg font-semibold uppercase tracking-[4px] text-ink group-hover:text-red">
+              {item.label}
+            </span>
+            <span className="mt-0.5 block text-[13px] italic text-ink-light">
+              {item.description}
+            </span>
+          </Link>
+        ))}
+      </nav>
+    </main>
+  )
+}

--- a/app/assets/textures/page.tsx
+++ b/app/assets/textures/page.tsx
@@ -13,10 +13,10 @@ export default function TexturesPage() {
     <main className="flex min-h-screen flex-col items-center bg-[#1a1208] px-5 py-14">
       <header className="mb-10 text-center">
         <Link
-          href="/"
+          href="/assets"
           className="mb-6 block font-display text-[10px] uppercase tracking-[3px] text-gold hover:text-gold-light"
         >
-          ← Menu
+          ← Assets
         </Link>
         <h1 className="font-display text-3xl font-bold tracking-[6px] text-parchment md:text-4xl">
           TEXTURES

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,18 +17,35 @@ export default function LandingPage() {
 
       <nav className="flex w-full max-w-xs flex-col gap-6">
         {SITE_MENU.map((item) => (
-          <Link
+          <div
             key={item.href}
-            href={item.href}
-            className="group border border-rule bg-parchment px-6 py-4 text-center shadow-[0_0_0_3px_var(--parchment-dark),0_0_0_4px_var(--rule),4px_4px_24px_rgba(0,0,0,0.6)] transition-colors hover:bg-parchment-dark"
+            className="border border-rule bg-parchment text-center shadow-[0_0_0_3px_var(--parchment-dark),0_0_0_4px_var(--rule),4px_4px_24px_rgba(0,0,0,0.6)]"
           >
-            <span className="font-display text-lg font-semibold uppercase tracking-[4px] text-ink group-hover:text-red">
-              {item.label}
-            </span>
-            <span className="mt-0.5 block text-[13px] italic text-ink-light">
-              {item.description}
-            </span>
-          </Link>
+            <Link
+              href={item.href}
+              className="group block px-6 py-4 transition-colors hover:bg-parchment-dark"
+            >
+              <span className="font-display text-lg font-semibold uppercase tracking-[4px] text-ink group-hover:text-red">
+                {item.label}
+              </span>
+              <span className="mt-0.5 block text-[13px] italic text-ink-light">
+                {item.description}
+              </span>
+            </Link>
+            {item.children && (
+              <div className="flex justify-center gap-6 border-t border-rule px-6 py-2.5">
+                {item.children.map((child) => (
+                  <Link
+                    key={child.href}
+                    href={child.href}
+                    className="font-display text-[10px] uppercase tracking-[3px] text-ink-light hover:text-red"
+                  >
+                    {child.label}
+                  </Link>
+                ))}
+              </div>
+            )}
+          </div>
         ))}
       </nav>
 

--- a/components/character-gallery.tsx
+++ b/components/character-gallery.tsx
@@ -1,0 +1,97 @@
+"use client"
+
+import dynamic from "next/dynamic"
+
+import { TRAVELER_TYPES, type StatRange, type TravelerTypeDef } from "@/lib/game/travelers"
+
+/* three.js touches browser globals on import, so previews are client-only. */
+const CharacterPreview = dynamic(
+  () => import("./character-preview").then((m) => m.CharacterPreview),
+  { ssr: false },
+)
+
+const TYPES = Object.values(TRAVELER_TYPES)
+const TOTAL_WEIGHT = TYPES.reduce((sum, t) => sum + t.weight, 0)
+
+function CellLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mb-2 font-display text-[9px] uppercase tracking-[2px] text-gold">
+      {children}
+    </div>
+  )
+}
+
+function range({ min, max }: StatRange): string {
+  return min === max ? String(min) : `${min}–${max}`
+}
+
+function percent(value: number): string {
+  return `${Math.round(value * 100)}%`
+}
+
+function Row({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-4">
+      <span className="text-[13px] italic text-ink-light">{label}</span>
+      <span className="text-right font-display text-[10px] text-ink">{value}</span>
+    </div>
+  )
+}
+
+function CharacterCard({ type }: { type: TravelerTypeDef }) {
+  return (
+    <article className="border border-rule bg-parchment p-5 shadow-[0_0_0_3px_var(--parchment-dark),0_0_0_4px_var(--rule),4px_4px_24px_rgba(0,0,0,0.6)]">
+      <div className="mb-1 flex items-center gap-2">
+        <span
+          className="inline-block h-3 w-3 border border-rule"
+          style={{ backgroundColor: type.color }}
+        />
+        <h2 className="font-display text-base font-semibold uppercase tracking-[3px] text-ink">
+          {type.label}
+        </h2>
+      </div>
+      <p className="mb-4 text-[14px] italic text-ink-light">
+        {percent(type.weight / TOTAL_WEIGHT)} of the road
+      </p>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <CellLabel>In game</CellLabel>
+          <div className="aspect-square w-full border border-rule">
+            <CharacterPreview type={type} />
+          </div>
+        </div>
+        <div>
+          <CellLabel>Rolls</CellLabel>
+          <div className="flex flex-col gap-0.5">
+            <Row label="Gold" value={`${range(type.gold)} ✦`} />
+            <Row label="Status" value={range(type.status)} />
+            <Row label="Piety" value={range(type.piety)} />
+            <Row label="Pace" value={`${type.paceMin}–${type.paceMax}×`} />
+            <Row label="Jobless" value={percent(type.joblessChance)} />
+            <Row label="Skills" value={range(type.skillCount)} />
+          </div>
+        </div>
+      </div>
+
+      <p className="mt-4 text-[12px] text-ink-light">
+        <span className="font-display text-[9px] uppercase tracking-[2px] text-gold">Trades </span>
+        {type.skills.join(", ")}
+      </p>
+      <p className="mt-1 text-[12px] text-ink-light">
+        <span className="font-display text-[9px] uppercase tracking-[2px] text-gold">Colour </span>
+        {type.color}
+      </p>
+    </article>
+  )
+}
+
+export function CharacterGallery() {
+  return (
+    <div className="grid w-full max-w-4xl grid-cols-1 gap-8 md:grid-cols-2">
+      {TYPES.map((type) => (
+        <CharacterCard key={type.id} type={type} />
+      ))}
+    </div>
+  )
+}

--- a/components/character-preview.tsx
+++ b/components/character-preview.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import { Suspense } from "react"
+import { Canvas } from "@react-three/fiber"
+
+import { parseAsciiMap } from "@/lib/game/map/prototype-map"
+import { TERRAIN } from "@/lib/game/map/terrain"
+import {
+  CAM_FAR,
+  CAM_NEAR,
+  cameraOffset,
+  lightOffsetForYaw,
+  yawForView,
+} from "@/lib/game/render/iso"
+import type { TravelerTypeDef } from "@/lib/game/travelers"
+
+import { TerrainTiles } from "./game/terrain-tiles"
+import { TravelerFigure } from "./game/traveler-figure"
+
+/** A stretch of road through grass for the figure to stand on. */
+const ROAD_MAP = parseAsciiMap([
+  ".....",
+  ".....",
+  "=====",
+  ".....",
+  ".....",
+])
+
+const PREVIEW_YAW = yawForView(0)
+
+/**
+ * One calling as it appears in game: the same figure component, lights, and
+ * camera maths as /play, standing on a real road tile. The scene is lifted so
+ * the figure's middle sits at the origin the iso camera studies. Vendors are
+ * shown mid-sale, awning up, since that is when the cart is most recognisable.
+ */
+export function CharacterPreview({ type }: { type: TravelerTypeDef }) {
+  const roadTop = TERRAIN.path.height
+  return (
+    <Canvas
+      orthographic
+      dpr={[1, 2]}
+      gl={{ antialias: true }}
+      camera={{
+        position: cameraOffset(PREVIEW_YAW),
+        zoom: 110,
+        near: CAM_NEAR,
+        far: CAM_FAR,
+      }}
+      onCreated={({ camera }) => camera.lookAt(0, 0, 0)}
+    >
+      <color attach="background" args={["#14100a"]} />
+
+      {/* Same lighting rig as the game, frozen at view 0. */}
+      <ambientLight intensity={0.5} />
+      <hemisphereLight args={["#bcd0f0", "#3a2a16", 0.45]} />
+      <directionalLight position={lightOffsetForYaw(PREVIEW_YAW)} intensity={2.7} />
+
+      <group position={[0, -roadTop - 0.3, 0]}>
+        <Suspense fallback={null}>
+          <TerrainTiles map={ROAD_MAP} />
+        </Suspense>
+        {/* Face east along the road so the vendor's cart trails visibly. */}
+        <group position={[0, roadTop, 0]} rotation={[0, Math.PI / 2, 0]}>
+          <TravelerFigure type={type} awning={type.id === "vendor"} />
+        </group>
+      </group>
+    </Canvas>
+  )
+}

--- a/components/game/game-hud.tsx
+++ b/components/game/game-hud.tsx
@@ -102,13 +102,23 @@ function MenuPanel() {
     <div className={`pointer-events-auto w-40 border border-rule bg-parchment/95 px-4 py-3 ${PANEL_SHADOW}`}>
       <nav className="flex flex-col gap-1.5">
         {SITE_MENU.map((item) => (
-          <Link
-            key={item.href}
-            href={item.href}
-            className="font-display text-[11px] uppercase tracking-[2px] text-ink hover:text-red"
-          >
-            {item.label}
-          </Link>
+          <div key={item.href} className="flex flex-col gap-1">
+            <Link
+              href={item.href}
+              className="font-display text-[11px] uppercase tracking-[2px] text-ink hover:text-red"
+            >
+              {item.label}
+            </Link>
+            {item.children?.map((child) => (
+              <Link
+                key={child.href}
+                href={child.href}
+                className="pl-3 font-display text-[10px] uppercase tracking-[2px] text-ink-light hover:text-red"
+              >
+                {child.label}
+              </Link>
+            ))}
+          </div>
         ))}
         <button
           type="button"

--- a/components/game/traveler-figure.tsx
+++ b/components/game/traveler-figure.tsx
@@ -1,0 +1,77 @@
+"use client"
+
+import type { TravelerTypeDef } from "@/lib/game/travelers"
+
+/**
+ * The visible body of one traveler: a coloured block in the calling's colour,
+ * plus the cart for vendors. Shared between the road (components/game/
+ * travelers.tsx) and the /assets/characters gallery, so the gallery shows the
+ * exact figure the player meets in game.
+ */
+
+export const BLOCK_WIDTH = 0.3
+export const BLOCK_HEIGHT = 0.55
+
+/**
+ * The vendor's cart trails behind on the group's local -z; the group is rotated
+ * to face the direction of travel so the cart follows properly around bends.
+ */
+export const CART_BED: [number, number, number] = [0.42, 0.16, 0.5]
+export const CART_OFFSET_Z = -0.5
+
+/**
+ * Cart pieces plus the shop awning. The awning is always mounted and toggled
+ * via `visible` from useFrame (by its name), because the vending state changes
+ * in the sim at frame rate, outside React.
+ */
+export const AWNING_NAME = "vendor-awning"
+
+export type FigureClickHandler = (event: { delta: number; stopPropagation: () => void }) => void
+
+function VendorCart({ onClick, awning }: { onClick?: FigureClickHandler; awning: boolean }) {
+  return (
+    <group position={[0, 0, CART_OFFSET_Z]}>
+      {/* Unnamed on purpose: travelerScreenPoints counts "traveler" meshes 1:1. */}
+      <mesh position={[0, 0.18, 0]} onClick={onClick}>
+        <boxGeometry args={CART_BED} />
+        <meshLambertMaterial color="#6f4f2a" />
+      </mesh>
+      {/* Wine and victuals riding on the bed. */}
+      <mesh position={[0, 0.33, 0]}>
+        <boxGeometry args={[0.28, 0.14, 0.34]} />
+        <meshLambertMaterial color="#8a2f2f" />
+      </mesh>
+      {[-0.26, 0.26].map((x) => (
+        <mesh key={x} position={[x, 0.12, 0]}>
+          <boxGeometry args={[0.06, 0.24, 0.24]} />
+          <meshLambertMaterial color="#3a2c1a" />
+        </mesh>
+      ))}
+      <mesh name={AWNING_NAME} position={[0, 0.75, 0.05]} visible={awning}>
+        <boxGeometry args={[0.62, 0.04, 0.72]} />
+        <meshLambertMaterial color="#d8d0b8" />
+      </mesh>
+    </group>
+  )
+}
+
+export function TravelerFigure({
+  type,
+  onClick,
+  /** Initial awning state for vendors; the sim flips it live on the road. */
+  awning = false,
+}: {
+  type: TravelerTypeDef
+  onClick?: FigureClickHandler
+  awning?: boolean
+}) {
+  return (
+    <>
+      <mesh name="traveler" position={[0, BLOCK_HEIGHT / 2, 0]} onClick={onClick}>
+        <boxGeometry args={[BLOCK_WIDTH, BLOCK_HEIGHT, BLOCK_WIDTH]} />
+        <meshLambertMaterial color={type.color} />
+      </mesh>
+      {type.id === "vendor" && <VendorCart onClick={onClick} awning={awning} />}
+    </>
+  )
+}

--- a/components/game/travelers.tsx
+++ b/components/game/travelers.tsx
@@ -14,63 +14,29 @@ import {
   travelerObjectId,
 } from "@/lib/game/render/outline"
 
+import {
+  AWNING_NAME,
+  BLOCK_HEIGHT,
+  BLOCK_WIDTH,
+  CART_BED,
+  CART_OFFSET_Z,
+  TravelerFigure,
+} from "./traveler-figure"
+
 /**
  * People on the road: placeholder blocks driven by the simulation in
  * lib/game/sim.ts — walking, camping in clearings, chasing vendors. Identity
  * comes from the travelers prop; all per-frame state lives in the sim, and this
  * component just copies positions out of it. Click a block to select it — the
- * HUD names it and shows its live stats.
+ * HUD names it and shows its live stats. The figure itself lives in
+ * traveler-figure.tsx so the character gallery can draw the same one.
  */
-
-const BLOCK_WIDTH = 0.3
-const BLOCK_HEIGHT = 0.55
 
 /** Campers fold down to this fraction of standing height. */
 const CAMP_SCALE = 0.35
 
 /** A click that dragged further than this many pixels is a pan, not a select. */
 const CLICK_SLOP_PX = 6
-
-/**
- * The vendor's cart trails behind on the group's local -z; the group is rotated
- * to face the direction of travel so the cart follows properly around bends.
- */
-const CART_BED: [number, number, number] = [0.42, 0.16, 0.5]
-const CART_OFFSET_Z = -0.5
-
-/**
- * Cart pieces plus the shop awning. The awning is always mounted and toggled
- * via `visible` from useFrame (by its name), because the vending state changes
- * in the sim at frame rate, outside React.
- */
-export const AWNING_NAME = "vendor-awning"
-
-function VendorCart({ onClick }: { onClick: (event: { delta: number; stopPropagation: () => void }) => void }) {
-  return (
-    <group position={[0, 0, CART_OFFSET_Z]}>
-      {/* Unnamed on purpose: travelerScreenPoints counts "traveler" meshes 1:1. */}
-      <mesh position={[0, 0.18, 0]} onClick={onClick}>
-        <boxGeometry args={CART_BED} />
-        <meshLambertMaterial color="#6f4f2a" />
-      </mesh>
-      {/* Wine and victuals riding on the bed. */}
-      <mesh position={[0, 0.33, 0]}>
-        <boxGeometry args={[0.28, 0.14, 0.34]} />
-        <meshLambertMaterial color="#8a2f2f" />
-      </mesh>
-      {[-0.26, 0.26].map((x) => (
-        <mesh key={x} position={[x, 0.12, 0]}>
-          <boxGeometry args={[0.06, 0.24, 0.24]} />
-          <meshLambertMaterial color="#3a2c1a" />
-        </mesh>
-      ))}
-      <mesh name={AWNING_NAME} position={[0, 0.75, 0.05]} visible={false}>
-        <boxGeometry args={[0.62, 0.04, 0.72]} />
-        <meshLambertMaterial color="#d8d0b8" />
-      </mesh>
-    </group>
-  )
-}
 
 export function Travelers({
   map,
@@ -138,12 +104,7 @@ export function Travelers({
               groupRefs.current[index] = node
             }}
           >
-            <mesh name="traveler" position={[0, BLOCK_HEIGHT / 2, 0]} onClick={select}>
-              <boxGeometry args={[BLOCK_WIDTH, BLOCK_HEIGHT, BLOCK_WIDTH]} />
-              <meshLambertMaterial color={traveler.type.color} />
-            </mesh>
-
-            {traveler.type.id === "vendor" && <VendorCart onClick={select} />}
+            <TravelerFigure type={traveler.type} onClick={select} />
 
             {/* ID silhouettes for the outline pass; inherit the group's motion. */}
             <mesh position={[0, BLOCK_HEIGHT / 2, 0]} layers-mask={OUTLINE_ID_LAYER_MASK}>

--- a/lib/game/game.test.ts
+++ b/lib/game/game.test.ts
@@ -37,6 +37,7 @@ import {
   type OutlineMode,
 } from "./render/outline"
 import { TEXTURES } from "./render/textures"
+import { SITE_MENU } from "../site-menu"
 import { DEFAULT_WORLD_SEED, deriveSeed, makeRng, parseSeed, SEED_STREAM } from "./rng"
 
 const DEG = 180 / Math.PI
@@ -317,6 +318,23 @@ describe("texture manifest", () => {
     for (const t of TEXTURES) {
       expect(existsSync(join(process.cwd(), "public", t.url)), t.url).toBe(true)
     }
+  })
+})
+
+describe("site menu", () => {
+  it("has unique hrefs and nests sub-pages under their parent route", () => {
+    const hrefs = SITE_MENU.flatMap((item) => [item.href, ...(item.children ?? []).map((c) => c.href)])
+    expect(new Set(hrefs).size).toBe(hrefs.length)
+    for (const item of SITE_MENU) {
+      for (const child of item.children ?? []) {
+        expect(child.href.startsWith(`${item.href}/`), child.href).toBe(true)
+      }
+    }
+  })
+
+  it("lists textures and characters under assets", () => {
+    const assets = SITE_MENU.find((item) => item.label === "Assets")
+    expect(assets?.children?.map((c) => c.label)).toEqual(["Textures", "Characters"])
   })
 })
 

--- a/lib/game/travelers.test.ts
+++ b/lib/game/travelers.test.ts
@@ -67,6 +67,19 @@ describe("generateTravelers", () => {
     expect(jobless).toBeLessThan(pilgrims.length * 0.7)
   })
 
+  it("weights callings as percent shares of the road, peasants at 60", () => {
+    const total = Object.values(TRAVELER_TYPES).reduce((sum, t) => sum + t.weight, 0)
+    expect(total).toBeCloseTo(100, 10)
+    expect(TRAVELER_TYPES.peasant.weight).toBe(60)
+  })
+
+  it("fills roughly six in ten places on the road with peasants", () => {
+    const travelers = generateTravelers(31337, 2000)
+    const peasants = travelers.filter((t) => t.type.id === "peasant").length / travelers.length
+    expect(peasants).toBeGreaterThan(0.55)
+    expect(peasants).toBeLessThan(0.65)
+  })
+
   it("sends traffic both ways and mixes the callings", () => {
     const travelers = generateTravelers(4242, 200)
     const eastbound = travelers.filter((t) => t.direction === 1).length

--- a/lib/game/travelers.ts
+++ b/lib/game/travelers.ts
@@ -12,6 +12,7 @@ import { deriveSeed, makeRng, SEED_STREAM } from "./rng"
  */
 
 export type TravelerTypeId =
+  | "peasant"
   | "pilgrim"
   | "merchant"
   | "friar"
@@ -30,7 +31,10 @@ export interface TravelerTypeDef {
   label: string
   /** Block colour in the scene. */
   color: string
-  /** Relative frequency on the road. */
+  /**
+   * Share of the road, in percent. The weights sum to 100 so each one reads
+   * directly as how much of the traffic that calling makes up.
+   */
   weight: number
   /** Walking pace relative to the shared base speed. */
   paceMin: number
@@ -50,11 +54,27 @@ export interface TravelerTypeDef {
 }
 
 export const TRAVELER_TYPES: Record<TravelerTypeId, TravelerTypeDef> = {
+  // The bulk of the road: local folk going about their business, poor and
+  // half of them looking for work — the settlement's future labour.
+  peasant: {
+    id: "peasant",
+    label: "Peasant",
+    color: "#9c8b66",
+    weight: 60,
+    paceMin: 0.8,
+    paceMax: 1.1,
+    gold: { min: 0, max: 15 },
+    status: { min: 5, max: 25 },
+    piety: { min: 30, max: 80 },
+    joblessChance: 0.6,
+    skillCount: { min: 1, max: 2 },
+    skills: ["farming", "herding", "woodcutting", "thatching", "milling", "labour"],
+  },
   pilgrim: {
     id: "pilgrim",
     label: "Pilgrim",
     color: "#8a7f9e",
-    weight: 6,
+    weight: 16.5,
     paceMin: 0.8,
     paceMax: 1.1,
     gold: { min: 5, max: 40 },
@@ -68,7 +88,7 @@ export const TRAVELER_TYPES: Record<TravelerTypeId, TravelerTypeDef> = {
     id: "merchant",
     label: "Merchant",
     color: "#b3762f",
-    weight: 3,
+    weight: 8.5,
     paceMin: 0.7,
     paceMax: 0.95,
     gold: { min: 60, max: 220 },
@@ -82,7 +102,7 @@ export const TRAVELER_TYPES: Record<TravelerTypeId, TravelerTypeDef> = {
     id: "friar",
     label: "Friar",
     color: "#6d5638",
-    weight: 2,
+    weight: 5.5,
     paceMin: 0.75,
     paceMax: 1.0,
     gold: { min: 0, max: 10 },
@@ -96,7 +116,7 @@ export const TRAVELER_TYPES: Record<TravelerTypeId, TravelerTypeDef> = {
     id: "knight",
     label: "Knight",
     color: "#96393a",
-    weight: 1,
+    weight: 3,
     paceMin: 1.1,
     paceMax: 1.4,
     gold: { min: 40, max: 120 },
@@ -110,7 +130,7 @@ export const TRAVELER_TYPES: Record<TravelerTypeId, TravelerTypeDef> = {
     id: "minstrel",
     label: "Minstrel",
     color: "#3f7d6c",
-    weight: 2,
+    weight: 5.5,
     paceMin: 0.9,
     paceMax: 1.2,
     gold: { min: 5, max: 30 },
@@ -126,7 +146,7 @@ export const TRAVELER_TYPES: Record<TravelerTypeId, TravelerTypeDef> = {
     id: "vendor",
     label: "Vendor",
     color: "#d1a33c",
-    weight: 0.5,
+    weight: 1,
     paceMin: 0.7,
     paceMax: 0.95,
     gold: { min: 30, max: 120 },

--- a/lib/site-menu.ts
+++ b/lib/site-menu.ts
@@ -1,6 +1,22 @@
+export interface SiteMenuItem {
+  label: string
+  description: string
+  href: string
+  /** Sub-pages listed underneath the entry, in every menu that renders it. */
+  children?: SiteMenuItem[]
+}
+
 /** Top-level navigation, shared by the landing page and the in-game menu. */
-export const SITE_MENU: Array<{ label: string; description: string; href: string }> = [
+export const SITE_MENU: SiteMenuItem[] = [
   { label: "Play", description: "Enter the prototype", href: "/play" },
   { label: "Docs", description: "Game design document", href: "/docs" },
-  { label: "Textures", description: "Every texture, in place", href: "/textures" },
+  {
+    label: "Assets",
+    description: "Everything the game is drawn with",
+    href: "/assets",
+    children: [
+      { label: "Textures", description: "Every texture, in place", href: "/assets/textures" },
+      { label: "Characters", description: "Every calling on the road", href: "/assets/characters" },
+    ],
+  },
 ]

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -30,6 +30,10 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  async redirects() {
+    // The texture gallery moved under /assets when characters joined it.
+    return [{ source: '/textures', destination: '/assets/textures', permanent: true }]
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
Renames the Textures menu entry to Assets and nests Textures and Characters beneath it on the landing page and in the in-game HUD menu, with a new /assets hub page. The textures gallery moves to /assets/textures (the old /textures route redirects permanently) and a new /assets/characters gallery shows every calling standing on a road tile, drawn with the same lights and camera as the game, alongside its stat roll ranges, pace, jobless chance, and trades. The traveler block and vendor cart are extracted into a shared TravelerFigure component used by both the road renderer and the gallery. Adds the peasant calling at 60% of road traffic, scales the other callings down proportionally, and makes weights sum to 100 so each reads as a percent share. Adds tests for the menu structure and the new weight balance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)