### PR TITLE
Scale traffic density with map area

### DIFF
--- a/components/game/game-hud.tsx
+++ b/components/game/game-hud.tsx
@@ -21,7 +21,7 @@ import { SITE_MENU } from "@/lib/site-menu"
 import { ACTIVITY_LABELS, formatGameTime, simRegistry, type SimTraveler } from "@/lib/game/sim"
 import { MONK_ACTIVITY_LABELS, monkRegistry, type Monk, type MonkActivity } from "@/lib/game/monks"
 import { relicTitle, type Relic } from "@/lib/game/relic"
-import type { Traveler } from "@/lib/game/travelers"
+import { DEFAULT_TRAFFIC, type Traveler } from "@/lib/game/travelers"
 import type { PixelationProps } from "@/components/pixel-canvas"
 
 import type { MapSettings } from "./game-shell"
@@ -777,13 +777,16 @@ export function GameHud({
 
         <Section {...section("Road")}>
           <Tuner
-            label="Traffic"
+            label="Traffic density"
             value={settings.traffic}
-            display={String(settings.traffic)}
+            display={`${Math.round((settings.traffic / DEFAULT_TRAFFIC) * 100)}%`}
             min={0}
             max={60}
             onChange={(traffic) => set({ traffic })}
           />
+          <p className="text-[11px] italic text-ink-light">
+            {travelers.length} folk across the map.
+          </p>
           <Tuner
             label="Pace"
             value={settings.walkSpeed}

--- a/components/game/game-shell.tsx
+++ b/components/game/game-shell.tsx
@@ -9,7 +9,7 @@ import { loadSavedSeed } from "@/lib/game/seed-storage"
 import { generateMonks } from "@/lib/game/monks"
 import { tileToWorldX, tileToWorldZ } from "@/lib/game/map/types"
 import { generateRelic, relicBound } from "@/lib/game/relic"
-import { DEFAULT_TRAFFIC, generateTravelers } from "@/lib/game/travelers"
+import { DEFAULT_TRAFFIC, generateTravelers, travelerCountForMap } from "@/lib/game/travelers"
 import {
   DEFAULT_CLEARING_COUNT,
   DEFAULT_DARK_FOREST_COUNT,
@@ -53,7 +53,7 @@ export interface MapSettings {
   darkForests: number
   /** How far off the road the relic's hovel is sited, in tiles. */
   relicDistance: number
-  /** How many travelers walk the road — the traffic level. */
+  /** Traffic density, in travelers per 128 × 128 tiles. */
   traffic: number
   /** Base walking speed in tiles per second. */
   walkSpeed: number
@@ -196,9 +196,10 @@ export function GameShell({
   )
 
   // Identities live outside the canvas so the HUD can name whoever is selected.
+  const travelerCount = map ? travelerCountForMap(map, settings.traffic) : 0
   const travelers = useMemo(
-    () => (seed === null ? [] : generateTravelers(seed, settings.traffic)),
-    [seed, settings.traffic],
+    () => (seed === null ? [] : generateTravelers(seed, travelerCount)),
+    [seed, travelerCount],
   )
 
   // The relic and the brothers who keep it, fixed per seed like the travelers.

--- a/lib/game/travelers.test.ts
+++ b/lib/game/travelers.test.ts
@@ -1,6 +1,31 @@
 import { describe, expect, it } from "vitest"
 
-import { generateTravelers, TRAVELER_TYPES } from "./travelers"
+import { generateTravelers, travelerCountForMap, TRAVELER_TYPES } from "./travelers"
+
+describe("travelerCountForMap", () => {
+  it("preserves the default crowd and scales with map area", () => {
+    expect(travelerCountForMap({ width: 128, depth: 128 })).toBe(12)
+    expect(travelerCountForMap({ width: 64, depth: 64 })).toBe(3)
+    expect(travelerCountForMap({ width: 256, depth: 256 })).toBe(48)
+    expect(travelerCountForMap({ width: 128, depth: 256 })).toBe(24)
+  })
+
+  it("applies the chosen density and allows empty roads at every size", () => {
+    for (const size of [64, 128, 256, 512]) {
+      const map = { width: size, depth: size }
+      expect(travelerCountForMap(map, 24)).toBe(travelerCountForMap(map) * 2)
+      expect(travelerCountForMap(map, 0)).toBe(0)
+    }
+  })
+
+  it("rounds to a whole crowd and ignores invalid densities", () => {
+    const map = { width: 96, depth: 96 }
+    expect(generateTravelers(7, travelerCountForMap(map))).toHaveLength(7)
+    for (const density of [-1, NaN, Infinity]) {
+      expect(travelerCountForMap(map, density)).toBe(0)
+    }
+  })
+})
 
 describe("generateTravelers", () => {
   it("is fully determined by its seed", () => {

--- a/lib/game/travelers.ts
+++ b/lib/game/travelers.ts
@@ -1,4 +1,5 @@
 import { deriveSeed, makeRng, SEED_STREAM } from "./rng"
+import type { GameMap } from "./map/types"
 
 /**
  * Travelers on the road. Pure data — no three.js, no React — so identities can
@@ -257,8 +258,17 @@ function rollAttributes(rng: () => number, type: TravelerTypeDef): TravelerAttri
   }
 }
 
-/** How many travelers walk the road unless the tuner says otherwise. */
+/** Travelers per 128 × 128 tiles; also the count on the reference map. */
 export const DEFAULT_TRAFFIC = 12
+
+/** Convert the traffic density into a whole crowd using the generated map's area. */
+export function travelerCountForMap(
+  map: Pick<GameMap, "width" | "depth">,
+  density: number = DEFAULT_TRAFFIC,
+): number {
+  if (!Number.isFinite(density) || density <= 0) return 0
+  return Math.max(0, Math.round((map.width * map.depth * density) / (128 * 128)))
+}
 
 export function generateTravelers(seed: number, count: number): Traveler[] {
   const rng = makeRng(deriveSeed(seed, SEED_STREAM.travelers))


### PR DESCRIPTION
Traveler counts now scale with map area, preserving 12 travelers on a 128 × 128 map and producing 48 on a 256 × 256 map at the default density.
The traffic slider displays relative density, and the HUD shows the resulting traveler count.
Tests cover area scaling, adjustable and zero density, rounding, and invalid density values.
Validation: all 217 tests pass, TypeScript checks pass, and `git diff --check` passes.
