### PR TITLE
Disable picture-in-picture for background music

### DIFF
--- a/components/game/music-player.tsx
+++ b/components/game/music-player.tsx
@@ -84,7 +84,16 @@ export function MusicPlayer({ className = "" }: { className?: string }) {
       playerRef.current = new window.YT.Player(host, {
         videoId: VIDEO_ID,
         // Looping a single video requires naming it as its own playlist.
-        playerVars: { controls: 0, disablekb: 1, loop: 1, playlist: VIDEO_ID },
+        playerVars: {
+          controls: 0,
+          disablekb: 1,
+          loop: 1,
+          playlist: VIDEO_ID,
+          // Keep background music inline on mobile; next.config.mjs also
+          // disables picture-in-picture through the page's permissions policy.
+          playsinline: 1,
+          fs: 0,
+        },
         events: {
           onReady: (event) => {
             event.target.setVolume(VOLUME)

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -30,6 +30,14 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  async headers() {
+    return [{
+      source: '/:path*',
+      // Background music uses a hidden YouTube video. Prevent the embed from
+      // opening a floating video player when the user switches tabs.
+      headers: [{ key: 'Permissions-Policy', value: 'picture-in-picture=()' }],
+    }]
+  },
   async redirects() {
     // The texture gallery moved under /assets when characters joined it.
     return [{ source: '/textures', destination: '/assets/textures', permanent: true }]


### PR DESCRIPTION
The hidden YouTube background-music player can appear in a floating mini player when switching tabs.
Disable picture-in-picture through the page Permissions-Policy header, keep the embed inline on mobile, and hide its fullscreen control.
Validated with `npm run typecheck`, `git diff --check`, and a local HTTP response confirming `Permissions-Policy: picture-in-picture=()`.
Browser tab-switch behavior still needs manual confirmation; the source remains a YouTube video internally.
