### PR TITLE
Fix bridge island crossings and grassy paths beside water

### DIFF
--- a/components/game/bridges.tsx
+++ b/components/game/bridges.tsx
@@ -3,7 +3,7 @@
 import { useLayoutEffect, useMemo, useRef } from "react"
 import * as THREE from "three"
 
-import { BRIDGE_RISE, bridgeLayout, type BridgeSpan } from "@/lib/game/map/bridges"
+import { BRIDGE_RISE, bridgeLayout, type BridgeSpan, type BridgeRamp, type BridgeConnector } from "@/lib/game/map/bridges"
 import { clampRoadTier } from "@/lib/game/map/road"
 import { TILE_HEIGHT } from "@/lib/game/map/terrain"
 import { tileToWorldX, tileToWorldZ, type GameMap } from "@/lib/game/map/types"
@@ -12,8 +12,8 @@ import { OUTLINE_ID_LAYER_MASK } from "@/lib/game/render/outline"
 
 /**
  * The bridges: decks floating BRIDGE_RISE above the water on driven piles,
- * reached by the ramps the terrain grows at each end (see terrain-tiles.tsx
- * and lib/game/map/bridges.ts for where those come from).
+ * reached by sloped planks or stone slabs at each end. Small islands carry
+ * the deck through without an intervening dirt platform.
  *
  * What a bridge is built of follows the road. While the road is a dirt trail
  * or gravel, its bridges are timber: planks laid across two stringers, on
@@ -78,6 +78,7 @@ interface Piece {
   y: number
   z: number
   rotY: number
+  rotZ: number
   sx: number
   sy: number
   sz: number
@@ -103,9 +104,7 @@ function spanFrame(map: GameMap, span: BridgeSpan) {
   const last = span.tiles[span.tiles.length - 1]
   const cx = (tileToWorldX(map, first.x) + tileToWorldX(map, last.x)) / 2
   const cz = (tileToWorldZ(map, first.z) + tileToWorldZ(map, last.z)) / 2
-  // A yaw of π/2 maps local +x onto world −z; boxes are symmetric, so the
-  // sign doesn't matter — only that length and width swap axes.
-  const rotY = span.dx !== 0 ? 0 : Math.PI / 2
+  const rotY = Math.atan2(-span.dz, span.dx)
   return (
     along: number,
     across: number,
@@ -119,6 +118,7 @@ function spanFrame(map: GameMap, span: BridgeSpan) {
     y,
     z: cz + span.dz * along + span.dx * across,
     rotY,
+    rotZ: 0,
     sx: length,
     sy: height,
     sz: width,
@@ -212,14 +212,101 @@ function stoneBridge(map: GameMap, span: BridgeSpan, tier: number, rng: () => nu
   }
 }
 
+/** A deck over a small island, with openings wherever another deck meets it. */
+function islandDeck(map: GameMap, tile: BridgeConnector, tier: number, rng: () => number, out: Pieces): void {
+  const place = spanFrame(map, { tiles: [tile], dx: 1, dz: 0, from: null, to: null, kind: tile.kind })
+  const timber = tile.kind === "track" || tier <= LAST_TIMBER_TIER
+  const color = new THREE.Color(timber ? PLANK_COLOR : (STONE[tier] ?? STONE[3]).slab)
+  const thickness = timber ? PLANK_THICKNESS : SLAB_THICKNESS
+  // Reach every connected tile edge; straight islands keep the span width.
+  const deckWidth = timber ? DECK_WIDTH : SLAB_WIDTH
+  const length = tile.open[0] || tile.open[1] ? 1 : deckWidth
+  const width = tile.open[2] || tile.open[3] ? 1 : deckWidth
+  const slab = place(0, 0, DECK_TOP - thickness / 2, length, thickness, width, color)
+  out.boxes.push(slab)
+  out.silhouettes.push({ ...slab })
+  if (timber) {
+    for (let k = 0; k < 5; k++) {
+      color.set(PLANK_COLOR).multiplyScalar(1 + (rng() - 0.5) * WOOD_GRAIN)
+      out.boxes.push(place((-0.4 + k * 0.2) * length, 0, DECK_TOP - PLANK_THICKNESS / 2,
+        PLANK_LENGTH * length, PLANK_THICKNESS, width, color))
+    }
+    // Recess the backing so the gaps between boards read as timber seams.
+    slab.y -= PLANK_THICKNESS
+  }
+  const dirs = [[1, 0], [-1, 0], [0, 1], [0, -1]] as const
+  dirs.forEach(([dx, dz], side) => {
+    if (tile.open[side]) return
+    const inset = timber ? POST_RADIUS : PARAPET_WIDTH / 2
+    const rail = place(dx * (length / 2 - inset), dz * (width / 2 - inset),
+      DECK_TOP + (timber ? POST_HEIGHT - RAIL_SIZE / 2 : PARAPET_HEIGHT / 2),
+      dx ? (timber ? RAIL_SIZE : PARAPET_WIDTH) : length, timber ? RAIL_SIZE : PARAPET_HEIGHT,
+      dz ? (timber ? RAIL_SIZE : PARAPET_WIDTH) : width, color.set(timber ? POST_COLOR : (STONE[tier] ?? STONE[3]).slab))
+    out.boxes.push(rail)
+    if (timber) {
+      for (const end of [-0.5, 0.5]) {
+        out.posts.push(place(dx ? dx * (length / 2 - inset) : end * length, dz ? dz * (width / 2 - inset) : end * width,
+          DECK_TOP + POST_HEIGHT / 2, POST_RADIUS, POST_HEIGHT, POST_RADIUS, color))
+      }
+    }
+  })
+}
+
+/** Sloped planks/slabs use the same material and surface height as their deck. */
+function bridgeApproach(map: GameMap, ramp: BridgeRamp, tier: number, rng: () => number, out: Pieces): void {
+  const place = spanFrame(map, { tiles: [ramp], dx: ramp.dx, dz: ramp.dz, from: null, to: null, kind: ramp.kind })
+  const timber = ramp.kind === "track" || tier <= LAST_TIMBER_TIER
+  const color = new THREE.Color()
+  const slope = Math.atan(BRIDGE_RISE)
+  const stretch = Math.hypot(1, BRIDGE_RISE)
+  const width = timber ? DECK_WIDTH : SLAB_WIDTH
+  const thickness = timber ? PLANK_THICKNESS : SLAB_THICKNESS
+  const surface = (along: number) => TILE_HEIGHT + BRIDGE_RISE * (along + 0.5)
+  const sloped = (along: number, across: number, y: number, length: number, height: number, breadth: number, tint: THREE.Color) => {
+    const piece = place(along, across, y, length * stretch, height, breadth, tint)
+    piece.rotZ = slope
+    return piece
+  }
+  const slab = sloped(0, 0, surface(0) - thickness * stretch / 2,
+    1, thickness, width, color.set(timber ? TIMBER_COLOR : (STONE[tier] ?? STONE[3]).slab))
+  out.boxes.push(slab)
+  out.silhouettes.push({ ...slab })
+  if (timber) {
+    slab.y -= PLANK_THICKNESS * stretch
+    for (let k = 0; k < 5; k++) {
+      const along = -0.4 + k * 0.2
+      color.set(PLANK_COLOR).multiplyScalar(1 + (rng() - 0.5) * WOOD_GRAIN)
+      out.boxes.push(sloped(along, 0, surface(along) - PLANK_THICKNESS * stretch / 2,
+        PLANK_LENGTH, PLANK_THICKNESS, width, color))
+    }
+  }
+  for (const side of [-1, 1]) {
+    const across = side * (width / 2 - (timber ? POST_RADIUS : PARAPET_WIDTH / 2))
+    const railHeight = timber ? RAIL_SIZE : PARAPET_HEIGHT
+    const railY = timber ? POST_HEIGHT - RAIL_SIZE / 2 : PARAPET_HEIGHT / 2
+    out.boxes.push(sloped(0, across, surface(0) + railY, 1, railHeight,
+      timber ? RAIL_SIZE : PARAPET_WIDTH, color.set(timber ? POST_COLOR : (STONE[tier] ?? STONE[3]).slab)))
+    if (timber) {
+      for (const along of [-0.5, 0.5]) {
+        const top = surface(along) + POST_HEIGHT
+        out.posts.push(place(along, across, (TILE_HEIGHT + top) / 2,
+          POST_RADIUS, top - TILE_HEIGHT, POST_RADIUS, color))
+      }
+    }
+  }
+}
+
 function buildPieces(map: GameMap, tier: number): Pieces {
   const out: Pieces = { boxes: [], posts: [], silhouettes: [] }
   const rng = makeRng(deriveSeed(map.seed ?? 0, SEED_STREAM.bridgeGrain))
-  for (const span of bridgeLayout(map).spans) {
+  const layout = bridgeLayout(map)
+  for (const span of layout.spans) {
     const timber = span.kind === "track" || tier <= LAST_TIMBER_TIER
     if (timber) timberBridge(map, span, rng, out)
     else stoneBridge(map, span, tier, rng, out)
   }
+  for (const tile of layout.connectors) islandDeck(map, tile, tier, rng, out)
+  for (const ramp of layout.ramps) bridgeApproach(map, ramp, tier, rng, out)
   return out
 }
 
@@ -243,11 +330,12 @@ function PieceBatch({
     const position = new THREE.Vector3()
     const quaternion = new THREE.Quaternion()
     const scale = new THREE.Vector3()
-    const up = new THREE.Vector3(0, 1, 0)
+    const rotation = new THREE.Euler(0, 0, 0, "YXZ")
     const color = new THREE.Color()
     pieces.forEach((piece, i) => {
       position.set(piece.x, piece.y, piece.z)
-      quaternion.setFromAxisAngle(up, piece.rotY)
+      rotation.set(0, piece.rotY, piece.rotZ, "YXZ")
+      quaternion.setFromEuler(rotation)
       scale.set(piece.sx, piece.sy, piece.sz)
       matrix.compose(position, quaternion, scale)
       mesh.setMatrixAt(i, matrix)

--- a/components/game/terrain-tiles.tsx
+++ b/components/game/terrain-tiles.tsx
@@ -5,7 +5,7 @@ import { useLoader, useThree } from "@react-three/fiber"
 import * as THREE from "three"
 
 import { deriveSeed, makeRng, SEED_STREAM } from "@/lib/game/rng"
-import { BRIDGE_RISE, bridgeLayout, type BridgeRamp } from "@/lib/game/map/bridges"
+import { bridgeLayout } from "@/lib/game/map/bridges"
 import { computeDarkShade, computeForestShade } from "@/lib/game/map/forest-field"
 import {
   clampRoadTier,
@@ -153,8 +153,7 @@ interface TileMaterialOptions {
  *
  * With `road` set, the tile is first painted as the land it sits in, exactly
  * as the ground mesh would have painted it: the grass texture under
- * `aLandOverlay` with the grain in `aLandJitter`, or the flat land colour in
- * `aVergeColor` (its `w` is how much of it is sward). The road surface is
+ * `aLandOverlay` with the grain in `aLand`. The road surface is
  * then laid over that — the tier texture by its alpha, the shade ramp on it
  * through `aOverlay`, the instance colour (the weathering tint, see
  * roadTint, and the grain) multiplied in. Only the road proper takes that
@@ -201,11 +200,9 @@ function makeTileMaterial({
         varying vec4 vOverlay;
         #ifdef USE_ROAD_MAP
           attribute vec4 aRoadOpen;
-          attribute vec4 aVergeColor;
           attribute vec4 aLandOverlay;
           attribute vec3 aLand;
           varying vec4 vRoadOpen;
-          varying vec4 vVergeColor;
           varying vec4 vLandOverlay;
           varying vec3 vLand;
           varying vec2 vTileLocal;
@@ -227,11 +224,9 @@ function makeTileMaterial({
           vOverlay = aOverlay;
           #ifdef USE_ROAD_MAP
             vRoadOpen = aRoadOpen;
-            vVergeColor = aVergeColor;
             vLandOverlay = aLandOverlay;
             vLand = aLand;
-            // Tile-local XZ in *world* axes, so an instance yawed to face
-            // its bridge (a ramp) still lines its edge data up with the map.
+            // Tile-local XZ in world axes, matching the road edge flags.
             #ifdef USE_INSTANCING
               vTileLocal = (instanceMatrix * vec4(position.x, 0.0, position.z, 0.0)).xz + 0.5;
             #else
@@ -258,7 +253,6 @@ function makeTileMaterial({
           uniform float roadEdgeWidth;
           uniform float roadPixelRatio;
           varying vec4 vRoadOpen;
-          varying vec4 vVergeColor;
           varying vec4 vLandOverlay;
           varying vec3 vLand;
           varying vec2 vTileLocal;
@@ -297,8 +291,7 @@ function makeTileMaterial({
           vec2 world = vWorld;
           vec3 grassColor = sampleTiled(grassMap, world * ${GRASS_UV_SCALE}, world).rgb;
           #ifdef USE_ROAD_MAP
-            // The land this tile is, as the ground mesh paints it — sward
-            // (texture, overlay, grain) or flat colour — untouched by the
+            // Grass (texture, overlay, grain), untouched by the
             // road's tint, so it matches the tiles alongside exactly.
             // vLand packs the land's grain and the rut's outer and inner
             // edges (see roadWear).
@@ -306,13 +299,18 @@ function makeTileMaterial({
             float vEdge = vLand.y;
             float vInner = vLand.z;
             vec3 sward = mix(grassColor, vLandOverlay.rgb, vLandOverlay.a) * landJitter;
-            vec3 flatLand = vVergeColor.rgb * (0.85 + 0.3 * tileNoise(world * 9.1)) * landJitter;
-            vec3 landTop = mix(flatLand, sward, vVergeColor.w);
+            vec3 landTop = sward;
 
             // The road proper: the tier texture, shaded, the shade ramp at
             // the road's own blend, then the weathering tint and grain.
             vec4 roadTex = sampleTiled(roadMap, world * ${ROAD_UV_SCALE}, world);
-            vec3 road = mix(roadTex.rgb * roadShade, vOverlay.rgb, vOverlay.a) * vColor.rgb;
+            // Empty road batches have no instance colours (all paths may
+            // be covered by bridges), but their shader must still compile.
+            vec3 roadColor = vec3(1.0);
+            #if defined(USE_COLOR) || defined(USE_COLOR_ALPHA)
+              roadColor = vColor.rgb;
+            #endif
+            vec3 road = mix(roadTex.rgb * roadShade, vOverlay.rgb, vOverlay.a) * roadColor;
 
             // Distance in from the nearest open side of this road tile (1.0
             // with none open: a junction, road on every side).
@@ -351,7 +349,7 @@ function makeTileMaterial({
             float line = (1.0 - smoothstep(halfLine - 0.5 * px, halfLine + 0.5 * px, abs(d - edge))) * roadEdgeLine;
 
             vec3 top = mix(landTop, road, cover) * (1.0 - 0.75 * line * roadOpacity);
-            vec3 surface = mix(${ROAD_SIDE_COLOR} * vColor.rgb, top, vGridTop);
+            vec3 surface = mix(${ROAD_SIDE_COLOR} * roadColor, top, vGridTop);
             diffuseColor.rgb *= surface;
           #else
             // Sward tiles: the texture on top, the flat grass colour on the
@@ -387,7 +385,7 @@ function makeTileMaterial({
  * Attach the per-instance data makeTileMaterial reads: `aGrass` and
  * `aOverlay` on every tile. A road geometry also carries which sides face
  * open land, where traffic puts the rut edges, and what the land here looks
- * like (flat colour, sward overlay, grain, share of sward).
+ * like (grass overlay and grain).
  */
 function addTileAttributes(geometry: THREE.BufferGeometry, slots: number, road: boolean): void {
   const n = Math.max(1, slots)
@@ -395,7 +393,6 @@ function addTileAttributes(geometry: THREE.BufferGeometry, slots: number, road: 
   geometry.setAttribute("aOverlay", new THREE.InstancedBufferAttribute(new Float32Array(n * 4), 4))
   if (road) {
     geometry.setAttribute("aRoadOpen", new THREE.InstancedBufferAttribute(new Float32Array(n * 4), 4))
-    geometry.setAttribute("aVergeColor", new THREE.InstancedBufferAttribute(new Float32Array(n * 4), 4))
     geometry.setAttribute("aLandOverlay", new THREE.InstancedBufferAttribute(new Float32Array(n * 4), 4))
     // Grain and the two rut edges packed together: vertex attributes are a
     // scarce resource (16 is a common limit) and the instance matrix alone
@@ -407,26 +404,6 @@ function addTileAttributes(geometry: THREE.BufferGeometry, slots: number, road: 
 /** Unit box for flat tiles, with the per-instance tile data. */
 function makeTileGeometry(slots: number, road = false): THREE.BoxGeometry {
   const geometry = new THREE.BoxGeometry(1, 1, 1)
-  addTileAttributes(geometry, slots, road)
-  return geometry
-}
-
-/**
- * The ramp up onto a bridge: a tile-sized wedge with its base on y=0, rising
- * from ground level at its -x edge to deck level at its +x edge; instances
- * are yawed to face their bridge. Every face stays planar, so the box's
- * per-face normals recompute cleanly, and the sloped top still counts as a
- * top face in the shader (its normal is well above the 0.5 cut-off).
- */
-function makeRampGeometry(slots = 0, road = false): THREE.BoxGeometry {
-  const geometry = new THREE.BoxGeometry(1, 1, 1)
-  const position = geometry.getAttribute("position") as THREE.BufferAttribute
-  for (let i = 0; i < position.count; i++) {
-    const top = position.getY(i) > 0
-    position.setY(i, top ? TILE_HEIGHT + BRIDGE_RISE * (position.getX(i) + 0.5) : 0)
-  }
-  position.needsUpdate = true
-  geometry.computeVertexNormals()
   addTileAttributes(geometry, slots, road)
   return geometry
 }
@@ -568,16 +545,17 @@ export function TerrainTiles({
 }) {
   const groundMeshRef = useRef<THREE.InstancedMesh>(null)
   const roadMeshRef = useRef<THREE.InstancedMesh>(null)
-  const groundRampMeshRef = useRef<THREE.InstancedMesh>(null)
-  const roadRampMeshRef = useRef<THREE.InstancedMesh>(null)
   const idMeshRef = useRef<THREE.InstancedMesh>(null)
-  const idRampMeshRef = useRef<THREE.InstancedMesh>(null)
   const count = map.width * map.depth
 
+  const bridges = useMemo(() => bridgeLayout(map), [map])
+  const coveredLand = useMemo(() => new Set([
+    ...bridges.connectors, ...bridges.ramps,
+  ].map((tile) => tile.z * map.width + tile.x)), [bridges, map.width])
   const tier = ROAD_TIERS[clampRoadTier(roadTier)]
   const roadCount = useMemo(
-    () => map.tiles.reduce((n, t) => (isRoadTerrain(t) ? n + 1 : n), 0),
-    [map],
+    () => map.tiles.reduce((n, t, i) => (isRoadTerrain(t) && !coveredLand.has(i) ? n + 1 : n), 0),
+    [map, coveredLand],
   )
 
   // The look is uniforms shared with the material: tuned in place, no recompile.
@@ -646,80 +624,40 @@ export function TerrainTiles({
   const roadGeometry = useMemo(() => makeTileGeometry(roadCount, true), [roadCount])
   useEffect(() => () => roadGeometry.dispose(), [roadGeometry])
 
-  // Bridge approaches wear the same materials on wedge geometry: one
-  // instanced mesh per material, drawn over the flat tile beneath, which the
-  // wedge hides entirely (they meet only along the far edge). The ground
-  // rises there; the decks themselves are their own component (bridges.tsx).
-  const bridges = useMemo(() => bridgeLayout(map), [map])
-  const rampAt = useMemo(() => {
-    const at = new Map<number, BridgeRamp>()
-    for (const ramp of bridges.ramps) at.set(ramp.z * map.width + ramp.x, ramp)
-    return at
-  }, [bridges, map.width])
-  const plateaus = useMemo(
-    () => new Set(bridges.plateaus.map((p) => p.z * map.width + p.x)),
-    [bridges, map.width],
-  )
-  const roadRampCount = useMemo(
-    () =>
-      bridges.ramps.reduce(
-        (n, r) => (isRoadTerrain(map.tiles[r.z * map.width + r.x]) ? n + 1 : n),
-        0,
-      ),
-    [bridges, map],
-  )
-  const groundRampCount = bridges.ramps.length - roadRampCount
-  const roadRampGeometry = useMemo(() => makeRampGeometry(roadRampCount, true), [roadRampCount])
-  useEffect(() => () => roadRampGeometry.dispose(), [roadRampGeometry])
-  const groundRampGeometry = useMemo(() => makeRampGeometry(groundRampCount), [groundRampCount])
-  useEffect(() => () => groundRampGeometry.dispose(), [groundRampGeometry])
-  const idRampGeometry = useMemo(() => makeRampGeometry(), [])
-  useEffect(() => () => idRampGeometry.dispose(), [idRampGeometry])
-
   useLayoutEffect(() => {
     const groundMesh = groundMeshRef.current
     const roadMesh = roadMeshRef.current
-    const groundRampMesh = groundRampMeshRef.current
-    const roadRampMesh = roadRampMeshRef.current
     const idMesh = idMeshRef.current
-    const idRampMesh = idRampMeshRef.current
-    if (!groundMesh || !roadMesh || !groundRampMesh || !roadRampMesh || !idMesh || !idRampMesh) {
+    if (!groundMesh || !roadMesh || !idMesh) {
       return
     }
 
     const matrix = new THREE.Matrix4()
-    const rampMatrix = new THREE.Matrix4()
     const position = new THREE.Vector3()
     const quaternion = new THREE.Quaternion()
-    const rampQuaternion = new THREE.Quaternion()
     const scale = new THREE.Vector3()
-    const unit = new THREE.Vector3(1, 1, 1)
-    const up = new THREE.Vector3(0, 1, 0)
     const color = new THREE.Color()
     const tint = new THREE.Color()
     const neighbourTint = new THREE.Color()
     const land: LandPaint = { sward: false, color: new THREE.Color(), overlay: new THREE.Vector4() }
     const landOverlay = new THREE.Vector4()
-    const vergeFlat = new THREE.Color()
 
-    // Every tile writes to the flat mesh for its material; a bridge approach
-    // writes the same data to that material's ramp mesh as well.
+    // Each tile writes to its flat ground material; bridge surfaces sit above it.
     const attr = (geometry: THREE.BufferGeometry, name: string) =>
       geometry.getAttribute(name) as THREE.InstancedBufferAttribute
-    const roadTargets = [roadMesh, roadRampMesh].map((mesh, i) => {
-      const geometry = i === 0 ? roadGeometry : roadRampGeometry
+    const roadTargets = [roadMesh].map((mesh) => {
+      const geometry = roadGeometry
       return {
         mesh,
         next: 0,
         open: attr(geometry, "aRoadOpen"),
-        verge: attr(geometry, "aVergeColor"),
         landOverlay: attr(geometry, "aLandOverlay"),
         land: attr(geometry, "aLand"),
         overlay: attr(geometry, "aOverlay"),
       }
     })
-    const groundTargets = [groundMesh, groundRampMesh].map((mesh, i) => {
-      const geometry = i === 0 ? groundGeometry : groundRampGeometry
+    const groundTargets = [groundMesh].map((mesh) => {
+      const geometry = groundGeometry
       return {
         mesh,
         next: 0,
@@ -727,7 +665,6 @@ export function TerrainTiles({
         overlay: attr(geometry, "aOverlay"),
       }
     })
-    const RAMP = 1
 
     const roadWearBy = roadWear(traffic, tier.tier)
     const trackWearBy = roadWear(relicTraffic, tier.tier)
@@ -740,11 +677,10 @@ export function TerrainTiles({
     const shadeTint = (index: number, out: THREE.Color) =>
       out.copy(OPEN_MEADOW_TINT).lerp(DEEP_WOOD_TINT, shade[index])
 
-    let rampIndex = 0
     for (let z = 0; z < map.depth; z++) {
       for (let x = 0; x < map.width; x++) {
         const index = z * map.width + x
-        const terrain = map.tiles[index]
+        const terrain = coveredLand.has(index) ? "grass" : map.tiles[index]
         // A bridge tile draws the water still running beneath it (see paintLand).
         const def = TERRAIN[terrain === "bridge" ? "water" : terrain]
         const grain = rng() - 0.5
@@ -753,9 +689,7 @@ export function TerrainTiles({
         // road, and the track cut through it alike; feathered so it has no
         // hard rim.
         const canopy = 1 - DARK_WOOD_DARKEN * darkShade[index]
-        const ramp = rampAt.get(index)
-        // A causeway between two spans stands level at deck height.
-        const height = plateaus.has(index) ? TILE_HEIGHT + BRIDGE_RISE : TILE_HEIGHT
+        const height = TILE_HEIGHT
 
         // Box base sits at y=0 and the top at the shared tile height, so tiles
         // sink into the slab and never show a gap from a low camera angle.
@@ -767,16 +701,6 @@ export function TerrainTiles({
         matrix.compose(position, quaternion, scale)
         idMesh.setMatrixAt(index, matrix)
 
-        if (ramp) {
-          // The wedge climbs along its local +x; yaw that onto the uphill
-          // direction. A yaw of θ maps +x to (cos θ, 0, −sin θ), hence −dz.
-          rampQuaternion.setFromAxisAngle(up, Math.atan2(-ramp.dz, ramp.dx))
-          position.y = 0
-          rampMatrix.compose(position, rampQuaternion, unit)
-          idRampMesh.setMatrixAt(rampIndex++, rampMatrix)
-        }
-        const targets = ramp ? 2 : 1
-
         // Where this tile sits on the forest-shade ramp.
         shadeTint(index, tint)
 
@@ -787,18 +711,11 @@ export function TerrainTiles({
           color.setRGB(r, g, b, THREE.SRGBColorSpace)
           color.multiplyScalar(jitter * canopy)
 
-          // The land this tile would be, painted as the ground mesh would
-          // paint it: the sward overlay averaged over every surrounding sward
-          // tile, the flat colour averaged over the open sides that face flat
-          // ground. Sward is the default with no sward around, so a road
-          // through bare earth still greens as meadow. The road runs on over
-          // a bridge, so a deck beside this tile is not land.
+          // Paths always sit on grass. Borrow only surrounding grass tints;
+          // water, sand, and bare earth must never replace the grassy base.
           const edge = roadEdge(map, x, z)
           landOverlay.set(0, 0, 0, 0)
-          vergeFlat.setRGB(0, 0, 0)
           let swardAround = 0
-          let openCount = 0
-          let openSward = 0
           for (let side = 0; side < AROUND.length; side++) {
             const [dx, dz] = AROUND[side]
             const neighbour = tileAt(map, x + dx, z + dz)
@@ -810,31 +727,22 @@ export function TerrainTiles({
               landOverlay.add(land.overlay)
               swardAround++
             }
-            if (side < 4) {
-              openCount++
-              if (land.sward) openSward++
-              else vergeFlat.add(land.color)
-            }
           }
           if (swardAround > 0) landOverlay.divideScalar(swardAround)
           else landOverlay.copy(paintLand(map, "grass", x, z, tint, land).overlay)
-          const openFlat = openCount - openSward
-          if (openFlat > 0) vergeFlat.multiplyScalar(1 / openFlat)
-          const vergeSward = openCount > 0 ? openSward / openCount : 1
           // The grain a land tile here would have had, from the same draw
           // (under the same canopy), and the rut edges for this road's own
           // traffic.
           const wear = terrain === "track" ? trackWearBy : roadWearBy
           const landJitter = (1 + grain * TERRAIN.grass.jitter) * canopy
 
-          for (let t = 0; t < targets; t++) {
-            const target = roadTargets[t]
+          {
+            const target = roadTargets[0]
             const i = target.next++
-            target.mesh.setMatrixAt(i, t === RAMP ? rampMatrix : matrix)
+            target.mesh.setMatrixAt(i, matrix)
             target.mesh.setColorAt(i, color)
             target.overlay.setXYZW(i, tint.r, tint.g, tint.b, def.shadeBlend)
             target.open.setXYZW(i, edge.open[0], edge.open[1], edge.open[2], edge.open[3])
-            target.verge.setXYZW(i, vergeFlat.r, vergeFlat.g, vergeFlat.b, vergeSward)
             target.landOverlay.setXYZW(i, landOverlay.x, landOverlay.y, landOverlay.z, landOverlay.w)
             target.land.setXYZ(i, landJitter, wear.edge, wear.inner)
           }
@@ -843,10 +751,10 @@ export function TerrainTiles({
 
         paintLand(map, terrain, x, z, tint, land)
         color.copy(land.color).multiplyScalar(jitter * canopy)
-        for (let t = 0; t < targets; t++) {
-          const target = groundTargets[t]
+        {
+          const target = groundTargets[0]
           const i = target.next++
-          target.mesh.setMatrixAt(i, t === RAMP ? rampMatrix : matrix)
+          target.mesh.setMatrixAt(i, matrix)
           target.mesh.setColorAt(i, color)
           target.grass.setX(i, land.sward ? 1 : 0)
           target.overlay.setXYZW(i, land.overlay.x, land.overlay.y, land.overlay.z, land.overlay.w)
@@ -858,7 +766,6 @@ export function TerrainTiles({
       target.mesh.instanceMatrix.needsUpdate = true
       if (target.mesh.instanceColor) target.mesh.instanceColor.needsUpdate = true
       target.open.needsUpdate = true
-      target.verge.needsUpdate = true
       target.landOverlay.needsUpdate = true
       target.land.needsUpdate = true
       target.overlay.needsUpdate = true
@@ -870,7 +777,6 @@ export function TerrainTiles({
       target.overlay.needsUpdate = true
     }
     idMesh.instanceMatrix.needsUpdate = true
-    idRampMesh.instanceMatrix.needsUpdate = true
   }, [
     map,
     tier,
@@ -878,10 +784,7 @@ export function TerrainTiles({
     relicTraffic,
     roadGeometry,
     groundGeometry,
-    roadRampGeometry,
-    groundRampGeometry,
-    rampAt,
-    plateaus,
+    coveredLand,
   ])
 
   const dirt = useLoader(THREE.TextureLoader, DIRT_TEXTURE_URL)
@@ -931,25 +834,6 @@ export function TerrainTiles({
         <primitive object={roadMaterial} attach="material" />
       </instancedMesh>
 
-      {/* Ramps up onto the bridges, in whichever material their tile wears. */}
-      <instancedMesh
-        ref={groundRampMeshRef}
-        frustumCulled={false}
-        args={[undefined as unknown as THREE.BufferGeometry, undefined as unknown as THREE.Material, groundRampCount]}
-      >
-        <primitive object={groundRampGeometry} attach="geometry" />
-        <primitive object={groundMaterial} attach="material" />
-      </instancedMesh>
-      <instancedMesh
-        ref={roadRampMeshRef}
-        key={`ramp-${tier.id}`}
-        frustumCulled={false}
-        args={[undefined as unknown as THREE.BufferGeometry, undefined as unknown as THREE.Material, roadRampCount]}
-      >
-        <primitive object={roadRampGeometry} attach="geometry" />
-        <primitive object={roadMaterial} attach="material" />
-      </instancedMesh>
-
       {/*
         Terrain in the outline pass: ID 0 (black), depth only. It takes no
         outline itself, but its depth stops hidden object seams — say two
@@ -965,15 +849,6 @@ export function TerrainTiles({
         layers-mask={OUTLINE_ID_LAYER_MASK}
       >
         <boxGeometry args={[1, 1, 1]} />
-        <meshBasicMaterial color="black" toneMapped={false} />
-      </instancedMesh>
-      <instancedMesh
-        ref={idRampMeshRef}
-        frustumCulled={false}
-        args={[undefined as unknown as THREE.BufferGeometry, undefined as unknown as THREE.Material, bridges.ramps.length]}
-        layers-mask={OUTLINE_ID_LAYER_MASK}
-      >
-        <primitive object={idRampGeometry} attach="geometry" />
         <meshBasicMaterial color="black" toneMapped={false} />
       </instancedMesh>
     </group>

--- a/lib/game/map/bridges.test.ts
+++ b/lib/game/map/bridges.test.ts
@@ -31,12 +31,12 @@ describe("bridgeLayout", () => {
     // Each ramp climbs toward the water.
     expect(layout.ramps).toEqual(
       expect.arrayContaining([
-        { x: 1, z: 2, dx: 1, dz: 0 },
-        { x: 5, z: 2, dx: -1, dz: 0 },
+        { x: 1, z: 2, dx: 1, dz: 0, kind: "road" },
+        { x: 5, z: 2, dx: -1, dz: 0, kind: "road" },
       ]),
     )
     expect(layout.ramps).toHaveLength(2)
-    expect(layout.plateaus).toHaveLength(0)
+    expect(layout.connectors).toHaveLength(0)
   })
 
   it("rises linearly from the road, up the ramp, onto the deck", () => {
@@ -78,23 +78,74 @@ describe("bridgeLayout", () => {
     const [span] = bridgeLayout(map).spans
     expect(span.from).toBeNull()
     expect(span.to).toEqual({ x: 2, z: 0 })
-    expect(bridgeLayout(map).ramps).toEqual([{ x: 2, z: 0, dx: -1, dz: 0 }])
+    expect(bridgeLayout(map).ramps).toEqual([{ x: 2, z: 0, dx: -1, dz: 0, kind: "road" }])
   })
 
-  it("makes a tile between two spans a level causeway, not a ramp", () => {
+  it("continues the deck over a one-tile island without a dirt causeway", () => {
     const map = parseAsciiMap(["=#=#="])
     const layout = bridgeLayout(map)
     expect(layout.spans).toHaveLength(2)
-    expect(layout.plateaus).toEqual([{ x: 2, z: 0 }])
+    expect(layout.connectors).toEqual([{ x: 2, z: 0, kind: "road", open: [true, true, false, false] }])
     expect(layout.ramps.map((r) => r.x).sort()).toEqual([0, 4])
     expect(surfaceHeight(map, 2, 0)).toBeCloseTo(TILE_HEIGHT + BRIDGE_RISE)
+  })
+
+  it.each([1, 2, 3, 4])("requires three dry tiles between ramps (gap %i)", (gap) => {
+    const map = parseAsciiMap(["=##" + "=".repeat(gap) + "##="])
+    const original = [...map.tiles]
+    const layout = bridgeLayout(map)
+    expect(layout.connectors).toHaveLength(gap < 3 ? gap : 0)
+    expect(layout.ramps).toHaveLength(gap < 3 ? 2 : 4)
+    if (gap === 3) expect(surfaceHeight(map, 4, 0)).toBe(TILE_HEIGHT)
+    expect(map.tiles).toEqual(original)
+  })
+
+  it("continues over a two-tile island when the crossing turns", () => {
+    const map = parseAsciiMap([
+      "..=..",
+      "~~#~~",
+      "~~#~~",
+      "~~==~",
+      "~~~#~",
+      "~~~#~",
+      "...=.",
+    ])
+    const layout = bridgeLayout(map)
+    expect(layout.connectors.map(({ x, z }) => ({ x, z }))).toEqual([
+      { x: 2, z: 3 }, { x: 3, z: 3 },
+    ])
+    expect(layout.connectors[0].open).toEqual([true, false, false, true])
+    expect(layout.connectors[1].open).toEqual([false, true, true, false])
+    expect(layout.ramps).toHaveLength(2)
+    for (const tile of layout.connectors) {
+      expect(surfaceHeight(map, tile.x, tile.z)).toBeCloseTo(TILE_HEIGHT + BRIDGE_RISE)
+    }
+  })
+
+  it("keeps a track island and its approaches timber", () => {
+    const layout = bridgeLayout(parseAsciiMap(["-##--##-"]))
+    expect(layout.connectors).toHaveLength(2)
+    expect([...layout.connectors, ...layout.ramps].every((tile) => tile.kind === "track")).toBe(true)
   })
 
   it("does not ramp off water: a span meeting a lake end-on has no approach there", () => {
     const map = parseAsciiMap(["~#="])
     const layout = bridgeLayout(map)
     expect(layout.spans[0].from).toEqual({ x: 0, z: 0 })
-    expect(layout.ramps).toEqual([{ x: 2, z: 0, dx: -1, dz: 0 }])
+    expect(layout.ramps).toEqual([{ x: 2, z: 0, dx: -1, dz: 0, kind: "road" }])
+  })
+
+  it("preserves water and dry island terrain while adding bridge surfaces", () => {
+    const map = parseAsciiMap(["=##==##="])
+    map.water = {
+      depth: [0, 2, 1, 0, 0, 1, 2, 0],
+      flow: { 1: [0, 1], 2: [0, 1], 5: [0, 1], 6: [0, 1] },
+    }
+    const before = structuredClone(map)
+    const layout = bridgeLayout(map)
+    expect(layout.connectors).toHaveLength(2)
+    expect(map).toEqual(before)
+    expect(layout.connectors.every((tile) => map.water!.depth[tile.z * map.width + tile.x] === 0)).toBe(true)
   })
 
   it("is memoised per map", () => {
@@ -115,9 +166,9 @@ describe("bridgeLayout", () => {
           expect(surfaceHeight(map, tile.x, tile.z)).toBeCloseTo(TILE_HEIGHT + BRIDGE_RISE)
         }
       }
-      // Every approach is either a ramp or a causeway, never both.
+      // Island decks never also become ramps.
       const rampKeys = new Set(layout.ramps.map((r) => `${r.x},${r.z}`))
-      for (const p of layout.plateaus) expect(rampKeys.has(`${p.x},${p.z}`)).toBe(false)
+      for (const p of layout.connectors) expect(rampKeys.has(`${p.x},${p.z}`)).toBe(false)
     }
   }, 30_000)
 })

--- a/lib/game/map/bridges.ts
+++ b/lib/game/map/bridges.ts
@@ -1,16 +1,17 @@
+import { isRoadTerrain } from "./road"
 import { TILE_HEIGHT } from "./terrain"
 import { tileAt, type GameMap, type TilePos } from "./types"
 
 /**
- * Where the bridges are and how the ground rises to meet them. Pure data
+ * Where the bridges are and how their approaches rise to meet them. Pure data
  * derived from the tile grid — no three.js, no React — so the renderer, the
  * traveler sim, and anything that stands a figure on a tile all agree on how
  * high the surface is.
  *
  * A bridge is a straight run of `bridge` tiles (the generator guarantees
  * straight, short spans over river water). Its deck floats BRIDGE_RISE above
- * the ground so the water shows beneath it, and the land tile at each end —
- * the approach — is a ramp that climbs from ground level at its far edge to
+ * the ground so the water shows beneath it, and a ramp on the land tile at
+ * each end — the approach — climbs from ground level at its far edge to
  * deck level where it meets the span. Anything walking the road follows the
  * same rise: tile-centre heights interpolate linearly, and the ramp's centre
  * sits at exactly half the rise, so a walker's feet track the wedge.
@@ -18,6 +19,9 @@ import { tileAt, type GameMap, type TilePos } from "./types"
 
 /** How far above the ground a bridge deck sits, in world units. */
 export const BRIDGE_RISE = 0.36
+
+/** Down ramp, level path, and up ramp between separate spans. */
+export const MIN_BRIDGE_LAND_GAP = 3
 
 export interface BridgeSpan {
   /** The bridge tiles in order from `from` to `to`. */
@@ -41,16 +45,20 @@ export interface BridgeSpan {
 export interface BridgeRamp extends TilePos {
   dx: number
   dz: number
+  kind: "road" | "track"
+}
+
+export interface BridgeConnector extends TilePos {
+  kind: "road" | "track"
+  /** Open deck edges in +x, -x, +z, -z order. */
+  open: boolean[]
 }
 
 export interface BridgeLayout {
   spans: BridgeSpan[]
   ramps: BridgeRamp[]
-  /**
-   * Land tiles between two spans, approached from both sides: the ground can't
-   * ramp both ways, so it stands level at deck height as a causeway.
-   */
-  plateaus: TilePos[]
+  /** Wooden/stone deck carried over land gaps shorter than three tiles. */
+  connectors: BridgeConnector[]
   /** Height of the walking surface above TILE_HEIGHT at each tile's centre, by tile index. */
   rise: Float32Array
 }
@@ -95,7 +103,7 @@ function spanAxis(map: GameMap, x: number, z: number): readonly [number, number]
   return best
 }
 
-/** Every bridge on the map, with the ramps and causeways that reach them. */
+/** Every bridge on the map, with the ramps and island decks that reach them. */
 export function bridgeLayout(map: GameMap): BridgeLayout {
   const cached = layoutCache.get(map)
   if (cached) return cached
@@ -103,7 +111,7 @@ export function bridgeLayout(map: GameMap): BridgeLayout {
   const spans: BridgeSpan[] = []
   const seen = new Set<number>()
   // Land tiles that a span launches from or lands on, keyed by tile index.
-  // A tile reached by more than one span becomes a plateau instead of a ramp.
+  // Nearby approaches are joined by decks when there is too little dry land.
   const approaches = new Map<number, BridgeRamp[]>()
 
   for (let z = 0; z < map.depth; z++) {
@@ -144,7 +152,7 @@ export function bridgeLayout(map: GameMap): BridgeLayout {
         if (!tile || isWet(map, tile.x, tile.z)) return
         const key = tile.z * map.width + tile.x
         const list = approaches.get(key) ?? []
-        list.push({ x: tile.x, z: tile.z, dx: ux, dz: uz })
+        list.push({ x: tile.x, z: tile.z, dx: ux, dz: uz, kind })
         approaches.set(key, list)
       }
       approach(from, dx, dz)
@@ -153,23 +161,78 @@ export function bridgeLayout(map: GameMap): BridgeLayout {
     }
   }
 
+  // Search from each bank through at most two path tiles. Three dry tiles
+  // leave room for a down ramp, level path, and an up ramp; shorter gaps
+  // carry the deck straight through, including bends on tiny islands.
+  const dirs = [[1, 0], [-1, 0], [0, 1], [0, -1]] as const
+  const connectorKeys = new Set<number>()
+  const spanAt = new Map<number, number>()
+  spans.forEach((span, id) => {
+    for (const tile of span.tiles) spanAt.set(tile.z * map.width + tile.x, id)
+  })
+  for (const [start, banks] of approaches) {
+    const bank = banks[0]
+    const source = spanAt.get((bank.z + bank.dz) * map.width + bank.x + bank.dx)
+    const visit = (path: number[]) => {
+      const index = path[path.length - 1]
+      const x = index % map.width
+      const z = Math.floor(index / map.width)
+      for (const [dx, dz] of dirs) {
+        const terrain = tileAt(map, x + dx, z + dz)
+        if (terrain === null) continue
+        const next = (z + dz) * map.width + x + dx
+        if (terrain === "bridge" && spanAt.get(next) !== source &&
+          approaches.get(index)?.some((bank) => bank.dx === dx && bank.dz === dz)) {
+          for (const key of path) connectorKeys.add(key)
+        } else if (path.length < MIN_BRIDGE_LAND_GAP - 1 && isRoadTerrain(terrain) && !path.includes(next)) {
+          visit([...path, next])
+        }
+      }
+    }
+    if (isRoadTerrain(map.tiles[start])) visit([start])
+  }
+
   const ramps: BridgeRamp[] = []
-  const plateaus: TilePos[] = []
   const rise = new Float32Array(map.width * map.depth)
   for (const span of spans) {
     for (const tile of span.tiles) rise[tile.z * map.width + tile.x] = BRIDGE_RISE
   }
   for (const [index, list] of approaches) {
-    if (list.length === 1) {
-      ramps.push(list[0])
-      rise[index] = BRIDGE_RISE / 2
-    } else {
-      plateaus.push({ x: list[0].x, z: list[0].z })
-      rise[index] = BRIDGE_RISE
+    if (connectorKeys.has(index)) continue
+    ramps.push(list[0])
+    rise[index] = BRIDGE_RISE / 2
+  }
+  // A branch may leave an island sideways: give it its own approach too.
+  for (const index of connectorKeys) {
+    for (const [dx, dz] of dirs) {
+      const x = index % map.width + dx
+      const z = Math.floor(index / map.width) + dz
+      const next = z * map.width + x
+      if (!isRoadTerrain(tileAt(map, x, z)) || connectorKeys.has(next) || approaches.has(next)) continue
+      ramps.push({ x, z, dx: -dx || 0, dz: -dz || 0, kind: map.tiles[next] === "path" ? "road" : "track" })
+      approaches.set(next, [ramps[ramps.length - 1]])
+      rise[next] = BRIDGE_RISE / 2
     }
   }
+  const rampAt = new Map(ramps.map((r) => [r.z * map.width + r.x, r]))
+  const connectors: BridgeConnector[] = [...connectorKeys].map((index) => {
+    const x = index % map.width
+    const z = Math.floor(index / map.width)
+    rise[index] = BRIDGE_RISE
+    return {
+      x, z,
+      kind: map.tiles[index] === "path" ? "road" : "track",
+      open: dirs.map(([dx, dz]) => {
+        if (tileAt(map, x + dx, z + dz) === null) return false
+        const next = (z + dz) * map.width + x + dx
+        const ramp = rampAt.get(next)
+        const meetsSpan = approaches.get(index)?.some((bank) => bank.dx === dx && bank.dz === dz) ?? false
+        return meetsSpan || connectorKeys.has(next) || (ramp?.dx === -dx && ramp?.dz === -dz)
+      }),
+    }
+  })
 
-  const layout = { spans, ramps, plateaus, rise }
+  const layout = { spans, ramps, connectors, rise }
   layoutCache.set(map, layout)
   return layout
 }


### PR DESCRIPTION
Paths now always render over grass, eliminating the water-colored ground beside rivers while preserving water tiles and depth data. Bridges continue across one- and two-tile islands, including bends, and require at least three dry tiles for separate ramps and a level path. Approaches use sloped timber planks or stone matching their bridge, and empty road batches no longer trigger shader errors.

Validation: all 195 tests and TypeScript checks pass; browser checks cover straight crossings, island bends, timber and stone approaches, and empty road batches without console errors.
