### PR TITLE
feat(game): found every world with a relic, its shrine, and the monks who keep it

### DIFF
--- a/app/play/page.tsx
+++ b/app/play/page.tsx
@@ -31,12 +31,14 @@ export default async function PlayPage({
   const coverage = parseIntParam(params.forest)
   const glades = parseIntParam(params.glades)
   const clearings = parseIntParam(params.clearings)
+  const relicDistance = parseIntParam(params.relic)
   const traffic = parseIntParam(params.traffic)
   const walkSpeed = parseFloatParam(params.speed)
   if (size !== undefined) initialSettings.size = size
   if (coverage !== undefined) initialSettings.coverage = coverage
   if (glades !== undefined) initialSettings.glades = glades
   if (clearings !== undefined) initialSettings.clearings = clearings
+  if (relicDistance !== undefined) initialSettings.relicDistance = relicDistance
   if (traffic !== undefined) initialSettings.traffic = traffic
   if (walkSpeed !== undefined) initialSettings.walkSpeed = walkSpeed
 

--- a/components/game/buildings.tsx
+++ b/components/game/buildings.tsx
@@ -35,6 +35,8 @@ export function Buildings({ map }: { map: GameMap }) {
   return (
     <group>
       {map.buildings.map((building, index) => {
+        // The hovel has its own geometry (see shrine.tsx); its ID slot stays reserved.
+        if (building.id === map.site?.hovelId) return null
         // Footprint centre: the origin tile's centre, offset by half the extra tiles.
         const centreX = tileToWorldX(map, building.x) + (building.w - 1) / 2
         const centreZ = tileToWorldZ(map, building.z) + (building.d - 1) / 2

--- a/components/game/game-canvas.tsx
+++ b/components/game/game-canvas.tsx
@@ -4,6 +4,8 @@ import { Suspense } from "react"
 import { Canvas } from "@react-three/fiber"
 
 import type { GameMap } from "@/lib/game/map/types"
+import type { Monk } from "@/lib/game/monks"
+import type { Relic } from "@/lib/game/relic"
 import type { Traveler } from "@/lib/game/travelers"
 import { CAM_FAR, CAM_NEAR } from "@/lib/game/render/iso"
 
@@ -11,7 +13,9 @@ import { Buildings } from "./buildings"
 import { CameraLight } from "./camera-light"
 import { CameraRig } from "./camera-rig"
 import { DebugHandle } from "./debug-handle"
+import { Monks } from "./monks"
 import { OutlinePass } from "./outline-pass"
+import { Shrine } from "./shrine"
 import { TerrainTiles } from "./terrain-tiles"
 import { TileCursor } from "./tile-cursor"
 import { Travelers } from "./travelers"
@@ -21,10 +25,14 @@ const BACKGROUND = "#14100a"
 
 export function GameCanvas({
   map,
+  relic,
+  monks,
   travelers,
   walkSpeed,
 }: {
   map: GameMap
+  relic: Relic
+  monks: Monk[]
   travelers: Traveler[]
   walkSpeed: number
 }) {
@@ -54,6 +62,8 @@ export function GameCanvas({
       </Suspense>
       <Trees map={map} />
       <Buildings map={map} />
+      <Shrine map={map} relic={relic} />
+      <Monks map={map} monks={monks} />
       <Travelers map={map} travelers={travelers} speed={walkSpeed} />
       <TileCursor map={map} />
 

--- a/components/game/game-hud.tsx
+++ b/components/game/game-hud.tsx
@@ -9,6 +9,8 @@ import { parseSeed } from "@/lib/game/rng"
 import { saveSeed } from "@/lib/game/seed-storage"
 import { SITE_MENU } from "@/lib/site-menu"
 import { ACTIVITY_LABELS, formatGameTime, simRegistry, type SimTraveler } from "@/lib/game/sim"
+import { MONK_ACTIVITY_LABELS, monkRegistry, type Monk, type MonkActivity } from "@/lib/game/monks"
+import { relicTitle, type Relic } from "@/lib/game/relic"
 import type { Traveler } from "@/lib/game/travelers"
 
 import type { MapSettings } from "./game-shell"
@@ -265,7 +267,7 @@ function TravelerPanel({ traveler }: { traveler: Traveler }) {
         <Label>Traveler</Label>
         <button
           type="button"
-          onClick={() => useCameraStore.getState().selectTraveler(null)}
+          onClick={() => useCameraStore.getState().select(null)}
           aria-label="Dismiss traveler"
           className="pointer-events-auto font-display text-[10px] text-ink-light hover:text-red"
         >
@@ -316,9 +318,103 @@ function TravelerPanel({ traveler }: { traveler: Traveler }) {
   )
 }
 
+/** What the monks keep in the hovel: the relic's name, nature, and pull. */
+function RelicPanel({ relic }: { relic: Relic }) {
+  const s = relic.stats
+  return (
+    <Panel>
+      <div className="flex items-baseline justify-between gap-4">
+        <Label>Relic</Label>
+        <button
+          type="button"
+          onClick={() => useCameraStore.getState().select(null)}
+          aria-label="Dismiss relic"
+          className="pointer-events-auto font-display text-[10px] text-ink-light hover:text-red"
+        >
+          ✕
+        </button>
+      </div>
+      <div className="pt-1">
+        <div className="font-display text-xs text-ink">{relicTitle(relic)}</div>
+        <div className="flex items-center gap-1.5">
+          <span
+            className="inline-block h-2 w-2 border border-rule"
+            style={{ backgroundColor: relic.color }}
+          />
+          <span className="text-[13px] italic capitalize text-ink-light">{relic.kind}</span>
+        </div>
+      </div>
+
+      <div className="mt-2 flex flex-col gap-0.5 border-t border-rule pt-2">
+        <StatBar label="Sanctity" value={s.sanctity} />
+        <StatBar label="Spectacle" value={s.spectacle} />
+        <StatBar label="Doubt" value={s.doubt} />
+        <StatBar label="Renown" value={s.renown} />
+      </div>
+    </Panel>
+  )
+}
+
+/** The scene writes monk activities at frame rate; sample on the HUD's own schedule. */
+function useMonkActivity(monkId: number): MonkActivity | null {
+  const [activity, setActivity] = useState<MonkActivity | null>(null)
+  useEffect(() => {
+    const read = () => setActivity(monkRegistry.current?.get(monkId) ?? null)
+    read()
+    const timer = setInterval(read, 250)
+    return () => clearInterval(timer)
+  }, [monkId])
+  return activity
+}
+
+/** One of the brothers: name, office, and what he brought with him. */
+function MonkPanel({ monk }: { monk: Monk }) {
+  const a = monk.attributes
+  const activity = useMonkActivity(monk.id)
+  return (
+    <Panel>
+      <div className="flex items-baseline justify-between gap-4">
+        <Label>Brother</Label>
+        <button
+          type="button"
+          onClick={() => useCameraStore.getState().select(null)}
+          aria-label="Dismiss monk"
+          className="pointer-events-auto font-display text-[10px] text-ink-light hover:text-red"
+        >
+          ✕
+        </button>
+      </div>
+      <div className="pt-1">
+        <div className="font-display text-xs text-ink">{monk.name}</div>
+        <div className="text-[13px] italic text-ink-light">
+          {monk.duty}, {a.age} years
+        </div>
+        {activity && (
+          <div className="text-[11px] italic text-gold">{MONK_ACTIVITY_LABELS[activity]}</div>
+        )}
+      </div>
+
+      <div className="mt-2 flex flex-col gap-0.5 border-t border-rule pt-2">
+        <StatBar label="Piety" value={a.piety} />
+      </div>
+
+      <div className="mt-2 border-t border-rule pt-2">
+        <div className="flex items-baseline justify-between gap-4">
+          <span className="text-[11px] italic text-ink-light">Skills</span>
+          <span className="max-w-32 text-right text-[11px] italic text-ink">
+            {a.skills.join(", ")}
+          </span>
+        </div>
+      </div>
+    </Panel>
+  )
+}
+
 export function GameHud({
   map,
   seed,
+  relic,
+  monks,
   travelers,
   settings,
   onSettingsChange,
@@ -327,6 +423,8 @@ export function GameHud({
 }: {
   map: GameMap | null
   seed: number | null
+  relic: Relic | null
+  monks: Monk[]
   travelers: Traveler[]
   settings: MapSettings
   onSettingsChange: (settings: MapSettings) => void
@@ -334,13 +432,14 @@ export function GameHud({
   onSeedChange: (seed: number) => void
 }) {
   const set = (patch: Partial<MapSettings>) => onSettingsChange({ ...settings, ...patch })
-  const selectedTravelerId = useCameraStore((s) => s.selectedTravelerId)
+  const selection = useCameraStore((s) => s.selection)
   const [menuOpen, setMenuOpen] = useState(false)
 
   const selectedTraveler =
-    selectedTravelerId === null
-      ? null
-      : (travelers.find((t) => t.id === selectedTravelerId) ?? null)
+    selection?.kind === "traveler" ? (travelers.find((t) => t.id === selection.id) ?? null) : null
+  const selectedMonk =
+    selection?.kind === "monk" ? (monks.find((m) => m.id === selection.id) ?? null) : null
+  const selectedRelic = selection?.kind === "relic"
 
   return (
     <>
@@ -409,6 +508,21 @@ export function GameHud({
         </Panel>
 
         <Panel>
+          <Label>Relic</Label>
+          {relic && (
+            <div className="pb-1 text-[11px] italic text-ink-light">{relicTitle(relic)}</div>
+          )}
+          <Tuner
+            label="Distance"
+            value={settings.relicDistance}
+            display={`${settings.relicDistance} tiles off road`}
+            min={6}
+            max={48}
+            onChange={(relicDistance) => set({ relicDistance })}
+          />
+        </Panel>
+
+        <Panel>
           <Label>Road</Label>
           <Tuner
             label="Traffic"
@@ -437,6 +551,16 @@ export function GameHud({
       {selectedTraveler && (
         <div className="absolute bottom-5 left-5 z-10">
           <TravelerPanel traveler={selectedTraveler} />
+        </div>
+      )}
+      {selectedMonk && (
+        <div className="absolute bottom-5 left-5 z-10">
+          <MonkPanel monk={selectedMonk} />
+        </div>
+      )}
+      {selectedRelic && relic && (
+        <div className="absolute bottom-5 left-5 z-10">
+          <RelicPanel relic={relic} />
         </div>
       )}
 

--- a/components/game/game-shell.tsx
+++ b/components/game/game-shell.tsx
@@ -5,12 +5,16 @@ import { useEffect, useMemo, useState } from "react"
 
 import { useCameraStore } from "@/lib/game/camera-store"
 import { loadSavedSeed } from "@/lib/game/seed-storage"
+import { generateMonks } from "@/lib/game/monks"
+import { tileToWorldX, tileToWorldZ } from "@/lib/game/map/types"
+import { generateRelic } from "@/lib/game/relic"
 import { generateTravelers } from "@/lib/game/travelers"
 import {
   DEFAULT_CLEARING_COUNT,
   DEFAULT_FOREST_COVERAGE,
   DEFAULT_GLADE_COUNT,
   DEFAULT_MAP_WIDTH,
+  DEFAULT_RELIC_DISTANCE,
   generateMap,
 } from "@/lib/game/map/generate-map"
 
@@ -42,6 +46,8 @@ export interface MapSettings {
   glades: number
   /** Number of small forest-floor clearings scattered through the woods. */
   clearings: number
+  /** How far off the road the relic's hovel is sited, in tiles. */
+  relicDistance: number
   /** How many travelers walk the road — the traffic level. */
   traffic: number
   /** Base walking speed in tiles per second. */
@@ -53,6 +59,7 @@ export const DEFAULT_SETTINGS: MapSettings = {
   coverage: Math.round(DEFAULT_FOREST_COVERAGE * 100),
   glades: DEFAULT_GLADE_COUNT,
   clearings: DEFAULT_CLEARING_COUNT,
+  relicDistance: DEFAULT_RELIC_DISTANCE,
   traffic: 12,
   walkSpeed: 1.5,
 }
@@ -95,6 +102,7 @@ export function GameShell({
       forest: String(settings.coverage),
       glades: String(settings.glades),
       clearings: String(settings.clearings),
+      relic: String(settings.relicDistance),
       traffic: String(settings.traffic),
       speed: String(settings.walkSpeed),
     })
@@ -112,8 +120,9 @@ export function GameShell({
             forestCoverage: settings.coverage / 100,
             gladeCount: settings.glades,
             clearingCount: settings.clearings,
+            relicDistance: settings.relicDistance,
           }),
-    [seed, settings.size, settings.coverage, settings.glades, settings.clearings],
+    [seed, settings.size, settings.coverage, settings.glades, settings.clearings, settings.relicDistance],
   )
 
   // Identities live outside the canvas so the HUD can name whoever is selected.
@@ -122,20 +131,41 @@ export function GameShell({
     [seed, settings.traffic],
   )
 
-  // The camera's pan clamp follows the loaded map's extent.
+  // The relic and the brothers who keep it, fixed per seed like the travelers.
+  const relic = useMemo(() => (seed === null ? null : generateRelic(seed)), [seed])
+  const monks = useMemo(() => (seed === null ? [] : generateMonks(seed)), [seed])
+
+  // The camera's pan clamp follows the loaded map's extent, and a new world
+  // opens on the hovel — the one landmark every map has.
   useEffect(() => {
-    if (map) useCameraStore.getState().setMapSize(map.width, map.depth)
+    if (!map) return
+    const camera = useCameraStore.getState()
+    camera.setMapSize(map.width, map.depth)
+    camera.select(null)
+    const hovel = map.buildings.find((b) => b.id === map.site?.hovelId)
+    if (hovel) {
+      camera.panTo(
+        tileToWorldX(map, hovel.x) + (hovel.w - 1) / 2,
+        tileToWorldZ(map, hovel.z) + (hovel.d - 1) / 2,
+      )
+    }
   }, [map])
 
   // A new cast of travelers invalidates whoever was selected.
   useEffect(() => {
-    useCameraStore.getState().selectTraveler(null)
+    useCameraStore.getState().select(null)
   }, [travelers])
 
   return (
     <div className="fixed inset-0 overflow-hidden bg-[#14100a] select-none">
-      {map ? (
-        <GameCanvas map={map} travelers={travelers} walkSpeed={settings.walkSpeed} />
+      {map && relic ? (
+        <GameCanvas
+          map={map}
+          relic={relic}
+          monks={monks}
+          travelers={travelers}
+          walkSpeed={settings.walkSpeed}
+        />
       ) : (
         <div className="flex h-full w-full items-center justify-center">
           <span className="font-display text-[10px] uppercase tracking-[3px] text-gold">
@@ -146,6 +176,8 @@ export function GameShell({
       <GameHud
         map={map}
         seed={seed}
+        relic={relic}
+        monks={monks}
         travelers={travelers}
         settings={settings}
         onSettingsChange={setSettings}

--- a/components/game/monks.tsx
+++ b/components/game/monks.tsx
@@ -1,0 +1,178 @@
+"use client"
+
+import { useEffect, useMemo, useRef } from "react"
+import { useFrame } from "@react-three/fiber"
+import * as THREE from "three"
+
+import { isSelected, useCameraStore } from "@/lib/game/camera-store"
+import { TERRAIN } from "@/lib/game/map/terrain"
+import { tileAt, tileToWorldX, tileToWorldZ, type GameMap } from "@/lib/game/map/types"
+import { monkRegistry, type Monk, type MonkActivity } from "@/lib/game/monks"
+import { deriveSeed, makeRng, SEED_STREAM } from "@/lib/game/rng"
+import { encodeObjectId, OUTLINE_ID_LAYER_MASK, residentObjectId } from "@/lib/game/render/outline"
+
+/**
+ * The brothers, always about the hovel: they drift between the open tiles
+ * around it, stand a while, and drift on — enough that the place is plainly
+ * lived in. Ambient motion only; they aren't in the traveler sim. Click one
+ * to select him — the HUD names him and his office.
+ */
+
+const BODY: [number, number, number] = [0.3, 0.55, 0.3]
+/** The bare crown of a tonsure, so a monk reads differently from a friar on the road. */
+const CROWN: [number, number, number] = [0.14, 0.05, 0.14]
+const HABIT_COLOR = "#4e4034"
+const CROWN_COLOR = "#d7b58e"
+
+/** How far from the footprint the brothers will wander, in tiles. */
+const WANDER_RADIUS = 3
+const WALK_SPEED = 0.7
+const PAUSE_MIN_SECONDS = 2
+const PAUSE_MAX_SECONDS = 7
+/** Standing within this many tiles of the hovel's centre counts as keeping vigil. */
+const VIGIL_RADIUS = 1.8
+
+/** A click that dragged further than this many pixels is a pan, not a select. */
+const CLICK_SLOP_PX = 6
+
+interface Spot {
+  x: number
+  y: number
+  z: number
+}
+
+interface MonkState {
+  x: number
+  y: number
+  z: number
+  target: Spot
+  pause: number
+}
+
+/** Open ground around the hovel a monk may stand on: never the walls, never the woods. */
+function wanderSpots(map: GameMap): { spots: Spot[]; centre: { x: number; z: number } | null } {
+  const hovel = map.buildings.find((b) => b.id === map.site?.hovelId)
+  if (!hovel) return { spots: [], centre: null }
+  const centre = {
+    x: tileToWorldX(map, hovel.x) + (hovel.w - 1) / 2,
+    z: tileToWorldZ(map, hovel.z) + (hovel.d - 1) / 2,
+  }
+  const spots: Spot[] = []
+  for (let z = hovel.z - WANDER_RADIUS; z < hovel.z + hovel.d + WANDER_RADIUS; z++) {
+    for (let x = hovel.x - WANDER_RADIUS; x < hovel.x + hovel.w + WANDER_RADIUS; x++) {
+      const inFootprint = x >= hovel.x && x < hovel.x + hovel.w && z >= hovel.z && z < hovel.z + hovel.d
+      if (inFootprint) continue
+      const terrain = tileAt(map, x, z)
+      if (!terrain || !TERRAIN[terrain].passable || terrain === "forest") continue
+      spots.push({ x: tileToWorldX(map, x), y: TERRAIN[terrain].height, z: tileToWorldZ(map, z) })
+    }
+  }
+  return { spots, centre }
+}
+
+export function Monks({ map, monks }: { map: GameMap; monks: Monk[] }) {
+  const selection = useCameraStore((s) => s.selection)
+  const groupRefs = useRef<Array<THREE.Group | null>>([])
+
+  const world = useMemo(() => {
+    const { spots, centre } = wanderSpots(map)
+    const rng = makeRng(deriveSeed(map.seed ?? 0, SEED_STREAM.monkWander))
+    const pick = (): Spot => {
+      const spot = spots[Math.floor(rng() * spots.length)]
+      // Jitter within the tile so two brothers never stand on the same spot.
+      return { x: spot.x + (rng() - 0.5) * 0.5, y: spot.y, z: spot.z + (rng() - 0.5) * 0.5 }
+    }
+    const states: MonkState[] = monks.map(() => {
+      const start = pick()
+      return { ...start, target: pick(), pause: rng() * PAUSE_MAX_SECONDS }
+    })
+    const activities = new Map<number, MonkActivity>()
+    return { spots, centre, rng, pick, states, activities }
+  }, [map, monks])
+
+  // Publish activities so the HUD's monk panel can poll them.
+  useEffect(() => {
+    monkRegistry.current = world.activities
+    return () => {
+      if (monkRegistry.current === world.activities) monkRegistry.current = null
+    }
+  }, [world])
+
+  useFrame((_, delta) => {
+    const dt = Math.min(delta, 0.1)
+    for (let i = 0; i < world.states.length; i++) {
+      const s = world.states[i]
+      const group = groupRefs.current[i]
+      if (!group) continue
+
+      if (s.pause > 0) {
+        s.pause -= dt
+        const nearRelic =
+          !!world.centre && Math.hypot(s.x - world.centre.x, s.z - world.centre.z) <= VIGIL_RADIUS
+        world.activities.set(monks[i].id, nearRelic ? "vigil" : "resting")
+      } else {
+        world.activities.set(monks[i].id, "walking")
+        const dx = s.target.x - s.x
+        const dz = s.target.z - s.z
+        const dist = Math.hypot(dx, dz)
+        const step = WALK_SPEED * dt
+        if (dist <= step) {
+          s.x = s.target.x
+          s.z = s.target.z
+          s.y = s.target.y
+          s.target = world.pick()
+          s.pause = PAUSE_MIN_SECONDS + world.rng() * (PAUSE_MAX_SECONDS - PAUSE_MIN_SECONDS)
+        } else {
+          s.x += (dx / dist) * step
+          s.z += (dz / dist) * step
+          s.y += (s.target.y - s.y) * Math.min(1, step / dist)
+          group.rotation.y = Math.atan2(dx, dz)
+        }
+      }
+      group.position.set(s.x, s.y, s.z)
+    }
+  })
+
+  if (world.spots.length === 0) return null
+
+  return (
+    <group>
+      {monks.map((monk, index) => {
+        const id = new THREE.Color(...encodeObjectId(residentObjectId(index)))
+        const selected = isSelected(selection, { kind: "monk", id: monk.id })
+        const select = (event: { delta: number; stopPropagation: () => void }) => {
+          if (event.delta > CLICK_SLOP_PX) return
+          event.stopPropagation()
+          useCameraStore.getState().select(selected ? null : { kind: "monk", id: monk.id })
+        }
+        return (
+          <group
+            key={monk.id}
+            ref={(node) => {
+              groupRefs.current[index] = node
+            }}
+          >
+            <mesh name="monk" position={[0, BODY[1] / 2, 0]} onClick={select}>
+              <boxGeometry args={BODY} />
+              <meshLambertMaterial color={HABIT_COLOR} />
+            </mesh>
+            <mesh position={[0, BODY[1] + CROWN[1] / 2, 0]} onClick={select}>
+              <boxGeometry args={CROWN} />
+              <meshLambertMaterial color={CROWN_COLOR} />
+            </mesh>
+            <mesh position={[0, BODY[1] / 2, 0]} layers-mask={OUTLINE_ID_LAYER_MASK}>
+              <boxGeometry args={BODY} />
+              <meshBasicMaterial color={id} toneMapped={false} />
+            </mesh>
+            {selected && (
+              <mesh position={[0, BODY[1] + 0.35, 0]}>
+                <boxGeometry args={[0.2, 0.05, 0.2]} />
+                <meshBasicMaterial color="#d8a93f" />
+              </mesh>
+            )}
+          </group>
+        )
+      })}
+    </group>
+  )
+}

--- a/components/game/shrine.tsx
+++ b/components/game/shrine.tsx
@@ -1,0 +1,214 @@
+"use client"
+
+import { useMemo, useRef } from "react"
+import { useFrame } from "@react-three/fiber"
+import * as THREE from "three"
+
+import { isSelected, useCameraStore } from "@/lib/game/camera-store"
+import { TERRAIN } from "@/lib/game/map/terrain"
+import { tileAt, tileToWorldX, tileToWorldZ, type GameMap } from "@/lib/game/map/types"
+import type { Relic } from "@/lib/game/relic"
+import {
+  buildingObjectId,
+  encodeObjectId,
+  OUTLINE_ID_LAYER_MASK,
+  RELIC_OBJECT_ID,
+} from "@/lib/game/render/outline"
+
+/**
+ * The monks' hovel: four low walls with a doorway toward the track, a ring of
+ * thatch around an open centre, and the relic on a plinth in the middle where
+ * the sky can see it. It pulses — faintly — so the eye finds it from any zoom.
+ * Click any part of it to select the relic; the HUD tells you what it is.
+ */
+
+const WALL_HEIGHT = 0.6
+const WALL_THICKNESS = 0.16
+/** Walls sit this far from the footprint centre; the roof overhangs a little. */
+const WALL_HALF = 0.85
+const ROOF_HALF = 0.95
+/** Half-width of the opening in the roof and of the doorway in the wall. */
+const OPENING_HALF = 0.4
+const DOOR_HALF = 0.3
+const ROOF_THICKNESS = 0.1
+const FLOOR_THICKNESS = 0.05
+
+const PLINTH: [number, number, number] = [0.3, 0.22, 0.3]
+const RELIC_SIZE = 0.16
+const HALO_RADIUS = 0.26
+
+/** Pulse: slow and shallow, a breath rather than a beacon. */
+const PULSE_PERIOD_SECONDS = 3.2
+const EMISSIVE_BASE = 0.35
+const EMISSIVE_SWING = 0.15
+const HALO_BASE = 0.07
+const HALO_SWING = 0.05
+const LIGHT_BASE = 0.55
+const LIGHT_SWING = 0.2
+
+/** A click that dragged further than this many pixels is a pan, not a select. */
+const CLICK_SLOP_PX = 6
+
+const WALL_COLOR = "#8c7658"
+const FLOOR_COLOR = "#5a4a38"
+const PLINTH_COLOR = "#9a958a"
+const HALO_COLOR = "#f6e7b0"
+const LIGHT_COLOR = "#ffd98a"
+
+type Side = "north" | "south" | "west" | "east"
+
+interface Piece {
+  args: [number, number, number]
+  position: [number, number, number]
+  color: string
+}
+
+/** Wall segments for one side, split around the doorway when it's the door side. */
+function wallPieces(side: Side, hasDoor: boolean): Piece[] {
+  const along = WALL_HALF * 2 + WALL_THICKNESS
+  const y = WALL_HEIGHT / 2
+  const place = (offset: number, length: number): Piece => {
+    const horizontal = side === "north" || side === "south"
+    const fixed = side === "north" || side === "west" ? -WALL_HALF : WALL_HALF
+    return {
+      args: horizontal ? [length, WALL_HEIGHT, WALL_THICKNESS] : [WALL_THICKNESS, WALL_HEIGHT, length],
+      position: horizontal ? [offset, y, fixed] : [fixed, y, offset],
+      color: WALL_COLOR,
+    }
+  }
+  if (!hasDoor) return [place(0, along)]
+  const segment = along / 2 - DOOR_HALF
+  const centre = DOOR_HALF + segment / 2
+  return [place(-centre, segment), place(centre, segment)]
+}
+
+function roofPieces(roofColor: string): Piece[] {
+  const y = WALL_HEIGHT + ROOF_THICKNESS / 2
+  const span = ROOF_HALF * 2
+  const band = ROOF_HALF - OPENING_HALF
+  const bandCentre = OPENING_HALF + band / 2
+  const inner = OPENING_HALF * 2
+  return [
+    { args: [span, ROOF_THICKNESS, band], position: [0, y, -bandCentre], color: roofColor },
+    { args: [span, ROOF_THICKNESS, band], position: [0, y, bandCentre], color: roofColor },
+    { args: [band, ROOF_THICKNESS, inner], position: [-bandCentre, y, 0], color: roofColor },
+    { args: [band, ROOF_THICKNESS, inner], position: [bandCentre, y, 0], color: roofColor },
+  ]
+}
+
+export function Shrine({ map, relic }: { map: GameMap; relic: Relic }) {
+  const selected = useCameraStore((s) => isSelected(s.selection, { kind: "relic" }))
+  const relicMaterial = useRef<THREE.MeshStandardMaterial>(null)
+  const haloMaterial = useRef<THREE.MeshBasicMaterial>(null)
+  const light = useRef<THREE.PointLight>(null)
+
+  const hovelIndex = map.buildings.findIndex((b) => b.id === map.site?.hovelId)
+  const hovel = hovelIndex >= 0 ? map.buildings[hovelIndex] : null
+
+  const layout = useMemo(() => {
+    if (!hovel || !map.site) return null
+    const door = map.site.door
+    const doorSide: Side =
+      door.x < hovel.x ? "west" : door.x >= hovel.x + hovel.w ? "east" : door.z < hovel.z ? "north" : "south"
+    const sides: Side[] = ["north", "south", "west", "east"]
+    const pieces: Piece[] = [
+      {
+        args: [WALL_HALF * 2, FLOOR_THICKNESS, WALL_HALF * 2],
+        position: [0, FLOOR_THICKNESS / 2, 0],
+        color: FLOOR_COLOR,
+      },
+      ...sides.flatMap((side) => wallPieces(side, side === doorSide)),
+      ...roofPieces(hovel.roofColor),
+      { args: PLINTH, position: [0, FLOOR_THICKNESS + PLINTH[1] / 2, 0], color: PLINTH_COLOR },
+    ]
+    const groundTerrain = tileAt(map, hovel.x, hovel.z)
+    return {
+      pieces,
+      centreX: tileToWorldX(map, hovel.x) + (hovel.w - 1) / 2,
+      centreZ: tileToWorldZ(map, hovel.z) + (hovel.d - 1) / 2,
+      baseY: groundTerrain ? TERRAIN[groundTerrain].height : 0,
+      relicY: FLOOR_THICKNESS + PLINTH[1] + RELIC_SIZE / 2 + 0.02,
+    }
+  }, [map, hovel])
+
+  const shrineId = useMemo(
+    () => new THREE.Color(...encodeObjectId(buildingObjectId(Math.max(0, hovelIndex)))),
+    [hovelIndex],
+  )
+  const relicId = useMemo(() => new THREE.Color(...encodeObjectId(RELIC_OBJECT_ID)), [])
+
+  useFrame(({ clock }) => {
+    const phase = Math.sin((clock.elapsedTime / PULSE_PERIOD_SECONDS) * Math.PI * 2)
+    if (relicMaterial.current) relicMaterial.current.emissiveIntensity = EMISSIVE_BASE + EMISSIVE_SWING * phase
+    if (haloMaterial.current) haloMaterial.current.opacity = HALO_BASE + HALO_SWING * phase
+    if (light.current) light.current.intensity = LIGHT_BASE + LIGHT_SWING * phase
+  })
+
+  if (!layout) return null
+
+  const select = (event: { delta: number; stopPropagation: () => void }) => {
+    if (event.delta > CLICK_SLOP_PX) return
+    event.stopPropagation()
+    useCameraStore.getState().select(selected ? null : { kind: "relic" })
+  }
+
+  return (
+    <group position={[layout.centreX, layout.baseY, layout.centreZ]}>
+      {layout.pieces.map((piece, i) => (
+        <group key={i} position={piece.position}>
+          <mesh onClick={select}>
+            <boxGeometry args={piece.args} />
+            <meshLambertMaterial color={piece.color} />
+          </mesh>
+          <mesh layers-mask={OUTLINE_ID_LAYER_MASK}>
+            <boxGeometry args={piece.args} />
+            <meshBasicMaterial color={shrineId} toneMapped={false} />
+          </mesh>
+        </group>
+      ))}
+
+      {/* The relic itself, set on its corner so it reads as a gem, not a crate. */}
+      <group position={[0, layout.relicY, 0]} rotation={[0, Math.PI / 4, 0]}>
+        <mesh name="relic" onClick={select}>
+          <boxGeometry args={[RELIC_SIZE, RELIC_SIZE, RELIC_SIZE]} />
+          <meshStandardMaterial
+            ref={relicMaterial}
+            color={relic.color}
+            emissive={relic.color}
+            emissiveIntensity={EMISSIVE_BASE}
+            roughness={0.4}
+          />
+        </mesh>
+        <mesh layers-mask={OUTLINE_ID_LAYER_MASK}>
+          <boxGeometry args={[RELIC_SIZE, RELIC_SIZE, RELIC_SIZE]} />
+          <meshBasicMaterial color={relicId} toneMapped={false} />
+        </mesh>
+      </group>
+      <mesh position={[0, layout.relicY, 0]}>
+        <sphereGeometry args={[HALO_RADIUS, 16, 12]} />
+        <meshBasicMaterial
+          ref={haloMaterial}
+          color={HALO_COLOR}
+          transparent
+          opacity={HALO_BASE}
+          depthWrite={false}
+        />
+      </mesh>
+      <pointLight
+        ref={light}
+        position={[0, WALL_HEIGHT, 0]}
+        color={LIGHT_COLOR}
+        intensity={LIGHT_BASE}
+        distance={3.5}
+        decay={2}
+      />
+
+      {selected && (
+        <mesh position={[0, WALL_HEIGHT + 0.6, 0]}>
+          <boxGeometry args={[0.2, 0.05, 0.2]} />
+          <meshBasicMaterial color="#d8a93f" />
+        </mesh>
+      )}
+    </group>
+  )
+}

--- a/components/game/travelers.tsx
+++ b/components/game/travelers.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useRef } from "react"
 import { useFrame } from "@react-three/fiber"
 import * as THREE from "three"
 
-import { useCameraStore } from "@/lib/game/camera-store"
+import { isSelected, useCameraStore } from "@/lib/game/camera-store"
 import type { GameMap } from "@/lib/game/map/types"
 import { createSim, simRegistry, stepSim } from "@/lib/game/sim"
 import type { Traveler } from "@/lib/game/travelers"
@@ -82,7 +82,7 @@ export function Travelers({
   /** Base walking speed in tiles per second; each traveler's pace scales it. */
   speed: number
 }) {
-  const selectedId = useCameraStore((s) => s.selectedTravelerId)
+  const selection = useCameraStore((s) => s.selection)
   const groupRefs = useRef<Array<THREE.Group | null>>([])
 
   const sim = useMemo(() => createSim(travelers, map), [travelers, map])
@@ -124,12 +124,12 @@ export function Travelers({
   return (
     <group>
       {travelers.map((traveler, index) => {
-        const selected = traveler.id === selectedId
+        const selected = isSelected(selection, { kind: "traveler", id: traveler.id })
         const [r, g, b] = encodeObjectId(travelerObjectId(index))
         const select = (event: { delta: number; stopPropagation: () => void }) => {
           if (event.delta > CLICK_SLOP_PX) return
           event.stopPropagation()
-          useCameraStore.getState().selectTraveler(selected ? null : traveler.id)
+          useCameraStore.getState().select(selected ? null : { kind: "traveler", id: traveler.id })
         }
         return (
           <group

--- a/lib/game/camera-store.ts
+++ b/lib/game/camera-store.ts
@@ -12,6 +12,17 @@ export interface HoveredTile {
   z: number
 }
 
+/** One thing selected at a time, whatever kind it is. */
+export type Selection =
+  | { kind: "traveler"; id: number }
+  | { kind: "monk"; id: number }
+  | { kind: "relic" }
+
+export function isSelected(selection: Selection | null, candidate: Selection): boolean {
+  if (!selection || selection.kind !== candidate.kind) return false
+  return selection.kind === "relic" || selection.id === (candidate as { id: number }).id
+}
+
 interface CameraState {
   /** Camera focus point on the ground plane. */
   targetX: number
@@ -26,8 +37,8 @@ interface CameraState {
   /** Current map extent; the pan clamp follows whatever map is loaded. */
   mapWidth: number
   mapDepth: number
-  /** Traveler the player clicked, by traveler id. Not part of reset(). */
-  selectedTravelerId: number | null
+  /** What the player clicked — a traveler, a monk, or the relic. Not part of reset(). */
+  selection: Selection | null
 
   pan: (dx: number, dz: number) => void
   /** Jump the focus straight to a world point — the minimap's click-to-travel. */
@@ -37,12 +48,12 @@ interface CameraState {
   setHovered: (tile: HoveredTile | null) => void
   cycleOutlineMode: () => void
   setMapSize: (width: number, depth: number) => void
-  selectTraveler: (id: number | null) => void
+  select: (selection: Selection | null) => void
   reset: () => void
 }
 
 const INITIAL = {
-  // Generated maps have no landmark to favour, so start at the map centre.
+  // Map centre by default; the shell pans to the hovel once a map loads.
   targetX: 0,
   targetZ: 0,
   viewIndex: 0,
@@ -69,7 +80,7 @@ export const useCameraStore = create<CameraState>((set) => ({
   outlineMode: DEFAULT_OUTLINE_MODE,
   mapWidth: DEFAULT_MAP_WIDTH,
   mapDepth: DEFAULT_MAP_DEPTH,
-  selectedTravelerId: null,
+  selection: null,
 
   pan: (dx, dz) => set((s) => clampTarget(s, s.targetX + dx, s.targetZ + dz)),
 
@@ -102,7 +113,7 @@ export const useCameraStore = create<CameraState>((set) => ({
       ...clampTarget({ mapWidth: width, mapDepth: depth }, s.targetX, s.targetZ),
     })),
 
-  selectTraveler: (id) => set({ selectedTravelerId: id }),
+  select: (selection) => set({ selection }),
 
   // Deliberately leaves mapWidth/mapDepth alone — reset is a camera action.
   reset: () =>

--- a/lib/game/map/generate-map.test.ts
+++ b/lib/game/map/generate-map.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { generateMap } from "./generate-map"
+import { DEFAULT_RELIC_DISTANCE, generateMap, HOVEL_ID, relicDistanceBand } from "./generate-map"
 import { TERRAIN } from "./terrain"
 import { tileAt, type GameMap } from "./types"
 
@@ -42,9 +42,114 @@ describe("generateMap", () => {
     expect(a.tiles).not.toEqual(b.tiles)
   })
 
-  it("generates no buildings — building is the player's job", () => {
+  it("generates exactly one building, the founded hovel, standing on grass off the road", () => {
     for (const seed of SEEDS) {
-      expect(generateMap({ seed }).buildings).toEqual([])
+      const map = generateMap({ seed })
+      expect(map.buildings.map((b) => b.id), `seed ${seed} has only the hovel`).toEqual([HOVEL_ID])
+      const hovel = map.buildings[0]
+      expect(map.site?.hovelId).toBe(HOVEL_ID)
+      for (let dz = -1; dz <= hovel.d; dz++) {
+        for (let dx = -1; dx <= hovel.w; dx++) {
+          const terrain = tileAt(map, hovel.x + dx, hovel.z + dz)
+          const inFootprint = dx >= 0 && dx < hovel.w && dz >= 0 && dz < hovel.d
+          if (inFootprint) {
+            expect(terrain, `seed ${seed} hovel stands on grass`).toBe("grass")
+          } else {
+            // The ring is grass except where the track arrives at the door.
+            expect(["grass", "track"], `seed ${seed} hovel has breathing room`).toContain(terrain)
+          }
+        }
+      }
+    }
+  })
+
+  /** Grid distance from the hovel's footprint to the nearest road tile. */
+  function hovelRoadDistance(map: GameMap): number {
+    const hovel = map.buildings[0]
+    let nearest = Infinity
+    for (const p of map.road!) {
+      for (let dz = 0; dz < hovel.d; dz++) {
+        for (let dx = 0; dx < hovel.w; dx++) {
+          nearest = Math.min(nearest, Math.abs(p.x - hovel.x - dx) + Math.abs(p.z - hovel.z - dz))
+        }
+      }
+    }
+    return nearest
+  }
+
+  it("sites the hovel a real detour off the road — inside the distance band", () => {
+    const band = relicDistanceBand(DEFAULT_RELIC_DISTANCE)
+    for (const seed of SEEDS) {
+      const nearest = hovelRoadDistance(generateMap({ seed }))
+      expect(nearest, `seed ${seed} not too close`).toBeGreaterThanOrEqual(band.min)
+      expect(nearest, `seed ${seed} not too far`).toBeLessThanOrEqual(band.max)
+    }
+  })
+
+  it("moves the hovel further out when asked", () => {
+    for (const seed of SEEDS.slice(0, 10)) {
+      const near = hovelRoadDistance(generateMap({ seed, relicDistance: 8 }))
+      const far = hovelRoadDistance(generateMap({ seed, relicDistance: 32 }))
+      expect(far, `seed ${seed} far > near`).toBeGreaterThan(near)
+      expect(near).toBeLessThanOrEqual(relicDistanceBand(8).max)
+      expect(far).toBeGreaterThanOrEqual(relicDistanceBand(32).min)
+    }
+  })
+
+  it("cuts one unbroken track from a mid-road junction to the hovel's door", () => {
+    for (const seed of SEEDS) {
+      const map = generateMap({ seed })
+      const { junction, branch, door } = map.site!
+      const road = map.road!
+      const hovel = map.buildings[0]
+
+      // The fork is never on the road's outermost stretches.
+      expect(junction, `seed ${seed} junction not at west end`).toBeGreaterThanOrEqual(road.length * 0.1 - 1)
+      expect(junction, `seed ${seed} junction not at east end`).toBeLessThanOrEqual(road.length * 0.9)
+      expect(branch[0], `seed ${seed} branch starts at the junction`).toEqual(road[junction])
+      expect(branch[branch.length - 1], `seed ${seed} branch ends at the door`).toEqual(door)
+
+      // The door touches the footprint but is not inside it.
+      const touching =
+        door.x >= hovel.x - 1 &&
+        door.x <= hovel.x + hovel.w &&
+        door.z >= hovel.z - 1 &&
+        door.z <= hovel.z + hovel.d
+      const inside =
+        door.x >= hovel.x && door.x < hovel.x + hovel.w && door.z >= hovel.z && door.z < hovel.z + hovel.d
+      expect(touching && !inside, `seed ${seed} door is adjacent to the hovel`).toBe(true)
+
+      for (let i = 0; i < branch.length; i++) {
+        const terrain = tileAt(map, branch[i].x, branch[i].z)
+        expect(terrain !== null && TERRAIN[terrain].passable, `seed ${seed} branch is walkable`).toBe(true)
+        const onHovel =
+          branch[i].x >= hovel.x &&
+          branch[i].x < hovel.x + hovel.w &&
+          branch[i].z >= hovel.z &&
+          branch[i].z < hovel.z + hovel.d
+        expect(onHovel, `seed ${seed} branch does not cross the hovel`).toBe(false)
+        if (i > 0) {
+          const step = Math.abs(branch[i].x - branch[i - 1].x) + Math.abs(branch[i].z - branch[i - 1].z)
+          expect(step, `seed ${seed} branch step ${i} is to a neighbour`).toBe(1)
+          expect(terrain, `seed ${seed} branch is track past the junction`).toBe("track")
+        }
+      }
+    }
+  })
+
+  it("founds a hovel even on a map with no glades to speak of", () => {
+    const map = generateMap({ seed: 7, forestCoverage: 0.98, gladeCount: 1, clearingCount: 0 })
+    const hovel = map.buildings[0]
+    expect(hovel).toBeDefined()
+    expect(tileAt(map, hovel.x, hovel.z)).toBe("grass")
+    expect(map.site!.branch.length).toBeGreaterThan(1)
+  })
+
+  it("sites the hovel on small maps too, scaling the band down", () => {
+    for (const seed of SEEDS.slice(0, 10)) {
+      const map = generateMap({ seed, width: 32, depth: 32 })
+      expect(map.buildings).toHaveLength(1)
+      expect(map.site!.branch.length).toBeGreaterThan(1)
     }
   })
 

--- a/lib/game/map/generate-map.ts
+++ b/lib/game/map/generate-map.ts
@@ -1,6 +1,6 @@
 import { makeRng } from "../rng"
 import type { TerrainId } from "./terrain"
-import type { GameMap } from "./types"
+import type { BuildingDef, FoundingSite, GameMap, TilePos } from "./types"
 
 /**
  * Seeded map generation. The world is dense forest by default: the map starts
@@ -8,8 +8,13 @@ import type { GameMap } from "./types"
  * forest-floor clearings are scattered through it, and winding trails link
  * everything together. One road runs from the west edge to the east edge. The
  * same seed always produces the identical map, so a seed number is a complete,
- * shareable description of a world — buildings are the player's job and are
- * never generated.
+ * shareable description of a world.
+ *
+ * Every world also comes founded: the monks' hovel already stands, with the
+ * relic inside, in a glade a real detour off the road, and a beaten track
+ * branches from the road to its door. That is the one building the generator
+ * places — everything else is the player's job. The game begins with the hovel
+ * because without it there is nothing for travelers to turn aside for.
  *
  * Two kinds of openness, on purpose:
  *  - "grass" glades are true open land — buildable, the places to settle.
@@ -42,6 +47,8 @@ export interface GenerateMapOptions {
   /** Clearing footprint in tiles. */
   clearingSizeMin?: number
   clearingSizeMax?: number
+  /** How far off the road the relic's hovel is sited, in tiles (see DEFAULT_RELIC_DISTANCE). */
+  relicDistance?: number
 }
 
 export const DEFAULT_FOREST_COVERAGE = 0.6
@@ -60,6 +67,50 @@ const PATH_WANDER = 2.0
 /** Trails meander more than the road — they're desire lines, not engineering. */
 const TRAIL_WANDER = 3.0
 
+// --- Founding site -----------------------------------------------------------
+
+export const HOVEL_ID = "hovel"
+/** Footprint of the hovel in tiles. */
+export const HOVEL_SIZE = 2
+
+/**
+ * How far the hovel sits from the nearest road tile, in grid steps. Close
+ * enough that a detour is plausible, far enough that it *is* a detour — the
+ * gap between road and relic is the ground the whole settlement will grow on.
+ * The generator accepts a band of ±25% around this target.
+ */
+export const DEFAULT_RELIC_DISTANCE = 24
+const RELIC_DISTANCE_SPREAD = 0.25
+
+/** The distance band the generator aims for around a target distance. */
+export function relicDistanceBand(target: number): { min: number; max: number } {
+  const min = Math.max(2, Math.round(target * (1 - RELIC_DISTANCE_SPREAD)))
+  return { min, max: Math.max(min + 2, Math.round(target * (1 + RELIC_DISTANCE_SPREAD))) }
+}
+
+/**
+ * The branch may not fork off the outermost stretch of road, so travelers from
+ * either direction have road on both sides of the junction.
+ */
+const JUNCTION_MARGIN = 0.1
+
+/** Side length of the neighbourhood counted as "room to grow" around a site. */
+const SITE_ROOM_RADIUS = 2
+
+/**
+ * A site this close to the map edge loses score per tile of shortfall — soft,
+ * so tiny maps still found, but enough that a hovel never hugs the boundary
+ * when there's any interior glade to be had.
+ */
+const SITE_EDGE_MARGIN = 10
+const SITE_EDGE_PENALTY = 4
+
+/** Random jitter on the site score, so equally good spots don't always tie the same way. */
+const SITE_SCORE_JITTER = 6
+
+/** Grid-step cost added to tiles the branch must avoid (the road, the hovel). */
+const BRANCH_AVOID_COST = 100
+
 const DIRS: ReadonlyArray<readonly [number, number]> = [
   [1, 0],
   [-1, 0],
@@ -77,6 +128,7 @@ export function generateMap(options: GenerateMapOptions): GameMap {
     clearingCount = DEFAULT_CLEARING_COUNT,
     clearingSizeMin = 2,
     clearingSizeMax = 6,
+    relicDistance = DEFAULT_RELIC_DISTANCE,
   } = options
 
   // Independent streams (constants are arbitrary odd numbers) so each part of
@@ -84,6 +136,7 @@ export function generateMap(options: GenerateMapOptions): GameMap {
   const rngForest = makeRng(seed ^ 0x1b873593)
   const rngRoad = makeRng(seed ^ 0x85ebca6b)
   const rngTrail = makeRng(seed ^ 0xc2b2ae35)
+  const rngSite = makeRng(seed ^ 0x27d4eb2f)
 
   const tiles: TerrainId[] = new Array<TerrainId>(width * depth).fill("forest")
 
@@ -236,7 +289,176 @@ export function generateMap(options: GenerateMapOptions): GameMap {
     carveTrail(bestCenter, { x: bestRoad % width, z: Math.floor(bestRoad / width) })
   }
 
-  return { width, depth, tiles, buildings: [], seed, road }
+  // --- Founding site: the hovel, its glade, and the branch to its door -------
+  const { hovel, site } = foundSite(tiles, width, depth, road, relicDistance, trailWander, rngSite)
+
+  return { width, depth, tiles, buildings: [hovel], seed, road, site }
+}
+
+/**
+ * Grid-step distance from every tile to the nearest road tile, ignoring
+ * terrain — the branch ignores terrain too, so this is the length of track it
+ * would take to reach each spot.
+ */
+function roadDistanceField(width: number, depth: number, road: TilePos[]): Int32Array {
+  const dist = new Int32Array(width * depth).fill(-1)
+  const queue: number[] = []
+  for (const p of road) {
+    const i = p.z * width + p.x
+    dist[i] = 0
+    queue.push(i)
+  }
+  for (let head = 0; head < queue.length; head++) {
+    const i = queue[head]
+    const x = i % width
+    const z = Math.floor(i / width)
+    for (const [dx, dz] of DIRS) {
+      const nx = x + dx
+      const nz = z + dz
+      if (nx < 0 || nz < 0 || nx >= width || nz >= depth) continue
+      const n = nz * width + nx
+      if (dist[n] !== -1) continue
+      dist[n] = dist[i] + 1
+      queue.push(n)
+    }
+  }
+  return dist
+}
+
+/**
+ * Choose where the relic lives and cut the way to it.
+ *
+ * The site is scored over every possible hovel origin: it must sit within the
+ * road-distance band (or as near to it as the map allows), and among those it
+ * prefers open grass around it — room for the settlement to grow — with a
+ * seeded jitter so the pick varies between worlds that look alike. The
+ * footprint and a one-tile ring are then guaranteed to be grass, so the hovel
+ * always stands on buildable ground with breathing space, even on a map whose
+ * knobs left no glade to be had.
+ *
+ * The branch forks from the road tile nearest the door (outside the road's
+ * outer stretches) and is routed with the trail wander, steered away from the
+ * road and the hovel itself so it reads as one clean track in, not a tangle.
+ */
+function foundSite(
+  tiles: TerrainId[],
+  width: number,
+  depth: number,
+  road: TilePos[],
+  relicDistance: number,
+  trailWander: Float64Array,
+  rng: () => number,
+): { hovel: BuildingDef; site: FoundingSite } {
+  const dist = roadDistanceField(width, depth, road)
+  const { min: bandMin, max: bandMax } = relicDistanceBand(relicDistance)
+
+  // --- Score every origin the footprint fits at ------------------------------
+  let best: TilePos = { x: EDGE_MARGIN, z: EDGE_MARGIN }
+  let bestScore = -Infinity
+  const outerMin = EDGE_MARGIN + 1 // leave room for the grass ring
+  for (let z = outerMin; z <= depth - HOVEL_SIZE - outerMin; z++) {
+    for (let x = outerMin; x <= width - HOVEL_SIZE - outerMin; x++) {
+      let onRoad = false
+      let nearest = Infinity
+      for (let dz = 0; dz < HOVEL_SIZE; dz++) {
+        for (let dx = 0; dx < HOVEL_SIZE; dx++) {
+          const i = (z + dz) * width + (x + dx)
+          if (tiles[i] === "path") onRoad = true
+          nearest = Math.min(nearest, dist[i])
+        }
+      }
+      if (onRoad) continue
+
+      // Outside the band, every step of shortfall or excess costs more than any
+      // amount of open ground can buy back — in-band sites always win if any exist.
+      const bandPenalty =
+        nearest < bandMin ? (bandMin - nearest) * 50 : nearest > bandMax ? (nearest - bandMax) * 50 : 0
+
+      let room = 0
+      for (let dz = -SITE_ROOM_RADIUS; dz < HOVEL_SIZE + SITE_ROOM_RADIUS; dz++) {
+        for (let dx = -SITE_ROOM_RADIUS; dx < HOVEL_SIZE + SITE_ROOM_RADIUS; dx++) {
+          const nx = x + dx
+          const nz = z + dz
+          if (nx < 0 || nz < 0 || nx >= width || nz >= depth) continue
+          if (tiles[nz * width + nx] !== "grass") continue
+          // The footprint itself counts extra: standing on grass beats being near it.
+          const inFootprint = dx >= 0 && dx < HOVEL_SIZE && dz >= 0 && dz < HOVEL_SIZE
+          room += inFootprint ? 4 : 1
+        }
+      }
+
+      const edgeDist = Math.min(x, z, width - HOVEL_SIZE - x, depth - HOVEL_SIZE - z)
+      const edgePenalty = Math.max(0, SITE_EDGE_MARGIN - edgeDist) * SITE_EDGE_PENALTY
+
+      const score = room - bandPenalty - edgePenalty + rng() * SITE_SCORE_JITTER
+      if (score > bestScore) {
+        bestScore = score
+        best = { x, z }
+      }
+    }
+  }
+
+  // --- Guarantee footing: footprint plus ring become grass ---------------------
+  for (let dz = -1; dz <= HOVEL_SIZE; dz++) {
+    for (let dx = -1; dx <= HOVEL_SIZE; dx++) {
+      const i = (best.z + dz) * width + (best.x + dx)
+      if (tiles[i] === "forest" || tiles[i] === "clearing") tiles[i] = "grass"
+    }
+  }
+
+  // --- Door and junction: the closest pair between the ring and the road ------
+  const ring: TilePos[] = []
+  for (let k = 0; k < HOVEL_SIZE; k++) {
+    ring.push({ x: best.x + k, z: best.z - 1 })
+    ring.push({ x: best.x + k, z: best.z + HOVEL_SIZE })
+    ring.push({ x: best.x - 1, z: best.z + k })
+    ring.push({ x: best.x + HOVEL_SIZE, z: best.z + k })
+  }
+  const lo = Math.floor(road.length * JUNCTION_MARGIN)
+  const hi = Math.max(lo, Math.ceil(road.length * (1 - JUNCTION_MARGIN)) - 1)
+  let door = ring[0]
+  let junction = lo
+  let bestDist = Infinity
+  for (const d of ring) {
+    for (let r = lo; r <= hi; r++) {
+      const manhattan = Math.abs(road[r].x - d.x) + Math.abs(road[r].z - d.z)
+      if (manhattan < bestDist) {
+        bestDist = manhattan
+        door = d
+        junction = r
+      }
+    }
+  }
+
+  // --- The branch: one track from junction to door -----------------------------
+  const branchWander = new Float64Array(trailWander)
+  for (let i = 0; i < branchWander.length; i++) {
+    if (tiles[i] === "path") branchWander[i] += BRANCH_AVOID_COST
+  }
+  for (let dz = 0; dz < HOVEL_SIZE; dz++) {
+    for (let dx = 0; dx < HOVEL_SIZE; dx++) {
+      branchWander[(best.z + dz) * width + (best.x + dx)] += BRANCH_AVOID_COST
+    }
+  }
+  const branch: TilePos[] = []
+  for (const i of routeSegment(road[junction], door, width, depth, branchWander)) {
+    if (tiles[i] !== "path") tiles[i] = "track"
+    branch.push({ x: i % width, z: Math.floor(i / width) })
+  }
+
+  const hovel: BuildingDef = {
+    id: HOVEL_ID,
+    label: "Hovel of the Relic",
+    x: best.x,
+    z: best.z,
+    w: HOVEL_SIZE,
+    d: HOVEL_SIZE,
+    height: 0.55,
+    color: "#8c7658",
+    roofColor: "#5b4631",
+  }
+
+  return { hovel, site: { junction, branch, door, hovelId: HOVEL_ID } }
 }
 
 /**

--- a/lib/game/map/terrain.ts
+++ b/lib/game/map/terrain.ts
@@ -6,7 +6,7 @@
  * isometric camera without needing a real heightmap yet.
  */
 
-export type TerrainId = "grass" | "dirt" | "path" | "forest" | "clearing" | "hills"
+export type TerrainId = "grass" | "dirt" | "path" | "track" | "forest" | "clearing" | "hills"
 
 export interface TerrainDef {
   id: TerrainId
@@ -51,6 +51,17 @@ export const TERRAIN: Record<TerrainId, TerrainDef> = {
     buildable: false,
     passable: true,
   },
+  // The branch off the road to the relic: a beaten track, not engineered road.
+  // Its own terrain so the main road stays identifiable (and stable) on its own.
+  track: {
+    id: "track",
+    label: "Track",
+    color: "#ad9468",
+    height: 0.15,
+    jitter: 0.1,
+    buildable: false,
+    passable: true,
+  },
   forest: {
     id: "forest",
     label: "Forest",
@@ -85,6 +96,7 @@ export const TERRAIN_CHARS: Record<string, TerrainId> = {
   ".": "grass",
   ",": "dirt",
   "=": "path",
+  "-": "track",
   F: "forest",
   o: "clearing",
   "^": "hills",

--- a/lib/game/map/types.ts
+++ b/lib/game/map/types.ts
@@ -15,6 +15,30 @@ export interface BuildingDef {
   roofColor: string
 }
 
+export interface TilePos {
+  x: number
+  z: number
+}
+
+/**
+ * Where the relic is, and how to get there. The hovel sits a real detour off
+ * the road in its own glade; the branch is the only way in. Travelers who turn
+ * at the junction walk the branch to the door, venerate, and walk back out.
+ */
+export interface FoundingSite {
+  /** Index into `road` of the tile where the branch forks off the main road. */
+  junction: number
+  /**
+   * Ordered walk from the junction tile to the hovel's door tile, each step to
+   * a 4-neighbour. The first entry is the junction itself (on the road).
+   */
+  branch: TilePos[]
+  /** The tile the branch ends on, adjacent to the hovel's footprint. */
+  door: TilePos
+  /** Which entry in `buildings` is the hovel. */
+  hovelId: string
+}
+
 export interface GameMap {
   width: number
   depth: number
@@ -28,7 +52,9 @@ export interface GameMap {
    * 4-neighbour. The tile grid only says *where* road is; this says in what
    * order a traveller crosses it.
    */
-  road?: Array<{ x: number; z: number }>
+  road?: TilePos[]
+  /** Present on generated maps: the relic's hovel and the branch that reaches it. */
+  site?: FoundingSite
 }
 
 export function tileAt(map: GameMap, x: number, z: number): TerrainId | null {

--- a/lib/game/monks.test.ts
+++ b/lib/game/monks.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest"
+
+import { generateMonks, MONK_COUNT } from "./monks"
+
+describe("generateMonks", () => {
+  it("is fully determined by its seed", () => {
+    expect(generateMonks(12345)).toEqual(generateMonks(12345))
+  })
+
+  it("raises a brotherhood of four with distinct names and offices, led by the keeper", () => {
+    for (let seed = 0; seed < 50; seed++) {
+      const monks = generateMonks(seed)
+      expect(monks).toHaveLength(MONK_COUNT)
+      expect(new Set(monks.map((m) => m.name)).size).toBe(MONK_COUNT)
+      expect(new Set(monks.map((m) => m.duty)).size).toBe(MONK_COUNT)
+      expect(monks[0].duty).toBe("Keeper of the Relic")
+      for (const m of monks) {
+        expect(m.name).toMatch(/^Brother /)
+        expect(m.attributes.piety).toBeGreaterThanOrEqual(75)
+        expect(m.attributes.skills.length).toBeGreaterThanOrEqual(1)
+        expect(new Set(m.attributes.skills).size).toBe(m.attributes.skills.length)
+      }
+    }
+  })
+})

--- a/lib/game/monks.ts
+++ b/lib/game/monks.ts
@@ -1,0 +1,85 @@
+import { deriveSeed, makeRng, SEED_STREAM } from "./rng"
+
+/**
+ * The brothers who carried the relic here and keep it. They live at the hovel
+ * from day one — the settlement's first residents, and the reason the place
+ * never looks abandoned. Pure data; the scene animates them.
+ */
+
+export const MONK_COUNT = 4
+
+export interface MonkAttributes {
+  /** Years. */
+  age: number
+  /** Devotion, 0–100 — a monk's is never in doubt. */
+  piety: number
+  /** The trades a brother brought with him; the settlement's first labour. */
+  skills: string[]
+}
+
+export interface Monk {
+  id: number
+  name: string
+  /** Office within the brotherhood; the first monk is always the relic's keeper. */
+  duty: string
+  attributes: MonkAttributes
+}
+
+const DUTIES = ["Keeper of the Relic", "Cellarer", "Chanter", "Almoner", "Infirmarian", "Gardener"]
+const SKILLS = ["letters", "chant", "healing", "brewing", "herb lore", "carpentry", "masonry", "illumination"]
+const AGE = { min: 22, max: 68 }
+const PIETY = { min: 75, max: 100 }
+const SKILL_COUNT = { min: 1, max: 3 }
+
+/** What a brother is up to, for the HUD; set by the scene's ambient loop. */
+export type MonkActivity = "vigil" | "walking" | "resting"
+
+export const MONK_ACTIVITY_LABELS: Record<MonkActivity, string> = {
+  vigil: "Keeping vigil at the relic",
+  walking: "About the grounds",
+  resting: "At rest",
+}
+
+/**
+ * Bridge to the HUD, like the sim registry: the scene writes each brother's
+ * current activity here at frame rate and the monk panel polls it.
+ */
+export const monkRegistry: { current: Map<number, MonkActivity> | null } = { current: null }
+
+const NAMES = [
+  "Anselm", "Bede", "Cuthbert", "Dunstan", "Eadmer", "Felix", "Gildas", "Hugh",
+  "Ivo", "Jerome", "Kentigern", "Lanfranc", "Maurus", "Ninian", "Odo", "Paulinus",
+  "Rumwold", "Swithun", "Theodore", "Wulfstan",
+]
+
+/** Uniform integer in an inclusive range. */
+function roll(rng: () => number, range: { min: number; max: number }): number {
+  return range.min + Math.floor(rng() * (range.max - range.min + 1))
+}
+
+/** Partial Fisher–Yates over a copy: the first `count` entries are the pick. */
+function pickDistinct<T>(rng: () => number, items: readonly T[], count: number): T[] {
+  const pool = [...items]
+  for (let i = 0; i < count && i < pool.length; i++) {
+    const j = i + Math.floor(rng() * (pool.length - i))
+    ;[pool[i], pool[j]] = [pool[j], pool[i]]
+  }
+  return pool.slice(0, count)
+}
+
+export function generateMonks(seed: number, count = MONK_COUNT): Monk[] {
+  const rng = makeRng(deriveSeed(seed, SEED_STREAM.monks))
+  const names = pickDistinct(rng, NAMES, count)
+  // The keeper comes first; the other offices are drawn without repeats.
+  const duties = [DUTIES[0], ...pickDistinct(rng, DUTIES.slice(1), count - 1)]
+  return names.map((name, i) => ({
+    id: i,
+    name: `Brother ${name}`,
+    duty: duties[i],
+    attributes: {
+      age: roll(rng, AGE),
+      piety: roll(rng, PIETY),
+      skills: pickDistinct(rng, SKILLS, roll(rng, SKILL_COUNT)),
+    },
+  }))
+}

--- a/lib/game/relic.test.ts
+++ b/lib/game/relic.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest"
+
+import { generateRelic, RELICS, relicTitle } from "./relic"
+
+describe("generateRelic", () => {
+  it("is fully determined by its seed", () => {
+    expect(generateRelic(12345)).toEqual(generateRelic(12345))
+  })
+
+  it("draws different relics for different seeds", () => {
+    const names = new Set(Array.from({ length: 60 }, (_, i) => generateRelic(i * 7919 + 1).name))
+    expect(names.size).toBeGreaterThan(10)
+  })
+
+  it("offers thirty-odd relics, every one with a distinct name", () => {
+    expect(RELICS.length).toBeGreaterThanOrEqual(30)
+    expect(new Set(RELICS.map((r) => r.name)).size).toBe(RELICS.length)
+  })
+
+  it("rolls stats inside the relic's own ranges", () => {
+    for (let seed = 0; seed < 200; seed++) {
+      const relic = generateRelic(seed)
+      const def = RELICS[relic.id]
+      expect(relic.name).toBe(def.name)
+      expect(relic.stats.sanctity).toBeGreaterThanOrEqual(def.sanctity.min)
+      expect(relic.stats.sanctity).toBeLessThanOrEqual(def.sanctity.max)
+      expect(relic.stats.spectacle).toBeGreaterThanOrEqual(def.spectacle.min)
+      expect(relic.stats.spectacle).toBeLessThanOrEqual(def.spectacle.max)
+      expect(relic.stats.doubt).toBeGreaterThanOrEqual(def.doubt.min)
+      expect(relic.stats.doubt).toBeLessThanOrEqual(def.doubt.max)
+      expect(relic.stats.renown).toBeGreaterThan(0)
+      expect(relic.stats.renown).toBeLessThan(20)
+    }
+  })
+
+  it("titles a relic for display", () => {
+    expect(relicTitle({ ...generateRelic(1), name: "a thorn of the Crown" })).toBe("A thorn of the Crown")
+  })
+})

--- a/lib/game/relic.ts
+++ b/lib/game/relic.ts
@@ -1,0 +1,126 @@
+import { deriveSeed, makeRng, SEED_STREAM } from "./rng"
+import type { StatRange } from "./travelers"
+
+/**
+ * The relic: what the monks carried here and what every traveler on the road
+ * might turn aside for. Pure data — no three.js, no React — generated from the
+ * world seed like everything else, so seed 12345 always enshrines the same
+ * bone in the same hovel.
+ *
+ * Its stats are the other half of the draw equation. A traveler's piety says
+ * how much they want *a* relic; these say how much they want *this* one:
+ *  - sanctity: how holy it is held to be — multiplies piety's pull.
+ *  - spectacle: how outlandish the claim — draws the curious and the idle
+ *    even when their piety is thin.
+ *  - doubt: how shaky the provenance — the learned and the high-born sniff
+ *    at it, and it caps how far renown can honestly climb.
+ *  - renown: how widely it is known. Starts small; visitors spread the word.
+ */
+
+export type RelicKind = "bone" | "wood" | "cloth" | "hair" | "stone" | "metal" | "vial"
+
+export const RELIC_KIND_COLORS: Record<RelicKind, string> = {
+  bone: "#ece2c8",
+  wood: "#6f4b2c",
+  cloth: "#7f93c8",
+  hair: "#caa24a",
+  stone: "#8f8a80",
+  metal: "#d9b654",
+  vial: "#a83a3a",
+}
+
+export interface RelicDef {
+  name: string
+  kind: RelicKind
+  sanctity: StatRange
+  spectacle: StatRange
+  doubt: StatRange
+}
+
+/** Uniform integer in an inclusive range. */
+function roll(rng: () => number, range: StatRange): number {
+  return range.min + Math.floor(rng() * (range.max - range.min + 1))
+}
+
+const r = (min: number, max: number): StatRange => ({ min, max })
+
+/**
+ * Thirty relics, from the venerable to the frankly suspicious. Ranges lean the
+ * way the claim does: the True Cross is holy and hard to doubt, the breath of
+ * the Holy Spirit is a marvel in a bottle that nobody serious believes.
+ */
+export const RELICS: readonly RelicDef[] = [
+  { name: "the pelvis of St. John", kind: "bone", sanctity: r(55, 80), spectacle: r(30, 55), doubt: r(25, 50) },
+  { name: "a thorn of the Crown", kind: "wood", sanctity: r(80, 100), spectacle: r(40, 60), doubt: r(10, 35) },
+  { name: "a toe bone of Moses", kind: "bone", sanctity: r(50, 75), spectacle: r(45, 70), doubt: r(55, 85) },
+  { name: "the veil of the Holy Mother", kind: "cloth", sanctity: r(85, 100), spectacle: r(35, 55), doubt: r(10, 30) },
+  { name: "a splinter of the True Cross", kind: "wood", sanctity: r(85, 100), spectacle: r(30, 50), doubt: r(15, 40) },
+  { name: "the jawbone of Samson's ass", kind: "bone", sanctity: r(25, 50), spectacle: r(75, 100), doubt: r(60, 90) },
+  { name: "a feather from the wing of Gabriel", kind: "hair", sanctity: r(60, 85), spectacle: r(80, 100), doubt: r(65, 95) },
+  { name: "the left sandal of St. Peter", kind: "cloth", sanctity: r(55, 75), spectacle: r(25, 45), doubt: r(30, 55) },
+  { name: "a vial of the Virgin's milk", kind: "vial", sanctity: r(70, 90), spectacle: r(60, 85), doubt: r(45, 75) },
+  { name: "the tooth of St. Apollonia", kind: "bone", sanctity: r(45, 65), spectacle: r(20, 40), doubt: r(20, 45) },
+  { name: "a lock of Mary Magdalene's hair", kind: "hair", sanctity: r(55, 80), spectacle: r(40, 60), doubt: r(30, 55) },
+  { name: "the finger of Doubting Thomas", kind: "bone", sanctity: r(65, 85), spectacle: r(50, 70), doubt: r(25, 50) },
+  { name: "a stone from the tomb of Lazarus", kind: "stone", sanctity: r(60, 80), spectacle: r(30, 50), doubt: r(35, 60) },
+  { name: "the rope that bound Isaac", kind: "cloth", sanctity: r(45, 70), spectacle: r(50, 70), doubt: r(60, 85) },
+  { name: "a scale of Jonah's whale", kind: "bone", sanctity: r(30, 55), spectacle: r(80, 100), doubt: r(70, 95) },
+  { name: "the tip of Goliath's sword", kind: "metal", sanctity: r(30, 50), spectacle: r(70, 90), doubt: r(50, 80) },
+  { name: "a loaf from the feeding of the five thousand", kind: "stone", sanctity: r(50, 70), spectacle: r(65, 90), doubt: r(70, 95) },
+  { name: "the staff of Aaron", kind: "wood", sanctity: r(65, 85), spectacle: r(45, 65), doubt: r(45, 70) },
+  { name: "one of the thirty pieces of silver", kind: "metal", sanctity: r(35, 60), spectacle: r(60, 80), doubt: r(40, 65) },
+  { name: "a swaddling cloth of the Nativity", kind: "cloth", sanctity: r(80, 100), spectacle: r(40, 60), doubt: r(25, 50) },
+  { name: "the skull of St. Denis", kind: "bone", sanctity: r(60, 80), spectacle: r(55, 75), doubt: r(20, 45) },
+  { name: "a tear of St. Peter, kept in glass", kind: "vial", sanctity: r(60, 85), spectacle: r(55, 80), doubt: r(55, 85) },
+  { name: "the girdle of St. Thomas", kind: "cloth", sanctity: r(65, 85), spectacle: r(30, 50), doubt: r(25, 50) },
+  { name: "the breath of the Holy Spirit, in a flask", kind: "vial", sanctity: r(40, 70), spectacle: r(90, 100), doubt: r(85, 100) },
+  { name: "a sliver of Noah's Ark", kind: "wood", sanctity: r(45, 65), spectacle: r(55, 75), doubt: r(60, 85) },
+  { name: "the shinbone of St. Christopher", kind: "bone", sanctity: r(50, 70), spectacle: r(35, 55), doubt: r(30, 55) },
+  { name: "the tablecloth of the Last Supper", kind: "cloth", sanctity: r(75, 95), spectacle: r(45, 65), doubt: r(35, 60) },
+  { name: "a pebble from David's sling", kind: "stone", sanctity: r(35, 55), spectacle: r(50, 70), doubt: r(55, 80) },
+  { name: "the eyelid of St. Lucy", kind: "bone", sanctity: r(45, 65), spectacle: r(70, 90), doubt: r(35, 60) },
+  { name: "the tail of Balaam's ass", kind: "hair", sanctity: r(20, 45), spectacle: r(80, 100), doubt: r(70, 95) },
+  { name: "a drop of the blood of St. Januarius", kind: "vial", sanctity: r(70, 90), spectacle: r(65, 85), doubt: r(30, 55) },
+]
+
+/** A relic that is known to a few and no more, until pilgrims spread the word. */
+const STARTING_RENOWN: StatRange = { min: 4, max: 14 }
+
+export interface RelicStats {
+  sanctity: number
+  spectacle: number
+  doubt: number
+  renown: number
+}
+
+export interface Relic {
+  /** Index into RELICS; stable per seed. */
+  id: number
+  name: string
+  kind: RelicKind
+  color: string
+  stats: RelicStats
+}
+
+/** Capitalise the first letter for use at the start of a sentence or title. */
+export function relicTitle(relic: Relic): string {
+  return relic.name.charAt(0).toUpperCase() + relic.name.slice(1)
+}
+
+export function generateRelic(seed: number): Relic {
+  const rng = makeRng(deriveSeed(seed, SEED_STREAM.relic))
+  const id = Math.floor(rng() * RELICS.length)
+  const def = RELICS[id]
+  return {
+    id,
+    name: def.name,
+    kind: def.kind,
+    color: RELIC_KIND_COLORS[def.kind],
+    stats: {
+      sanctity: roll(rng, def.sanctity),
+      spectacle: roll(rng, def.spectacle),
+      doubt: roll(rng, def.doubt),
+      renown: roll(rng, STARTING_RENOWN),
+    },
+  }
+}

--- a/lib/game/render/outline.ts
+++ b/lib/game/render/outline.ts
@@ -72,6 +72,20 @@ export function travelerObjectId(travelerIndex: number): number {
 }
 
 /**
+ * Residents (the monks) take a block below the travelers — 4096 IDs down,
+ * far more travelers than any road will carry.
+ */
+export function residentObjectId(residentIndex: number): number {
+  return MAX_OBJECT_ID - 0x1000 - residentIndex
+}
+
+/**
+ * The relic sits alone in the middle of the ID space, so it outlines against
+ * the shrine that houses it rather than merging into the walls.
+ */
+export const RELIC_OBJECT_ID = 0x8000
+
+/**
  * Outline thickness in CSS pixels. The edge pass samples neighbours at this
  * screen-space distance, so lines render at a constant display width at every
  * zoom level and DPR.

--- a/lib/game/rng.ts
+++ b/lib/game/rng.ts
@@ -43,4 +43,8 @@ export const SEED_STREAM = {
   trees: 2,
   travelers: 3,
   treeCount: 4,
+  relic: 5,
+  monks: 6,
+  /** Runtime stream for the monks' ambient wandering around the hovel. */
+  monkWander: 7,
 } as const


### PR DESCRIPTION
Every generated map now starts founded, RCT-style: worldgen sites the monks' hovel in a glade a real detour off the road (new `relicDistance` knob with HUD slider and `?relic=` param, default 24 tiles) and cuts a beaten `track` from a mid-road junction to its door, exposed as `map.site`. A seeded relic from a list of 31, biblical to absurd, is enshrined there with sanctity / spectacle / doubt / renown stats, and four named brothers with offices and skills drift about the grounds. The hovel renders as a walled shrine with an open centre where the relic pulses faintly, and both the relic and the monks are selectable with HUD panels, with selection consolidated into one store field across travelers, monks, and relic. New worlds open with the camera on the hovel. 72 tests pass and typecheck is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)