### PR TITLE
fix(game): 24-bit outline IDs so large maps stop crashing on load

### DIFF
--- a/components/game/outline-pass.tsx
+++ b/components/game/outline-pass.tsx
@@ -47,7 +47,10 @@ const FRAGMENT_SHADER = /* glsl */ `
 
   float idAt(vec2 uv) {
     vec4 t = texture2D(tId, uv);
-    return floor(t.r * 255.0 + 0.5) + 256.0 * floor(t.g * 255.0 + 0.5);
+    // 24-bit ID, exact in highp float (24-bit mantissa) — see MAX_OBJECT_ID.
+    return floor(t.r * 255.0 + 0.5)
+      + 256.0 * floor(t.g * 255.0 + 0.5)
+      + 65536.0 * floor(t.b * 255.0 + 0.5);
   }
 
   bool occludedBy(vec2 uv, float idC, float dC) {

--- a/lib/changelog.ts
+++ b/lib/changelog.ts
@@ -11,6 +11,12 @@ export type Release = {
 
 export const CHANGELOG: Release[] = [
   {
+    version: "0.0.13",
+    title: "Room for Every Tree",
+    summary:
+      "Large maps no longer crash on load. Every tree carries its own outline ID, and the biggest worlds grew more trees than the old 16-bit ID space could name; IDs are now 24-bit, with room for every tree a 512 × 512 map can hold.",
+  },
+  {
     version: "0.0.12",
     title: "Wider Horizons",
     summary:

--- a/lib/game/game.test.ts
+++ b/lib/game/game.test.ts
@@ -41,6 +41,9 @@ import {
   MAX_OBJECT_ID,
   nextOutlineMode,
   OUTLINE_MODES,
+  RELIC_OBJECT_ID,
+  residentObjectId,
+  travelerObjectId,
   treeObjectId,
   type OutlineMode,
 } from "./render/outline"
@@ -247,13 +250,13 @@ describe("seeded rng", () => {
 describe("outline ids", () => {
   it("round-trips ids through 8-bit-per-channel quantisation", () => {
     const readback = (v: number) => Math.round(v * 255) / 255
-    for (const id of [0, 1, 2, 255, 256, 257, 1024, MAX_OBJECT_ID]) {
-      const [r, g] = encodeObjectId(id)
-      expect(decodeObjectId(readback(r), readback(g))).toBe(id)
+    for (const id of [0, 1, 2, 255, 256, 257, 1024, 65535, 65536, 65537, 0x8000ff, MAX_OBJECT_ID]) {
+      const [r, g, b] = encodeObjectId(id)
+      expect(decodeObjectId(readback(r), readback(g), readback(b))).toBe(id)
     }
   })
 
-  it("rejects ids the two channels cannot hold", () => {
+  it("rejects ids the three channels cannot hold", () => {
     expect(() => encodeObjectId(-1)).toThrow()
     expect(() => encodeObjectId(MAX_OBJECT_ID + 1)).toThrow()
     expect(() => encodeObjectId(1.5)).toThrow()
@@ -268,6 +271,18 @@ describe("outline ids", () => {
     expect(ids.has(0)).toBe(false)
     expect(ids.size).toBe(buildingCount + treeCount)
     expect(Math.max(...ids)).toBeLessThanOrEqual(MAX_OBJECT_ID)
+  })
+
+  it("holds the trees of the largest map without reaching the reserved blocks", () => {
+    // 512 × 512 tiles, every one forest, two trees each: the worst case the
+    // size and coverage sliders can produce. The tree block must stay below
+    // the relic, the residents, and the travelers counting down from the top.
+    const worstTrees = 512 * 512 * 2
+    const top = treeObjectId(64, worstTrees - 1)
+    expect(top).toBeLessThan(RELIC_OBJECT_ID)
+    expect(top).toBeLessThan(residentObjectId(0x1000 - 1))
+    expect(top).toBeLessThan(travelerObjectId(0xfff))
+    expect(() => encodeObjectId(top)).not.toThrow()
   })
 
   it("cycles through every mode and wraps back to the first", () => {

--- a/lib/game/render/outline.ts
+++ b/lib/game/render/outline.ts
@@ -34,8 +34,13 @@ export function nextOutlineMode(mode: OutlineMode): OutlineMode {
   return OUTLINE_MODES[(OUTLINE_MODES.indexOf(mode) + 1) % OUTLINE_MODES.length]
 }
 
-/** IDs use 8 bits in each of the R and G channels. ID 0 means "not an object". */
-export const MAX_OBJECT_ID = 0xffff
+/**
+ * IDs use 8 bits in each of the R, G, and B channels — 24 bits, so a 512 × 512
+ * map packed two trees to a tile (about half a million objects) still fits with
+ * room to spare. Two channels ran out around 65k trees, which a large map
+ * reached at ordinary forest coverage. ID 0 means "not an object".
+ */
+export const MAX_OBJECT_ID = 0xffffff
 
 /**
  * Encode an ID as linear RGB in 0–1, exact under 8-bit-per-channel quantisation.
@@ -45,12 +50,12 @@ export function encodeObjectId(id: number): [number, number, number] {
   if (!Number.isInteger(id) || id < 0 || id > MAX_OBJECT_ID) {
     throw new Error(`Object id out of range: ${id}`)
   }
-  return [(id & 0xff) / 255, ((id >> 8) & 0xff) / 255, 0]
+  return [(id & 0xff) / 255, ((id >> 8) & 0xff) / 255, ((id >> 16) & 0xff) / 255]
 }
 
 /** Inverse of `encodeObjectId`, for tests and readback debugging. */
-export function decodeObjectId(r: number, g: number): number {
-  return Math.round(r * 255) + 256 * Math.round(g * 255)
+export function decodeObjectId(r: number, g: number, b: number): number {
+  return Math.round(r * 255) + 256 * Math.round(g * 255) + 65536 * Math.round(b * 255)
 }
 
 /** Buildings take the first block of IDs, starting above the reserved 0. */
@@ -83,7 +88,7 @@ export function residentObjectId(residentIndex: number): number {
  * The relic sits alone in the middle of the ID space, so it outlines against
  * the shrine that houses it rather than merging into the walls.
  */
-export const RELIC_OBJECT_ID = 0x8000
+export const RELIC_OBJECT_ID = 0x800000
 
 /**
  * Outline thickness in CSS pixels. The edge pass samples neighbours at this


### PR DESCRIPTION
Maps past roughly 192 tiles a side crashed on load: every tree gets its own outline ID, the R+G channel encoding capped IDs at 65,535, and a large map at ordinary forest coverage grew more trees than that, so `encodeObjectId` threw from the tree placement effect. IDs now use the blue channel too, giving 24 bits and room for the half-million trees a 512 × 512 map can hold at most. The edge shader decodes the third channel (exact in highp float) and the relic's reserved ID moves to the middle of the wider range. Tests cover round-tripping across the channel boundaries and assert the largest map's trees stay below the relic, resident, and traveler blocks; verified headlessly at 288 and 512 with 90% coverage. Adds the 0.0.13 changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)