### PR TITLE
feat(landing): link the GitHub repo and credit tomjohn in the footer

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -50,8 +50,27 @@ export default function LandingPage() {
         ))}
       </nav>
 
-      <footer className="mt-14 text-center font-display text-[10px] uppercase tracking-[3px] text-gold/60">
-        {CURRENT_VERSION}
+      <footer className="mt-14 flex flex-col items-center gap-3 text-center font-display text-[10px] uppercase tracking-[3px] text-gold/60">
+        <span>{CURRENT_VERSION}</span>
+        <a
+          href="https://github.com/tomjohndesign/pilgrimage"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="transition-colors hover:text-gold"
+        >
+          View the source on GitHub
+        </a>
+        <span>
+          Created by{" "}
+          <a
+            href="https://www.tomjohn.design"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="transition-colors hover:text-gold"
+          >
+            tomjohn
+          </a>
+        </span>
       </footer>
     </main>
   )


### PR DESCRIPTION
Adds two links to the landing page footer beneath the version string: a "View the source on GitHub" link to the repo, and a "Created by tomjohn" credit where the name links to www.tomjohn.design. Both open in a new tab and reuse the footer's existing gold, uppercase, tracked style with a hover brighten. Typecheck passes and the rendered page was checked in the dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)