### PR TITLE
feat(site): changelog page and alpha version on the main menu

### DIFF
--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -1,0 +1,54 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+
+import { CHANGELOG, CURRENT_VERSION } from "@/lib/changelog"
+
+export const metadata: Metadata = {
+  title: "Pilgrimage — Changelog",
+  description: "Release history for Pilgrimage, a medieval settlement builder.",
+}
+
+export default function ChangelogPage() {
+  return (
+    <main className="min-h-screen bg-[#1a1208] px-5 py-10 md:px-5 md:py-10">
+      <article className="relative mx-auto max-w-[780px] bg-parchment p-7 md:p-[60px_70px] shadow-[0_0_0_1px_var(--rule),0_0_0_4px_var(--parchment-dark),0_0_0_5px_var(--rule),8px_8px_40px_rgba(0,0,0,0.7)] page-border parchment-texture">
+        <header className="mb-10 border-b-2 border-rule pb-8 text-center">
+          <span className="mb-4 block text-base tracking-[10px] text-gold">✦ ✦ ✦</span>
+          <h1 className="font-display text-4xl font-bold tracking-[6px] text-ink md:text-5xl">
+            CHANGELOG
+          </h1>
+          <p className="mt-3 font-display text-xs uppercase tracking-[4px] text-ink-light">
+            {CURRENT_VERSION}
+          </p>
+        </header>
+
+        <ol className="flex flex-col gap-8">
+          {CHANGELOG.map((release) => (
+            <li key={release.version} className="border-l-[3px] border-gold pl-5">
+              <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                <h2 className="font-display text-xl font-semibold uppercase tracking-[2px] text-ink">
+                  {release.title}
+                </h2>
+                <span className="font-display text-[11px] uppercase tracking-[2px] text-red">
+                  Alpha v{release.version}
+                </span>
+              </div>
+              <p className="mt-2 text-base leading-relaxed text-ink-light">
+                {release.summary}
+              </p>
+            </li>
+          ))}
+        </ol>
+
+        <footer className="mt-12 border-t-2 border-rule pt-6 text-center">
+          <Link
+            href="/"
+            className="font-display text-xs uppercase tracking-[3px] text-ink hover:text-red"
+          >
+            ← Return to the main menu
+          </Link>
+        </footer>
+      </article>
+    </main>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link"
 
+import { CURRENT_VERSION } from "@/lib/changelog"
 import { SITE_MENU } from "@/lib/site-menu"
 
 export default function LandingPage() {
@@ -33,7 +34,7 @@ export default function LandingPage() {
       </nav>
 
       <footer className="mt-14 text-center font-display text-[10px] uppercase tracking-[3px] text-gold/60">
-        Prototype — v0.3
+        {CURRENT_VERSION}
       </footer>
     </main>
   )

--- a/lib/changelog.ts
+++ b/lib/changelog.ts
@@ -1,0 +1,58 @@
+/**
+ * Release history, newest first. Add a new entry (and bump the version) with
+ * every release — the landing page shows the latest version, and /changelog
+ * renders the full list.
+ */
+export type Release = {
+  version: string
+  title: string
+  summary: string
+}
+
+export const CHANGELOG: Release[] = [
+  {
+    version: "0.0.7",
+    title: "Changelog & Versioning",
+    summary:
+      "The game now keeps a public record of its own history. Every release gets a version number, a title, and a summary, all reachable from the main menu.",
+  },
+  {
+    version: "0.0.6",
+    title: "Music of the Road",
+    summary:
+      "Looping background music accompanies the prototype, starting from a random point in the track so every visit sounds a little different. A HUD toggle silences it.",
+  },
+  {
+    version: "0.0.5",
+    title: "The Dense Forest",
+    summary:
+      "Forests grew thick and believable: dense tree cover broken by glades, winding trails, and passable clearings, tuned for exploration on foot.",
+  },
+  {
+    version: "0.0.4",
+    title: "A Seeded World",
+    summary:
+      "A full rendering pass over the map, worlds generated from shareable seeds, and site-wide navigation linking the game, docs, and textures together.",
+  },
+  {
+    version: "0.0.3",
+    title: "Terrain Takes Shape",
+    summary:
+      "Seeded map generation arrived with tunable forests, a road crossing the land, and adjustable map sizes.",
+  },
+  {
+    version: "0.0.2",
+    title: "First Steps on the Map",
+    summary:
+      "An isometric camera and map prototype opened at /play — pan, zoom, and rotate across the first tiles of the world.",
+  },
+  {
+    version: "0.0.1",
+    title: "The Pilgrimage Begins",
+    summary:
+      "The founding release: a landing page, the game design document, and the vision for a medieval pilgrimage-site builder.",
+  },
+]
+
+/** The version currently on the home screen — always the newest release. */
+export const CURRENT_VERSION = `Alpha v${CHANGELOG[0].version}`

--- a/lib/site-menu.ts
+++ b/lib/site-menu.ts
@@ -3,4 +3,5 @@ export const SITE_MENU: Array<{ label: string; description: string; href: string
   { label: "Play", description: "Enter the prototype", href: "/play" },
   { label: "Docs", description: "Game design document", href: "/docs" },
   { label: "Textures", description: "Every texture, in place", href: "/textures" },
+  { label: "Changelog", description: "What changed, release by release", href: "/changelog" },
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "my-project",
-  "version": "0.1.0",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "my-project",
-      "version": "0.1.0",
+      "version": "0.0.7",
       "dependencies": {
         "@hookform/resolvers": "^3.9.1",
         "@radix-ui/react-accordion": "1.2.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-project",
-  "version": "0.1.0",
+  "version": "0.0.7",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Adds a release history to the game. `lib/changelog.ts` is the single source of truth — a list of `{ version, title, summary }` entries, newest first — and derives `CURRENT_VERSION` from the top one so the home screen can never drift from the list.

The new `/changelog` route renders those entries on parchment matching the design document, and `Changelog` joins `SITE_MENU`, so it shows up on both the landing page and the in-game HUD nav. The landing footer now reads **Alpha v0.0.7** in place of the hardcoded "Prototype — v0.3", and `package.json` is reset to `0.0.7` to match.

Releases 0.0.1–0.0.7 are backfilled from the existing git history, so the page has content on day one — the wording is derived from commit subjects and is worth a skim. To cut a release from here, add an entry at the top of `CHANGELOG` and bump `package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)