### PR TITLE
feat(game): per-species tree footprints and per-tile caps so trunks stop overlapping

### DIFF
--- a/components/game/trees.tsx
+++ b/components/game/trees.tsx
@@ -4,18 +4,17 @@ import { useEffect, useLayoutEffect, useMemo } from "react"
 import * as THREE from "three"
 
 import { deriveSeed, makeRng, SEED_STREAM } from "@/lib/game/rng"
-import { computeDarkShade, computeForestShade } from "@/lib/game/map/forest-field"
-import { isWoods, TILE_HEIGHT } from "@/lib/game/map/terrain"
-import { tileAt, tileToWorldX, tileToWorldZ, type GameMap } from "@/lib/game/map/types"
+import { TILE_HEIGHT } from "@/lib/game/map/terrain"
+import type { GameMap } from "@/lib/game/map/types"
 import {
   encodeObjectId,
   OUTLINE_ID_LAYER_MASK,
   RELIC_OBJECT_ID,
   treeObjectId,
 } from "@/lib/game/render/outline"
+import { placeTrees, type TreePlacement } from "@/lib/game/trees/placement"
 import {
   generateTree,
-  pickSpecies,
   TREE_SPECIES_ORDER,
   type TreeShape,
   type TreeSpeciesDef,
@@ -27,17 +26,9 @@ import { useTreeTuningStore } from "@/lib/game/trees/tree-tuning-store"
  * Parametric species trees, drawn as instanced low-poly primitives.
  *
  * Two layers:
- *  - `Trees` reads a map, decides where trees stand and which species each is
- *    (weighted by habitat — birch and hawthorn favour the forest edge, beech
- *    the interior — and by each species' grove field, so kinds clump together),
- *    and hands the placements on. Every forest tile holds 1 or 2 trees — a
- *    seeded coin flip that only lands on 2 deep in the woods — and the stand
- *    fades at its rim: the outermost trees are a little shorter and lighter,
- *    following the forest-shade field the ground colour also reads, so the
- *    woods taper into grassland instead of stopping at a wall. Dark forest is
- *    the one exception to the 1–2 rule: old growth holds 2 or 3 trees, taller
- *    and darker, and the dark-shade field feathers that into the woods around
- *    it so the heart of a forest never has a hard rim.
+ *  - `Trees` reads a map and asks `placeTrees` (lib/game/trees/placement) where
+ *    the trees stand and which species each is: habitat and groves pick the
+ *    kind, and each species' footprint and per-tile cap decide how many fit.
  *  - `TreeField` grows each placement into a `TreeShape` and renders them. The
  *    lab on /assets/textures uses it directly to line up trees of one species.
  *
@@ -49,28 +40,7 @@ import { useTreeTuningStore } from "@/lib/game/trees/tree-tuning-store"
  * per-tree geometry, no textures, no transparency.
  */
 
-export interface TreePlacement {
-  /** World position of the tree's base. */
-  x: number
-  y: number
-  z: number
-  species: TreeSpeciesId
-  /** Whole-tree size multiplier; edge trees are smaller. Defaults to 1. */
-  scale?: number
-  /** Brightness multiplier on bark and foliage; edge trees are lighter. Defaults to 1. */
-  brightness?: number
-}
-
-/** Edge trees scale down to this fraction of a core tree's size. */
-const EDGE_SIZE_SCALE = 0.7
-
-/** Chance of a second tree at the very heart of the woods; fades to 0 at the rim. */
-const SECOND_TREE_CHANCE = 0.5
-
-/** Old growth stands this much taller than the woods around it, at full dark shade. */
-const DARK_HEIGHT_SCALE = 1.45
-/** And this much darker. */
-const DARK_BRIGHTNESS = 0.6
+export type { TreePlacement }
 
 /** Trunks sink slightly into the ground so a lean never exposes a gap. */
 const TRUNK_SINK = 0.04
@@ -94,67 +64,9 @@ function makeCrownGeometry(shape: TreeSpeciesDef["crown"]["shape"]): THREE.Buffe
     : new THREE.IcosahedronGeometry(1, BLOB_DETAIL)
 }
 
-/** Woods tiles that touch open ground; the map edge does not count. */
-function isForestEdge(map: GameMap, x: number, z: number): boolean {
-  for (const [dx, dz] of [
-    [1, 0],
-    [-1, 0],
-    [0, 1],
-    [0, -1],
-  ]) {
-    const neighbour = tileAt(map, x + dx, z + dz)
-    if (neighbour !== null && !isWoods(neighbour)) return true
-  }
-  return false
-}
-
 export function Trees({ map }: { map: GameMap }) {
   const species = useTreeTuningStore((s) => s.species)
-
-  const placements = useMemo<TreePlacement[]>(() => {
-    const seed = map.seed ?? 0
-    const shade = computeForestShade(map)
-    const darkShade = computeDarkShade(map)
-    // Counts get their own stream so species and jitter (from the `trees`
-    // stream) stay independent of the coin flips.
-    const rngCount = makeRng(deriveSeed(seed, SEED_STREAM.treeCount))
-    const rng = makeRng(deriveSeed(seed, SEED_STREAM.trees))
-    // Spread across the tile so a packed tile reads as many trees, not a lattice.
-    const scatter = 0.8
-    const out: TreePlacement[] = []
-    for (let z = 0; z < map.depth; z++) {
-      for (let x = 0; x < map.width; x++) {
-        const index = z * map.width + x
-        if (!isWoods(map.tiles[index])) continue
-        const depth = shade[index]
-        const dark = darkShade[index]
-        const oldGrowth = map.tiles[index] === "darkwood"
-        // One coin flip per woods tile, dark or not, so ordinary forest draws
-        // exactly what it did before dark forest existed.
-        const flip = rngCount()
-        const count = oldGrowth
-          ? 2 + (flip < SECOND_TREE_CHANCE * dark ? 1 : 0)
-          : 1 + (flip < SECOND_TREE_CHANCE * depth ? 1 : 0)
-        const site = { x, z, onEdge: isForestEdge(map, x, z), seed }
-        for (let t = 0; t < count; t++) {
-          const id = pickSpecies(species, site, rng)
-          out.push({
-            x: tileToWorldX(map, x) + (rng() - 0.5) * scatter,
-            y: TILE_HEIGHT,
-            z: tileToWorldZ(map, z) + (rng() - 0.5) * scatter,
-            species: id,
-            scale:
-              (EDGE_SIZE_SCALE + (1 - EDGE_SIZE_SCALE) * depth) *
-              (1 + (DARK_HEIGHT_SCALE - 1) * dark),
-            // Edge growth reads younger and sunlit — a touch lighter than the
-            // core; old growth darker still, feathered by the dark shade.
-            brightness: (1.1 - 0.15 * depth) * (1 - (1 - DARK_BRIGHTNESS) * dark),
-          })
-        }
-      }
-    }
-    return out
-  }, [map, species])
+  const placements = useMemo(() => placeTrees(map, species), [map, species])
 
   return (
     <TreeField

--- a/components/tree-lab/tree-lab.tsx
+++ b/components/tree-lab/tree-lab.tsx
@@ -360,10 +360,30 @@ function SpeciesEditor({ def }: { def: TreeSpeciesDef }) {
             format={(v) => `${v} tiles`}
             onChange={(groveSize) => habitat({ groveSize })}
           />
+          <Slider
+            label="Footprint"
+            value={def.habitat.footprint}
+            min={0.1}
+            max={0.8}
+            step={0.05}
+            format={(v) => `${v.toFixed(2)} tiles`}
+            onChange={(footprint) => habitat({ footprint })}
+          />
+          <Slider
+            label="Per tile"
+            value={def.habitat.perTile}
+            min={1}
+            max={3}
+            step={1}
+            format={(v) => (v === 1 ? "1 tree" : `${v} trees`)}
+            onChange={(perTile) => habitat({ perTile })}
+          />
           <p className="mt-3 text-[12px] text-ink-light">
             Abundance is the species&apos; share of the forest; edge bias pulls it toward tiles
             that border open ground (positive) or away from them (negative). Grouping keeps the
-            species to groves of about the given size, with mixing along their seams.
+            species to groves of about the given size, with mixing along their seams. Footprint
+            is the ground a trunk claims — no other trunk stands closer — and per tile caps how
+            many of the species one tile can hold.
           </p>
         </div>
       </div>

--- a/lib/game/trees/placement.test.ts
+++ b/lib/game/trees/placement.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest"
+
+import { parseAsciiMap } from "../map/prototype-map"
+import { tileToWorldX, tileToWorldZ, worldToTileX, worldToTileZ, type GameMap } from "../map/types"
+import {
+  DARK_HEIGHT_SCALE,
+  MAX_FOOTPRINT,
+  MAX_TREES_PER_TILE,
+  placeTrees,
+  requiredSpacing,
+  type TreePlacement,
+} from "./placement"
+import {
+  cloneSpeciesTable,
+  TREE_SPECIES,
+  TREE_SPECIES_ORDER,
+  type TreeSpeciesDef,
+  type TreeSpeciesId,
+} from "./species"
+
+/** A square block of woods with a margin of grass, so it has both rim and heart. */
+function woodsBlock(size: number, seed: number, char = "F"): GameMap {
+  const row = (fill: string) => fill.repeat(size)
+  const rows: string[] = []
+  for (let z = 0; z < size; z++) {
+    rows.push(z < 3 || z >= size - 3 ? row(".") : ".".repeat(3) + char.repeat(size - 6) + ".".repeat(3))
+  }
+  return { ...parseAsciiMap(rows), seed }
+}
+
+/** Trees grouped by the tile their trunk stands on. */
+function byTile(map: GameMap, trees: TreePlacement[]): Map<number, TreePlacement[]> {
+  const tiles = new Map<number, TreePlacement[]>()
+  for (const tree of trees) {
+    const x = worldToTileX(map, tree.x)
+    const z = worldToTileZ(map, tree.z)
+    const key = z * map.width + x
+    const list = tiles.get(key) ?? []
+    list.push(tree)
+    tiles.set(key, list)
+  }
+  return tiles
+}
+
+/** A table where only one species can be picked. */
+function only(id: TreeSpeciesId): Record<TreeSpeciesId, TreeSpeciesDef> {
+  const table = cloneSpeciesTable()
+  for (const other of TREE_SPECIES_ORDER) {
+    table[other].habitat.weight = other === id ? 1 : 0
+    table[other].habitat.grouping = 0
+  }
+  return table
+}
+
+describe("placeTrees", () => {
+  const map = woodsBlock(40, 11)
+  const trees = placeTrees(map, TREE_SPECIES)
+
+  it("is deterministic in the seed and fills the woods", () => {
+    expect(trees.length).toBeGreaterThan(34 * 34)
+    expect(placeTrees(map, TREE_SPECIES)).toEqual(trees)
+    expect(placeTrees({ ...map, seed: 12 }, TREE_SPECIES)).not.toEqual(trees)
+  })
+
+  it("keeps every trunk on a woods tile, inside the tile", () => {
+    for (const tree of trees) {
+      const x = worldToTileX(map, tree.x)
+      const z = worldToTileZ(map, tree.z)
+      expect(map.tiles[z * map.width + x]).toBe("forest")
+      expect(Math.abs(tree.x - tileToWorldX(map, x))).toBeLessThan(0.5)
+      expect(Math.abs(tree.z - tileToWorldZ(map, z))).toBeLessThan(0.5)
+    }
+  })
+
+  it("never stands one trunk inside another's footprint", () => {
+    // Brute force over every pair: the placement's 3 × 3 shortcut must agree.
+    for (let i = 0; i < trees.length; i++) {
+      for (let j = i + 1; j < trees.length; j++) {
+        const a = trees[i]
+        const b = trees[j]
+        const d = Math.hypot(a.x - b.x, a.z - b.z)
+        if (d >= MAX_FOOTPRINT) continue
+        const gap = requiredSpacing(
+          TREE_SPECIES[a.species],
+          a.scale ?? 1,
+          TREE_SPECIES[b.species],
+          b.scale ?? 1,
+        )
+        expect(d).toBeGreaterThanOrEqual(gap)
+      }
+    }
+  })
+
+  it("holds no tile past its species caps or the slot ceiling", () => {
+    for (const list of byTile(map, trees).values()) {
+      expect(list.length).toBeLessThanOrEqual(MAX_TREES_PER_TILE)
+      const counts: Partial<Record<TreeSpeciesId, number>> = {}
+      for (const tree of list) counts[tree.species] = (counts[tree.species] ?? 0) + 1
+      for (const id of TREE_SPECIES_ORDER) {
+        expect(counts[id] ?? 0).toBeLessThanOrEqual(TREE_SPECIES[id].habitat.perTile)
+      }
+    }
+  })
+
+  it("gives oaks a tile each but lets birch crowd in", () => {
+    const oaks = placeTrees(map, only("oak"))
+    for (const list of byTile(map, oaks).values()) expect(list.length).toBe(1)
+
+    const birches = placeTrees(map, only("birch"))
+    const crowded = [...byTile(map, birches).values()].filter((list) => list.length >= 2)
+    expect(crowded.length).toBeGreaterThan(50)
+    expect(birches.length).toBeGreaterThan(oaks.length * 1.3)
+  })
+
+  it("thins toward the rim: fewer trees per tile on the edge than at the heart", () => {
+    const birches = placeTrees(map, only("birch"))
+    const tiles = byTile(map, birches)
+    let rim = 0
+    let rimTiles = 0
+    let heart = 0
+    let heartTiles = 0
+    for (let z = 3; z < 37; z++) {
+      for (let x = 3; x < 37; x++) {
+        const n = tiles.get(z * map.width + x)?.length ?? 0
+        const inset = Math.min(x - 3, z - 3, 36 - x, 36 - z)
+        if (inset === 0) {
+          rim += n
+          rimTiles++
+        } else if (inset >= 8) {
+          heart += n
+          heartTiles++
+        }
+      }
+    }
+    // The shade field is a centred window, so even the outermost row reads as
+    // half-wooded; the thinning is real but gentle.
+    expect(heart / heartTiles).toBeGreaterThan((rim / rimTiles) * 1.2)
+    // Rim trees are smaller and lighter.
+    const rimTree = tiles.get(3 * map.width + 3)![0]
+    const heartTree = tiles.get(20 * map.width + 20)![0]
+    expect(rimTree.scale!).toBeLessThan(heartTree.scale!)
+    expect(rimTree.brightness!).toBeGreaterThan(heartTree.brightness!)
+  })
+
+  it("lets a big old-growth oak hold more ground than a rim oak", () => {
+    const oak = TREE_SPECIES.oak
+    expect(requiredSpacing(oak, DARK_HEIGHT_SCALE, oak, DARK_HEIGHT_SCALE)).toBeGreaterThan(
+      requiredSpacing(oak, 0.7, oak, 0.7),
+    )
+    // The larger footprint wins between neighbours of different kinds.
+    const birch = TREE_SPECIES.birch
+    expect(requiredSpacing(oak, 1, birch, 1)).toBe(oak.habitat.footprint)
+    expect(requiredSpacing(birch, 1, oak, 1)).toBe(oak.habitat.footprint)
+  })
+
+  it("keeps every default footprint inside the room check's reach, even grown", () => {
+    for (const id of TREE_SPECIES_ORDER) {
+      expect(TREE_SPECIES[id].habitat.footprint * DARK_HEIGHT_SCALE).toBeLessThanOrEqual(MAX_FOOTPRINT)
+    }
+  })
+
+  it("packs old growth denser than ordinary woods of the same kind", () => {
+    const dark = placeTrees(woodsBlock(40, 11, "D"), only("birch"))
+    const light = placeTrees(woodsBlock(40, 11, "F"), only("birch"))
+    expect(dark.length).toBeGreaterThan(light.length)
+    expect(Math.max(...dark.map((t) => t.scale ?? 1))).toBeGreaterThan(1.2)
+  })
+})

--- a/lib/game/trees/placement.ts
+++ b/lib/game/trees/placement.ts
@@ -1,0 +1,177 @@
+import { computeDarkShade, computeForestShade } from "../map/forest-field"
+import { isWoods, TILE_HEIGHT } from "../map/terrain"
+import { tileAt, tileToWorldX, tileToWorldZ, type GameMap } from "../map/types"
+import { deriveSeed, makeRng, SEED_STREAM } from "../rng"
+import { pickSpecies, type TreeSpeciesDef, type TreeSpeciesId } from "./species"
+
+/**
+ * Where the trees stand. Pure data — no three.js, no React — so the stand can
+ * be unit-tested; `Trees` in components/game renders what this returns.
+ *
+ * Every woods tile is offered a few *slots*: one at the forest rim, up to
+ * three at its heart (dark forest starts at two). Each slot draws a species,
+ * weighted by habitat and grove, and then has to earn its place:
+ *
+ *  - Density. A species has a per-tile cap. Oak and beech get a tile to
+ *    themselves; birch, hawthorn and holly crowd two or three to a tile. A
+ *    slot whose species is already at its cap on this tile is dropped, which
+ *    is what keeps a pure beech stand open under its big crowns while a birch
+ *    drift packs tight.
+ *  - Footprint. Every tree claims a radius around its trunk where no other
+ *    trunk may stand; between two neighbours the larger footprint wins. The
+ *    footprint scales with the individual, so old growth holds more ground
+ *    and the shrunken trees of the rim can stand closer. A slot tries a few
+ *    spots on its tile and is dropped if none has room.
+ *
+ * Trees still overlap crowns — that is a closed canopy — but no two trunks
+ * ever stand inside one another's footprint, so each tree reads as a tree.
+ *
+ * The stand fades at its rim: the outermost trees are a little shorter and
+ * lighter, following the forest-shade field the ground colour also reads, so
+ * the woods taper into grassland instead of stopping at a wall. Old growth
+ * runs the other way — taller and darker — and the dark-shade field feathers
+ * that into the woods around it so the heart of a forest never has a hard rim.
+ */
+
+export interface TreePlacement {
+  /** World position of the tree's base. */
+  x: number
+  y: number
+  z: number
+  species: TreeSpeciesId
+  /** Whole-tree size multiplier; edge trees are smaller. Defaults to 1. */
+  scale?: number
+  /** Brightness multiplier on bark and foliage; edge trees are lighter. Defaults to 1. */
+  brightness?: number
+}
+
+/** Edge trees scale down to this fraction of a core tree's size. */
+export const EDGE_SIZE_SCALE = 0.7
+
+/** Old growth stands this much taller than the woods around it, at full dark shade. */
+export const DARK_HEIGHT_SCALE = 1.45
+/** And this much darker. */
+export const DARK_BRIGHTNESS = 0.6
+
+/** Slots a tile is offered, at most. Species caps and footprints prune from here. */
+export const MAX_TREES_PER_TILE = 3
+/** Chance of each extra slot at the very heart of the woods; fades to 0 at the rim. */
+export const EXTRA_SLOT_CHANCE = 0.5
+
+/**
+ * Largest footprint the placement can honour, in tiles, after scaling by the
+ * individual. Room is checked against the 3 × 3 tiles around a slot, and a
+ * trunk two tiles over is at least this far away.
+ */
+export const MAX_FOOTPRINT = 1.2
+
+/** Trunks scatter across this much of the tile so a full tile reads as trees, not a lattice. */
+const SCATTER = 0.8
+/** Spots a slot tries before giving up on a crowded tile. */
+const PLACE_ATTEMPTS = 6
+
+/** Woods tiles that touch open ground; the map edge does not count. */
+export function isForestEdge(map: GameMap, x: number, z: number): boolean {
+  for (const [dx, dz] of [
+    [1, 0],
+    [-1, 0],
+    [0, 1],
+    [0, -1],
+  ]) {
+    const neighbour = tileAt(map, x + dx, z + dz)
+    if (neighbour !== null && !isWoods(neighbour)) return true
+  }
+  return false
+}
+
+/** The distance two trunks must keep: the larger of the two footprints, as grown. */
+export function requiredSpacing(
+  a: TreeSpeciesDef,
+  aScale: number,
+  b: TreeSpeciesDef,
+  bScale: number,
+): number {
+  return Math.max(a.habitat.footprint * aScale, b.habitat.footprint * bScale)
+}
+
+export function placeTrees(
+  map: GameMap,
+  species: Record<TreeSpeciesId, TreeSpeciesDef>,
+): TreePlacement[] {
+  const seed = map.seed ?? 0
+  const shade = computeForestShade(map)
+  const darkShade = computeDarkShade(map)
+  // Slot counts get their own stream so species and jitter (from the `trees`
+  // stream) stay independent of the coin flips.
+  const rngCount = makeRng(deriveSeed(seed, SEED_STREAM.treeCount))
+  const rng = makeRng(deriveSeed(seed, SEED_STREAM.trees))
+
+  const out: TreePlacement[] = []
+  // Indices into `out` of the trees on each tile, for the cap and the room check.
+  const byTile: (number[] | undefined)[] = new Array(map.width * map.depth)
+
+  const hasRoom = (px: number, pz: number, def: TreeSpeciesDef, scale: number, x: number, z: number) => {
+    for (let dz = -1; dz <= 1; dz++) {
+      for (let dx = -1; dx <= 1; dx++) {
+        const nx = x + dx
+        const nz = z + dz
+        if (nx < 0 || nz < 0 || nx >= map.width || nz >= map.depth) continue
+        const near = byTile[nz * map.width + nx]
+        if (!near) continue
+        for (const i of near) {
+          const other = out[i]
+          const gap = requiredSpacing(def, scale, species[other.species], other.scale ?? 1)
+          if (Math.hypot(other.x - px, other.z - pz) < gap) return false
+        }
+      }
+    }
+    return true
+  }
+
+  for (let z = 0; z < map.depth; z++) {
+    for (let x = 0; x < map.width; x++) {
+      const index = z * map.width + x
+      if (!isWoods(map.tiles[index])) continue
+      const depth = shade[index]
+      const dark = darkShade[index]
+      const oldGrowth = map.tiles[index] === "darkwood"
+
+      // Slots: the rim gets one, the heart up to MAX; old growth starts at two.
+      let slots = oldGrowth ? 2 : 1
+      const chance = EXTRA_SLOT_CHANCE * (oldGrowth ? dark : depth)
+      for (let k = slots; k < MAX_TREES_PER_TILE; k++) if (rngCount() < chance) slots++
+
+      const scale =
+        (EDGE_SIZE_SCALE + (1 - EDGE_SIZE_SCALE) * depth) * (1 + (DARK_HEIGHT_SCALE - 1) * dark)
+      // Edge growth reads younger and sunlit — a touch lighter than the core;
+      // old growth darker still, feathered by the dark shade.
+      const brightness = (1.1 - 0.15 * depth) * (1 - (1 - DARK_BRIGHTNESS) * dark)
+      const site = { x, z, onEdge: isForestEdge(map, x, z), seed }
+      const cx = tileToWorldX(map, x)
+      const cz = tileToWorldZ(map, z)
+
+      for (let t = 0; t < slots; t++) {
+        const id = pickSpecies(species, site, rng)
+        const def = species[id]
+
+        // Density: the tile holds only so many of this species.
+        let here = byTile[index]
+        let same = 0
+        if (here) for (const i of here) if (out[i].species === id) same++
+        if (same >= def.habitat.perTile) continue
+
+        // Footprint: try a few spots; a crowded tile simply loses the slot.
+        for (let attempt = 0; attempt < PLACE_ATTEMPTS; attempt++) {
+          const px = cx + (rng() - 0.5) * SCATTER
+          const pz = cz + (rng() - 0.5) * SCATTER
+          if (!hasRoom(px, pz, def, scale, x, z)) continue
+          if (!here) byTile[index] = here = []
+          here.push(out.length)
+          out.push({ x: px, y: TILE_HEIGHT, z: pz, species: id, scale, brightness })
+          break
+        }
+      }
+    }
+  }
+  return out
+}

--- a/lib/game/trees/species.test.ts
+++ b/lib/game/trees/species.test.ts
@@ -40,7 +40,19 @@ describe("tree species table", () => {
       expect(def.habitat.grouping).toBeGreaterThanOrEqual(0)
       expect(def.habitat.grouping).toBeLessThanOrEqual(1)
       expect(def.habitat.groveSize).toBeGreaterThanOrEqual(1)
+      expect(def.habitat.footprint).toBeGreaterThan(0)
+      expect(Number.isInteger(def.habitat.perTile)).toBe(true)
+      expect(def.habitat.perTile).toBeGreaterThanOrEqual(1)
     }
+  })
+
+  it("gives the big crowns a tile to themselves and lets scrub crowd in", () => {
+    expect(TREE_SPECIES.oak.habitat.perTile).toBe(1)
+    expect(TREE_SPECIES.beech.habitat.perTile).toBe(1)
+    expect(TREE_SPECIES.birch.habitat.perTile).toBeGreaterThan(1)
+    expect(TREE_SPECIES.hawthorn.habitat.perTile).toBeGreaterThan(1)
+    expect(TREE_SPECIES.oak.habitat.footprint).toBeGreaterThan(TREE_SPECIES.birch.habitat.footprint)
+    expect(TREE_SPECIES.beech.habitat.footprint).toBeGreaterThan(TREE_SPECIES.hawthorn.habitat.footprint)
   })
 
   it("clones deeply so tuning never touches the defaults", () => {

--- a/lib/game/trees/species.ts
+++ b/lib/game/trees/species.ts
@@ -17,6 +17,11 @@
  * out, so the forest reads as birch groves, beech stands and pine patches with
  * mixing along their seams rather than as a uniform salt-and-pepper mix.
  *
+ * Each species also claims ground. A footprint is the radius around a trunk
+ * where no other trunk may stand, and a per-tile cap says how many of the
+ * species fit on one tile: an oak or beech has a tile to itself, while birch
+ * and hawthorn crowd two or three to a tile. See placement.ts for the rules.
+ *
  * Rendering cost is deliberately fixed and low. Every tree is a trunk plus a
  * handful of canopy shapes, each an instance of one tiny shared geometry, so
  * the whole forest is a few instanced draw calls regardless of tree count.
@@ -79,6 +84,14 @@ export interface TreeSpeciesDef {
     grouping: number
     /** Typical grove diameter, in tiles. */
     groveSize: number
+    /**
+     * The ground a tree claims: no other trunk may stand closer than this, in
+     * tiles. Between two neighbours the larger footprint wins, and it scales
+     * with the individual, so old growth holds more ground and rim trees less.
+     */
+    footprint: number
+    /** Most trees of this species one tile can hold: 1 for the big crowns, up to 3 for scrub. */
+    perTile: number
   }
 }
 
@@ -116,7 +129,7 @@ export const TREE_SPECIES: Record<TreeSpeciesId, TreeSpeciesDef> = {
       colorJitter: 0.17,
     },
     // The generalist: everywhere, and the one that fills the seams between groves.
-    habitat: { weight: 0.5, edgeBias: 0.1, grouping: 0.35, groveSize: 9 },
+    habitat: { weight: 0.5, edgeBias: 0.1, grouping: 0.35, groveSize: 9, footprint: 0.7, perTile: 1 },
   },
   beech: {
     id: "beech",
@@ -142,7 +155,7 @@ export const TREE_SPECIES: Record<TreeSpeciesId, TreeSpeciesDef> = {
       colorJitter: 0.14,
     },
     // Beech shades everything else out, so it forms big pure stands.
-    habitat: { weight: 0.8, edgeBias: -0.5, grouping: 0.75, groveSize: 12 },
+    habitat: { weight: 0.8, edgeBias: -0.5, grouping: 0.75, groveSize: 12, footprint: 0.7, perTile: 1 },
   },
   birch: {
     id: "birch",
@@ -168,7 +181,7 @@ export const TREE_SPECIES: Record<TreeSpeciesId, TreeSpeciesDef> = {
       colorJitter: 0.21,
     },
     // Birch seeds in drifts: small tight groves, rarely a lone tree.
-    habitat: { weight: 0.6, edgeBias: 0.8, grouping: 0.9, groveSize: 5 },
+    habitat: { weight: 0.6, edgeBias: 0.8, grouping: 0.9, groveSize: 5, footprint: 0.28, perTile: 3 },
   },
   scotsPine: {
     id: "scotsPine",
@@ -193,7 +206,8 @@ export const TREE_SPECIES: Record<TreeSpeciesId, TreeSpeciesDef> = {
       color: "#2f5030",
       colorJitter: 0.14,
     },
-    habitat: { weight: 0.25, edgeBias: -0.2, grouping: 0.8, groveSize: 8 },
+    // Tall and narrow: pines stand close, but not on top of each other.
+    habitat: { weight: 0.25, edgeBias: -0.2, grouping: 0.8, groveSize: 8, footprint: 0.4, perTile: 2 },
   },
   hawthorn: {
     id: "hawthorn",
@@ -219,7 +233,7 @@ export const TREE_SPECIES: Record<TreeSpeciesId, TreeSpeciesDef> = {
       colorJitter: 0.14,
     },
     // Scrub: strings along edges rather than forming stands.
-    habitat: { weight: 0.45, edgeBias: 0.9, grouping: 0.4, groveSize: 4 },
+    habitat: { weight: 0.45, edgeBias: 0.9, grouping: 0.4, groveSize: 4, footprint: 0.3, perTile: 3 },
   },
   holly: {
     id: "holly",
@@ -244,7 +258,7 @@ export const TREE_SPECIES: Record<TreeSpeciesId, TreeSpeciesDef> = {
       color: "#294a26",
       colorJitter: 0.1,
     },
-    habitat: { weight: 0.35, edgeBias: 0, grouping: 0.5, groveSize: 5 },
+    habitat: { weight: 0.35, edgeBias: 0, grouping: 0.5, groveSize: 5, footprint: 0.3, perTile: 2 },
   },
 }
 


### PR DESCRIPTION
Trees were scattered one or two per tile with no spacing check, so big crowns piled on top of each other in the same tile. Each species now claims ground: a footprint radius no other trunk may enter (the larger of two neighbours' wins, scaled by the individual so old growth holds more and rim trees less) and a per-tile cap, so oak and beech get a tile to themselves while pine and holly allow two and birch and hawthorn three. Placement moves out of the `Trees` component into a pure, tested `lib/game/trees/placement.ts` that offers each woods tile up to three slots and drops any slot that hits its species cap or finds no room. The tree lab gains Footprint and Per tile sliders for tuning the crowding live. Crowns may still close into a canopy, but every tree now reads as its own tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)