### PR TITLE
Make property panels opt-in while keeping traffic density visible

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,14 @@
 
 ## Rules
 
+- **Property panels are opt-in development tools.** For a branch that needs the
+  World tuning sidebar, set `NEXT_PUBLIC_PROPERTY_PANELS=1` in that workspace's
+  gitignored `.env.local` and restart `npm run dev` (or run
+  `NEXT_PUBLIC_PROPERTY_PANELS=1 npm run dev`). Leave it unset elsewhere.
+  Production builds always omit the sidebar, even with the flag set. Keep player
+  controls such as settlement building available without the tuning sidebar.
+  Traffic density is the exception: keep its compact control visible in production.
+
 - **Releases and documentation have shared ownership rules.** Follow
   [docs/releases.md](docs/releases.md). The post-merge GitHub Action owns version
   increments and changelog entries; feature workspaces must leave those fields

--- a/components/game/game-hud.tsx
+++ b/components/game/game-hud.tsx
@@ -44,6 +44,11 @@ const CONTROLS: Array<[string, string]> = [
 
 const PANEL_SHADOW = "shadow-[0_2px_16px_rgba(0,0,0,0.6)]"
 
+// Opt in per workspace; a production build must never expose the tuning UI.
+const SHOW_PROPERTY_PANELS =
+  process.env.NODE_ENV === "development" &&
+  process.env.NEXT_PUBLIC_PROPERTY_PANELS === "1"
+
 function Panel({ children, className = "" }: { children: React.ReactNode; className?: string }) {
   return (
     <div className={`pointer-events-none border border-rule bg-parchment/95 px-4 py-3 ${className}`}>
@@ -168,6 +173,28 @@ function Tuner({
         />
       </div>
     </div>
+  )
+}
+
+function TrafficDensity({ value, travelerCount, onChange }: {
+  value: number
+  travelerCount: number
+  onChange: (traffic: number) => void
+}) {
+  return (
+    <>
+      <Tuner
+        label="Traffic density"
+        value={value}
+        display={`${Math.round((value / DEFAULT_TRAFFIC) * 100)}%`}
+        min={0}
+        max={60}
+        onChange={onChange}
+      />
+      <p className="text-[11px] italic text-ink-light">
+        {travelerCount} folk across the map.
+      </p>
+    </>
   )
 }
 
@@ -626,8 +653,8 @@ function MonkPanel({ monk }: { monk: Monk }) {
 }
 
 /**
- * The play-screen chrome: transparent header, one World panel of tuning knobs,
- * the inspector, and the minimap dock.
+ * The play-screen chrome: transparent header, settlement controls, the inspector,
+ * and the minimap dock. Local workspaces can opt into the World tuning sidebar.
  *
  * @see https://app.paper.design/file/01M1QTYBYHXP4H1BXFQ79N18AP/2-0 — HUD layout frame
  */
@@ -662,6 +689,7 @@ export function GameHud({
   const set = (patch: Partial<MapSettings>) => onSettingsChange({ ...settings, ...patch })
   const selection = useCameraStore((s) => s.selection)
   const [menuOpen, setMenuOpen] = useState(false)
+  const [settlementOpen, setSettlementOpen] = useState(false)
   const [openSections, setOpenSections] = useState<Record<string, boolean>>({
     Seed: true,
     Pixelation: true,
@@ -686,9 +714,8 @@ export function GameHud({
 
   return (
     <>
-      {/* Header: title and version just right of the sidebar, menu on the right,
-          no backing — it sits straight on the scene like a title card. */}
-      <header className="pointer-events-none absolute inset-x-0 top-0 z-20 flex items-center justify-between py-4 pl-[244px] pr-4">
+      {/* Header follows the available scene width, including the optional sidebar. */}
+      <header className={`pointer-events-none absolute inset-x-0 top-0 z-20 flex items-center justify-between py-4 pr-4 ${SHOW_PROPERTY_PANELS ? "pl-[244px]" : "pl-4"}`}>
         <div className={`flex items-baseline gap-3 ${HEADER_TEXT_SHADOW}`}>
           <Link
             href="/"
@@ -702,13 +729,31 @@ export function GameHud({
         </div>
 
         <div className="relative flex items-center gap-2">
+          {!SHOW_PROPERTY_PANELS && map && (
+            <div className="relative">
+              <button
+                type="button"
+                onClick={() => { setSettlementOpen((open) => !open); setMenuOpen(false) }}
+                aria-expanded={settlementOpen}
+                aria-controls="settlement-controls"
+                className={HEADER_BUTTON}
+              >
+                Settlement
+              </button>
+              {settlementOpen && (
+                <div id="settlement-controls" className={`pointer-events-auto absolute right-0 top-full mt-2 w-[228px] border border-rule bg-parchment/95 px-3 py-3 ${PANEL_SHADOW}`}>
+                  <SettlementPanel map={map} />
+                </div>
+              )}
+            </div>
+          )}
           <button type="button" onClick={onReroll} className={HEADER_BUTTON}>
             ✦ New Map
           </button>
           <MusicPlayer className={HEADER_BUTTON} />
           <button
             type="button"
-            onClick={() => setMenuOpen((open) => !open)}
+            onClick={() => { setMenuOpen((open) => !open); setSettlementOpen(false) }}
             aria-expanded={menuOpen}
             className={HEADER_BUTTON}
           >
@@ -718,8 +763,15 @@ export function GameHud({
         </div>
       </header>
 
+      {!SHOW_PROPERTY_PANELS && (
+        <aside aria-label="Traffic" className={`pointer-events-auto absolute left-4 top-20 z-10 w-[228px] border border-rule bg-parchment/95 px-3 py-2 ${PANEL_SHADOW}`}>
+          <TrafficDensity value={settings.traffic} travelerCount={travelers.length} onChange={(traffic) => set({ traffic })} />
+        </aside>
+      )}
+
       {/* World: a full-height sidebar of tuning knobs, grouped under fold-away headers. */}
-      <aside
+      {SHOW_PROPERTY_PANELS && <aside
+        aria-label="World properties"
         className={`pointer-events-auto absolute inset-y-0 left-0 z-10 flex w-[228px] flex-col overflow-y-auto border border-rule bg-parchment/95 px-2 py-3 ${PANEL_SHADOW}`}
       >
         <Section {...section("Seed")}>
@@ -828,17 +880,7 @@ export function GameHud({
         </Section>
 
         <Section {...section("Road")}>
-          <Tuner
-            label="Traffic density"
-            value={settings.traffic}
-            display={`${Math.round((settings.traffic / DEFAULT_TRAFFIC) * 100)}%`}
-            min={0}
-            max={60}
-            onChange={(traffic) => set({ traffic })}
-          />
-          <p className="text-[11px] italic text-ink-light">
-            {travelers.length} folk across the map.
-          </p>
+          <TrafficDensity value={settings.traffic} travelerCount={travelers.length} onChange={(traffic) => set({ traffic })} />
           <Tuner
             label="Pace"
             value={settings.walkSpeed}
@@ -929,23 +971,25 @@ export function GameHud({
             onChange={(ponds) => set({ ponds })}
           />
         </Section>
-      </aside>
+      </aside>}
 
-      {(selection?.kind === "tree" || selection?.kind === "pile") && <ResourceInspector selection={selection} />}
+      {(selection?.kind === "tree" || selection?.kind === "pile") && (
+        <ResourceInspector selection={selection} className={SHOW_PROPERTY_PANELS ? "left-[228px]" : "left-0"} />
+      )}
 
       {/* Inspector: whoever or whatever the player clicked, tucked against the sidebar. */}
       {selectedTraveler && (
-        <div className="absolute bottom-0 left-[228px] z-10">
+        <div className={`absolute bottom-0 z-10 ${SHOW_PROPERTY_PANELS ? "left-[228px]" : "left-0"}`}>
           <TravelerPanel traveler={selectedTraveler} />
         </div>
       )}
       {selectedMonk && (
-        <div className="absolute bottom-0 left-[228px] z-10">
+        <div className={`absolute bottom-0 z-10 ${SHOW_PROPERTY_PANELS ? "left-[228px]" : "left-0"}`}>
           <MonkPanel monk={selectedMonk} />
         </div>
       )}
       {selectedRelic && relic && (
-        <div className="absolute bottom-0 left-[228px] z-10">
+        <div className={`absolute bottom-0 z-10 ${SHOW_PROPERTY_PANELS ? "left-[228px]" : "left-0"}`}>
           <RelicPanel relic={relic} />
         </div>
       )}

--- a/components/game/resource-inspector.tsx
+++ b/components/game/resource-inspector.tsx
@@ -11,7 +11,10 @@ function Row({ label, children }: { label: string; children: ReactNode }) {
 }
 
 /** The same tree identity can be inspected standing, fallen, or as a stump. */
-export function ResourceInspector({ selection }: { selection: Extract<Selection, { kind: "tree" | "pile" }> }) {
+export function ResourceInspector({ selection, className = "left-0" }: {
+  selection: Extract<Selection, { kind: "tree" | "pile" }>
+  className?: string
+}) {
   const [, refresh] = useState(0)
   useEffect(() => {
     const timer = setInterval(() => refresh((n) => n + 1), 250)
@@ -52,7 +55,7 @@ export function ResourceInspector({ selection }: { selection: Extract<Selection,
       <p className="mt-2 italic text-ink-light">Delivered here by the camp’s woodcutters.</p>
     </>
   }
-  return <div className="pointer-events-auto absolute bottom-0 left-[228px] z-10 w-[250px] border border-rule bg-parchment/95 px-4 py-3 text-[11px] text-ink">
+  return <div className={`pointer-events-auto absolute bottom-0 z-10 w-[250px] border border-rule bg-parchment/95 px-4 py-3 text-[11px] text-ink ${className}`}>
     <div className="mb-2 flex items-center justify-between gap-3">
       <span className="font-display text-xs">{title}</span>
       <button type="button" aria-label="Dismiss resource" onClick={() => useCameraStore.getState().select(null)}>✕</button>


### PR DESCRIPTION
Remove the persistent World tuning sidebar from production while keeping traffic density visible in a compact panel.
Move settlement controls into a header dropdown, reclaim the sidebar space for the header and inspectors, and document the local development opt-in (`NEXT_PUBLIC_PROPERTY_PANELS=1`); production excludes the sidebar even when the flag is set.

Validated with TypeScript checking, a production build with the flag enabled, and browser checks covering production, default development, opted-in development, traffic changes, and settlement controls.

HUD design reference: [Paper frame](https://app.paper.design/file/01M1QTYBYHXP4H1BXFQ79N18AP/2-0).
