### PR TITLE
Fix bridge ramps to connect straight onto paths

### DIFF
--- a/lib/game/map/bridges.test.ts
+++ b/lib/game/map/bridges.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vitest"
 import { BRIDGE_RISE, bridgeLayout, surfaceHeight } from "./bridges"
 import { generateMap } from "./generate-map"
 import { parseAsciiMap } from "./prototype-map"
+import { isRoadTerrain } from "./road"
 import { TILE_HEIGHT } from "./terrain"
+import { tileAt } from "./types"
 
 describe("bridgeLayout", () => {
   it("finds a straight span with a ramp at each end, running from bank to bank", () => {
@@ -40,7 +42,7 @@ describe("bridgeLayout", () => {
   })
 
   it("rises linearly from the road, up the ramp, onto the deck", () => {
-    const map = parseAsciiMap(["=.=#=.="])
+    const map = parseAsciiMap(["===#==="])
     // (this map is a single row: the span is one tile, crossing along x)
     expect(surfaceHeight(map, 0, 0)).toBe(TILE_HEIGHT)
     expect(surfaceHeight(map, 2, 0)).toBeCloseTo(TILE_HEIGHT + BRIDGE_RISE / 2)
@@ -73,12 +75,91 @@ describe("bridgeLayout", () => {
     expect(bridgeLayout(bare).spans[0].kind).toBe("track")
   })
 
+  it("aligns a single-tile crossing with the path when both axes have dry banks", () => {
+    const map = parseAsciiMap([".=.", ".=.", ".#.", ".=.", ".=."])
+    const layout = bridgeLayout(map)
+    expect([layout.spans[0].dx, layout.spans[0].dz]).toEqual([0, 1])
+    expect(layout.ramps).toEqual([
+      { x: 1, z: 1, dx: 0, dz: 1, kind: "road" },
+      { x: 1, z: 3, dx: 0, dz: -1, kind: "road" },
+    ])
+  })
+
+  it.each(["=", "-"])("turns the landing toward a perpendicular %s path before descending", (path) => {
+    const map = parseAsciiMap([
+      "..=.....",
+      "..=.....",
+      "..=##=..",
+      ".....=..",
+      ".....=..",
+    ].map((row) => row.replaceAll("=", path)))
+    const original = [...map.tiles]
+    const layout = bridgeLayout(map)
+    const kind = path === "=" ? "road" : "track"
+    expect(layout.connectors).toEqual([
+      { x: 2, z: 2, kind, open: [true, false, false, true] },
+      { x: 5, z: 2, kind, open: [false, true, true, false] },
+    ])
+    expect(layout.ramps).toEqual(expect.arrayContaining([
+      { x: 2, z: 1, dx: 0, dz: 1, kind },
+      { x: 5, z: 3, dx: 0, dz: -1, kind },
+    ]))
+    expect(layout.ramps).toHaveLength(2)
+    expect(surfaceHeight(map, 2, 0)).toBe(TILE_HEIGHT)
+    expect(surfaceHeight(map, 2, 1)).toBeCloseTo(TILE_HEIGHT + BRIDGE_RISE / 2)
+    expect(surfaceHeight(map, 2, 2)).toBeCloseTo(TILE_HEIGHT + BRIDGE_RISE)
+    expect(map.tiles).toEqual(original)
+  })
+
+  it("follows consecutive path bends until a ramp has a straight exit", () => {
+    const map = parseAsciiMap([
+      "==##=...",
+      "....==..",
+      ".....=..",
+      ".....=..",
+    ])
+    const layout = bridgeLayout(map)
+    expect(layout.connectors.map(({ x, z }) => ({ x, z }))).toEqual([
+      { x: 4, z: 0 }, { x: 4, z: 1 }, { x: 5, z: 1 },
+    ])
+    expect(layout.ramps).toEqual(expect.arrayContaining([
+      { x: 5, z: 2, dx: 0, dz: -1, kind: "road" },
+    ]))
+    expect(surfaceHeight(map, 5, 3)).toBe(TILE_HEIGHT)
+  })
+
   it("leaves a span ending at the map edge with no approach there", () => {
     const map = parseAsciiMap(["##=="])
     const [span] = bridgeLayout(map).spans
     expect(span.from).toBeNull()
     expect(span.to).toEqual({ x: 2, z: 0 })
     expect(bridgeLayout(map).ramps).toEqual([{ x: 2, z: 0, dx: -1, dz: 0, kind: "road" }])
+  })
+
+  it("keeps a dead-end bank level instead of descending into grass or water", () => {
+    const map = parseAsciiMap(["==##=~"])
+    const layout = bridgeLayout(map)
+    expect(layout.ramps).toEqual([{ x: 1, z: 0, dx: 1, dz: 0, kind: "road" }])
+    expect(layout.connectors).toEqual([{ x: 4, z: 0, kind: "road", open: [false, true, false, false] }])
+  })
+
+  it("joins turning approaches when their ramps would run into one another", () => {
+    const map = parseAsciiMap(["==##=...", "....=...", "....=##="])
+    const layout = bridgeLayout(map)
+    expect(layout.connectors).toHaveLength(3)
+    for (const z of [0, 1, 2]) {
+      expect(surfaceHeight(map, 4, z)).toBeCloseTo(TILE_HEIGHT + BRIDGE_RISE)
+    }
+    expect(layout.ramps).toHaveLength(2)
+  })
+
+  it("turns a branch off an island deck before placing its ramp", () => {
+    const map = parseAsciiMap(["==##=##==", "....==...", ".....=...", ".....=..."])
+    const layout = bridgeLayout(map)
+    expect(layout.connectors).toHaveLength(3)
+    expect(layout.ramps).toHaveLength(3)
+    expect(layout.ramps).toContainEqual({ x: 5, z: 2, dx: 0, dz: -1, kind: "road" })
+    expect(surfaceHeight(map, 5, 3)).toBe(TILE_HEIGHT)
   })
 
   it("continues the deck over a one-tile island without a dirt causeway", () => {
@@ -154,7 +235,7 @@ describe("bridgeLayout", () => {
   })
 
   it("accounts for every bridge tile on generated maps, each span with land at both ends", () => {
-    for (const seed of [1, 7920, 15839]) {
+    for (const seed of Array.from({ length: 20 }, (_, i) => 1 + i * 7919)) {
       const map = generateMap({ seed })
       const layout = bridgeLayout(map)
       const covered = layout.spans.reduce((n, s) => n + s.tiles.length, 0)
@@ -169,6 +250,14 @@ describe("bridgeLayout", () => {
       // Island decks never also become ramps.
       const rampKeys = new Set(layout.ramps.map((r) => `${r.x},${r.z}`))
       for (const p of layout.connectors) expect(rampKeys.has(`${p.x},${p.z}`)).toBe(false)
+      for (const ramp of layout.ramps) {
+        const x = ramp.x - ramp.dx
+        const z = ramp.z - ramp.dz
+        const terrain = tileAt(map, x, z)
+        expect(terrain === null || isRoadTerrain(terrain), `seed ${seed} ramp at ${ramp.x},${ramp.z}`).toBe(true)
+        expect(surfaceHeight(map, x, z)).toBe(TILE_HEIGHT)
+        expect(surfaceHeight(map, ramp.x + ramp.dx, ramp.z + ramp.dz)).toBeCloseTo(TILE_HEIGHT + BRIDGE_RISE)
+      }
     }
   }, 30_000)
 })

--- a/lib/game/map/bridges.ts
+++ b/lib/game/map/bridges.ts
@@ -10,9 +10,10 @@ import { tileAt, type GameMap, type TilePos } from "./types"
  *
  * A bridge is a straight run of `bridge` tiles (the generator guarantees
  * straight, short spans over river water). Its deck floats BRIDGE_RISE above
- * the ground so the water shows beneath it, and a ramp on the land tile at
- * each end — the approach — climbs from ground level at its far edge to
- * deck level where it meets the span. Anything walking the road follows the
+ * the ground so the water shows beneath it. Ramps follow the path at each
+ * end, with level landings wherever it turns before descending. Each ramp
+ * climbs from ground level at its far edge to deck level at its upper edge.
+ * Anything walking the road follows the
  * same rise: tile-centre heights interpolate linearly, and the ramp's centre
  * sits at exactly half the rise, so a walker's feet track the wedge.
  */
@@ -57,7 +58,7 @@ export interface BridgeConnector extends TilePos {
 export interface BridgeLayout {
   spans: BridgeSpan[]
   ramps: BridgeRamp[]
-  /** Wooden/stone deck carried over land gaps shorter than three tiles. */
+  /** Level decks over short land gaps and corners before the ramps. */
   connectors: BridgeConnector[]
   /** Height of the walking surface above TILE_HEIGHT at each tile's centre, by tile index. */
   rise: Float32Array
@@ -86,10 +87,13 @@ function spanAxis(map: GameMap, x: number, z: number): readonly [number, number]
     if (isBridge(map, x + dx, z + dz) || isBridge(map, x - dx, z - dz)) return [dx, dz]
   }
   // A single-tile span: it crosses from bank to bank, so it runs along
-  // whichever axis has the most land at its ends. Off the map counts for
-  // half — the bank may well be there, just out of sight.
-  const landScore = (tx: number, tz: number) =>
-    tileAt(map, tx, tz) === null ? 1 : isWet(map, tx, tz) ? 0 : 2
+  // whichever axis has the most path at its ends, then land. Off the map
+  // counts for half a bank — it may be there, just out of sight.
+  const landScore = (tx: number, tz: number) => {
+    const terrain = tileAt(map, tx, tz)
+    if (isRoadTerrain(terrain)) return 5
+    return terrain === null ? 1 : isWet(map, tx, tz) ? 0 : 2
+  }
   let best = AXES[0]
   let bestScore = -1
   for (const axis of AXES) {
@@ -147,9 +151,8 @@ export function bridgeLayout(map: GameMap): BridgeLayout {
       spans.push({ tiles, dx, dz, from, to, kind })
 
       const approach = (tile: TilePos | null, ux: number, uz: number) => {
-        // Only land climbs; a span that meets water end-on (say, at a lake
-        // the generator let it touch) has nothing to ramp from.
-        if (!tile || isWet(map, tile.x, tile.z)) return
+        // Approaches follow the path; bare banks and water have no ramp.
+        if (!tile || !isRoadTerrain(tileAt(map, tile.x, tile.z))) return
         const key = tile.z * map.width + tile.x
         const list = approaches.get(key) ?? []
         list.push({ x: tile.x, z: tile.z, dx: ux, dz: uz, kind })
@@ -192,27 +195,50 @@ export function bridgeLayout(map: GameMap): BridgeLayout {
     if (isRoadTerrain(map.tiles[start])) visit([start])
   }
 
-  const ramps: BridgeRamp[] = []
+  // A ramp needs a level path tile beyond its low edge. Carry the deck
+  // around corners until that is possible, also merging approaches that
+  // would otherwise descend into each other or meet a deck sideways.
+  const pending = new Map([...approaches].map(([index, list]) => [index, [...list]]))
+  const expanded = new Set<number>()
+  while (true) {
+    for (const index of connectorKeys) {
+      if (expanded.has(index)) continue
+      expanded.add(index)
+      pending.delete(index)
+      for (const [dx, dz] of dirs) {
+        const x = index % map.width + dx
+        const z = Math.floor(index / map.width) + dz
+        const terrain = tileAt(map, x, z)
+        const next = z * map.width + x
+        if (!isRoadTerrain(terrain) || connectorKeys.has(next)) continue
+        const list = pending.get(next) ?? []
+        list.push({ x, z, dx: -dx || 0, dz: -dz || 0, kind: terrain === "path" ? "road" : "track" })
+        pending.set(next, list)
+      }
+    }
+    const promote: number[] = []
+    for (const [index, list] of pending) {
+      const ramp = list[0]
+      const x = ramp.x - ramp.dx
+      const z = ramp.z - ramp.dz
+      const terrain = tileAt(map, x, z)
+      const next = z * map.width + x
+      const conflicting = list.some((other) => other.dx !== ramp.dx || other.dz !== ramp.dz)
+      // Off-map paths continue beyond the visible world, as on ground roads.
+      const levelExit = terrain === null || (isRoadTerrain(terrain) && !connectorKeys.has(next) && !pending.has(next))
+      if (conflicting || !levelExit) promote.push(index)
+    }
+    if (promote.length === 0) break
+    for (const index of promote) connectorKeys.add(index)
+  }
+
+  const ramps = [...pending.values()].map((list) => list[0])
   const rise = new Float32Array(map.width * map.depth)
   for (const span of spans) {
     for (const tile of span.tiles) rise[tile.z * map.width + tile.x] = BRIDGE_RISE
   }
-  for (const [index, list] of approaches) {
-    if (connectorKeys.has(index)) continue
-    ramps.push(list[0])
-    rise[index] = BRIDGE_RISE / 2
-  }
-  // A branch may leave an island sideways: give it its own approach too.
-  for (const index of connectorKeys) {
-    for (const [dx, dz] of dirs) {
-      const x = index % map.width + dx
-      const z = Math.floor(index / map.width) + dz
-      const next = z * map.width + x
-      if (!isRoadTerrain(tileAt(map, x, z)) || connectorKeys.has(next) || approaches.has(next)) continue
-      ramps.push({ x, z, dx: -dx || 0, dz: -dz || 0, kind: map.tiles[next] === "path" ? "road" : "track" })
-      approaches.set(next, [ramps[ramps.length - 1]])
-      rise[next] = BRIDGE_RISE / 2
-    }
+  for (const ramp of ramps) {
+    rise[ramp.z * map.width + ramp.x] = BRIDGE_RISE / 2
   }
   const rampAt = new Map(ramps.map((r) => [r.z * map.width + r.x, r]))
   const connectors: BridgeConnector[] = [...connectorKeys].map((index) => {


### PR DESCRIPTION
Bridge ramps could descend past a path that turned sideways at the bank, leaving the ramp facing grass or water.
This change adds level landings around path corners until each ramp can descend straight onto a level path tile, merges conflicting approaches, and aligns single-tile bridges with the path while keeping traveller heights consistent.
Regression coverage includes road and track corners, consecutive bends, dead ends, island branches, and ramp alignment across 20 generated maps.

Validation: all 215 tests pass with `npm test`, and `npm run typecheck` passes.
