### PR TITLE
Unify selection highlights and reveal obscured characters

### DIFF
--- a/components/game/buildings.tsx
+++ b/components/game/buildings.tsx
@@ -3,7 +3,7 @@
 import { useMemo } from "react"
 import * as THREE from "three"
 
-import { isSelected, useCameraStore } from "@/lib/game/camera-store"
+import { selectElement } from "@/lib/game/selection"
 import { useBuildStore } from "@/lib/game/build-store"
 import { pileOffset } from "@/lib/game/trees/timber"
 import { WoodPile } from "./wood-pile"
@@ -11,7 +11,7 @@ import { TILE_HEIGHT } from "@/lib/game/map/terrain"
 import { tileToWorldX, tileToWorldZ, type GameMap } from "@/lib/game/map/types"
 import {
   buildingObjectId,
-  placedObjectId,
+  pileObjectId,
   encodeObjectId,
   OUTLINE_ID_LAYER_MASK,
 } from "@/lib/game/render/outline"
@@ -30,13 +30,12 @@ const ROOF_THICKNESS = 0.18
  * between a building and its own roof — only against *other* objects.
  */
 export function Buildings({ map }: { map: GameMap }) {
-  const selection = useCameraStore((s) => s.selection)
   const piles = useBuildStore((s) => s.piles)
   const buildings = map.buildings
   const idColors = useMemo(
     // Component tuples straight into the working colour space — an ID is data,
     // not a colour, so it must dodge sRGB conversion to survive readback.
-    () => buildings.map((_, index) => new THREE.Color(...encodeObjectId(index < map.buildings.length ? buildingObjectId(index) : placedObjectId(index - map.buildings.length)))),
+    () => buildings.map((_, index) => new THREE.Color(...encodeObjectId(buildingObjectId(index)))),
     [map, buildings],
   )
 
@@ -51,28 +50,30 @@ export function Buildings({ map }: { map: GameMap }) {
         const baseY = TILE_HEIGHT
 
         const cross = building.buildType === "cross"
-        const selected = isSelected(selection, { kind: "building", id: building.id })
         const capY = cross ? building.height * 0.72 : building.height + ROOF_THICKNESS / 2
         if (building.id.startsWith("lumberCamp-")) {
           return (
-            <group key={building.id} name={`lumber-yard-${building.id}`} position={[centreX, baseY, centreZ]} onClick={(event) => {
-              if (event.delta > 6 || useBuildStore.getState().tool) return
-              event.stopPropagation()
-              useCameraStore.getState().select(selected ? null : { kind: "building", id: building.id })
-            }}>
+            <group key={building.id} name={`lumber-yard-${building.id}`} position={[centreX, baseY, centreZ]} onClick={(event) => selectElement({ kind: "building", id: building.id }, event)}>
               <mesh position={[0, 0.022, 0]}>
                 <boxGeometry args={[building.w * 0.98, 0.044, building.d * 0.98]} />
                 <meshLambertMaterial color="#a18a60" />
               </mesh>
+              <mesh position={[0, 0.022, 0]} layers-mask={OUTLINE_ID_LAYER_MASK}>
+                <boxGeometry args={[building.w * 0.98, 0.044, building.d * 0.98]} />
+                <meshBasicMaterial color={idColors[index]} toneMapped={false} />
+              </mesh>
               {/* Low corner pegs mark the open yard without hiding its stacks. */}
               {[-1, 1].flatMap((x) => [-1, 1].map((z) => (
-                <mesh key={`${x}:${z}`} position={[x * (building.w / 2 - 0.12), 0.13, z * (building.d / 2 - 0.12)]}>
-                  <boxGeometry args={[0.08, 0.26, 0.08]} /><meshLambertMaterial color="#705135" />
-                </mesh>
+                <group key={`${x}:${z}`} position={[x * (building.w / 2 - 0.12), 0.13, z * (building.d / 2 - 0.12)]}>
+                  <mesh><boxGeometry args={[0.08, 0.26, 0.08]} /><meshLambertMaterial color="#705135" /></mesh>
+                  <mesh layers-mask={OUTLINE_ID_LAYER_MASK}>
+                    <boxGeometry args={[0.08, 0.26, 0.08]} /><meshBasicMaterial color={idColors[index]} toneMapped={false} />
+                  </mesh>
+                </group>
               )))}
               {piles.filter((pile) => pile.campId === building.id).map((pile) => {
                 const [x, z] = pileOffset(pile.slot)
-                return <group key={pile.id} position={[x, 0.03, z]}><WoodPile pile={pile} /></group>
+                return <group key={pile.id} position={[x, 0.03, z]}><WoodPile pile={pile} objectId={pileObjectId(piles.indexOf(pile))} /></group>
               })}
             </group>
           )
@@ -89,12 +90,7 @@ export function Buildings({ map }: { map: GameMap }) {
         ]
 
         return (
-          <group key={building.id} position={[centreX, baseY, centreZ]} onClick={(event) => {
-            if (event.delta > 6 || useBuildStore.getState().tool) return
-            event.stopPropagation()
-            useCameraStore.getState().select(selected ? null : { kind: "building", id: building.id })
-          }}>
-            {selected && <mesh position={[0, building.height + 0.4, 0]}><boxGeometry args={[0.2, 0.05, 0.2]} /><meshBasicMaterial color="#d8a93f" /></mesh>}
+          <group key={building.id} position={[centreX, baseY, centreZ]} onClick={(event) => selectElement({ kind: "building", id: building.id }, event)}>
             <mesh position={[0, building.height / 2, 0]}>
               <boxGeometry args={bodyArgs} />
               <meshLambertMaterial color={building.color} />

--- a/components/game/character-selection.tsx
+++ b/components/game/character-selection.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import { useLayoutEffect, useMemo, useRef } from "react"
+import { createPortal, useFrame, useThree } from "@react-three/fiber"
+import * as THREE from "three"
+import { surfaceHeight } from "@/lib/game/map/bridges"
+import { worldToTileX, worldToTileZ, type GameMap } from "@/lib/game/map/types"
+import { SELECTION_COLOR } from "@/lib/game/selection"
+import { SELECTED_CHARACTER_LAYER } from "@/lib/game/render/outline"
+import type { FigureClickHandler } from "./traveler-figure"
+
+/** A generous click volume shared by monks and travelers, without visible geometry. */
+export function CharacterHitTarget({ onClick }: { onClick: FigureClickHandler }) {
+  return <mesh name="character-hit-target" position={[0, 0.4, 0]} onClick={onClick}>
+    <boxGeometry args={[0.8, 1, 0.8]} />
+    <meshBasicMaterial visible={false} />
+  </mesh>
+}
+
+/** A soft ground glow that stays level during work, camping, and flight. */
+export function CharacterSelectionShadow({ map, flying = false }: { map: GameMap; flying?: boolean }) {
+  const anchor = useRef<THREE.Group>(null)
+  const shadow = useRef<THREE.Mesh>(null)
+  const scene = useThree((s) => s.scene)
+  const position = useMemo(() => new THREE.Vector3(), [])
+  const uniforms = useMemo(() => ({ uColor: { value: new THREE.Color(SELECTION_COLOR) } }), [])
+  useLayoutEffect(() => {
+    const tagged: Array<{ object: THREE.Object3D; mask: number }> = []
+    const include = (object: THREE.Object3D) => {
+      tagged.push({ object, mask: object.layers.mask })
+      object.layers.enable(SELECTED_CHARACTER_LAYER)
+    }
+    // Use the actual animated figure, including its cart and carried items.
+    // The click volume and flat ID copies must never enlarge its silhouette.
+    anchor.current?.parent?.traverse((object) => {
+      if (object instanceof THREE.Mesh && object.layers.isEnabled(0) && object.name !== "character-hit-target") include(object)
+    })
+    scene.traverse((object) => {
+      if (object instanceof THREE.Light) include(object)
+    })
+    return () => {
+      for (const { object, mask } of tagged) object.layers.mask = mask
+    }
+  }, [scene, flying])
+  useFrame(() => {
+    if (!anchor.current || !shadow.current) return
+    anchor.current.getWorldPosition(position)
+    const y = flying ? surfaceHeight(map, worldToTileX(map, position.x), worldToTileZ(map, position.z)) : position.y
+    shadow.current.position.set(position.x, y + 0.035, position.z)
+  })
+  return <>
+    <group ref={anchor} />
+    {createPortal(<mesh ref={shadow} name="character-selection-shadow" rotation={[-Math.PI / 2, 0, 0]} raycast={() => {}}>
+      <planeGeometry args={[1, 1]} />
+      <shaderMaterial transparent depthWrite={false} toneMapped={false} uniforms={uniforms}
+        vertexShader={`varying vec2 vUv;
+          void main() { vUv = uv; gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0); }`}
+        fragmentShader={`uniform vec3 uColor; varying vec2 vUv;
+          void main() {
+            float radius = length(vUv - 0.5) * 2.0;
+            float alpha = 0.3 * (1.0 - smoothstep(0.0, 1.0, radius));
+            gl_FragColor = vec4(uColor, alpha);
+          }`} />
+    </mesh>, scene)}
+  </>
+}

--- a/components/game/game-canvas.tsx
+++ b/components/game/game-canvas.tsx
@@ -116,7 +116,7 @@ export function GameCanvas({
       <TileCursor map={map} buildType={buildType} resources={resources} shrineRenown={shrineRenown} />
 
       <CameraRig map={map} onPlace={buildType ? onPlace : undefined} />
-      <OutlinePass />
+      <OutlinePass objects={{ buildings: map.buildings, travelers, monks }} />
       <DebugHandle map={map} travelers={travelers} speed={walkSpeed} />
     </PixelCanvas>
   )

--- a/components/game/game-hud.tsx
+++ b/components/game/game-hud.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link"
 import { useEffect, useMemo, useState } from "react"
+import { useBuildStore } from "@/lib/game/build-store"
 
 import { useCameraStore } from "@/lib/game/camera-store"
 import {
@@ -649,8 +650,10 @@ export function GameHud({
     selection?.kind === "traveler" ? (travelers.find((t) => t.id === selection.id) ?? null) : null
   const selectedMonk =
     selection?.kind === "monk" ? (monks.find((m) => m.id === selection.id) ?? null) : null
+  const piles = useBuildStore((s) => s.piles)
   const selectedBuilding = selection?.kind === "building" ? map?.buildings.find((b) => b.id === selection.id) : null
   const selectedDefinition = buildCatalog(economy.balance).find((item) => item.id === selectedBuilding?.buildType)
+  const storedWood = piles.reduce((sum, pile) => sum + (pile.campId === selectedBuilding?.id ? pile.wood : 0), 0)
   const selectedRelic = selection?.kind === "relic"
 
   return (
@@ -903,14 +906,19 @@ export function GameHud({
       {(selection?.kind === "tree" || selection?.kind === "pile") && <ResourceInspector selection={selection} />}
 
       {/* Inspector: whoever or whatever the player clicked, tucked against the sidebar. */}
-      {selectedBuilding && selectedDefinition && (
+      {selectedBuilding && (
         <div className="absolute bottom-0 left-[228px] z-10">
           <Panel>
-            <div className="flex items-center justify-between gap-4"><Label>{selectedDefinition.category === "scenery" ? "Scenery" : "Building"}</Label><button type="button" aria-label="Dismiss building" onClick={() => useCameraStore.getState().select(null)} className="pointer-events-auto text-xs text-ink-light">✕</button></div>
+            <div className="flex items-center justify-between gap-4"><Label>{selectedDefinition?.category === "scenery" ? "Scenery" : "Building"}</Label><button type="button" aria-label="Dismiss building" onClick={() => useCameraStore.getState().select(null)} className="pointer-events-auto text-xs text-ink-light">✕</button></div>
             <p className="mt-1 font-display text-xs text-ink">{selectedBuilding.label}</p>
-            <p className="mt-2 text-[11px] text-ink-light">Contributes +{selectedDefinition.renown} shrine renown</p>
-            <p className="mt-1 max-w-56 text-[11px] italic text-ink-light">{selectedDefinition.description}</p>
-            <p className="mt-1 text-[11px] text-ink-light">{buildingIncomeLabel(selectedDefinition, economy.balance)}</p>
+            {selectedBuilding.buildType === "lumberCamp" && (
+              <p className="mt-2 text-[11px] text-ink"><span className="text-ink-light">Stored wood</span> · {storedWood} wood</p>
+            )}
+            {selectedDefinition && <>
+              <p className="mt-2 text-[11px] text-ink-light">Contributes +{selectedDefinition.renown} shrine renown</p>
+              <p className="mt-1 max-w-56 text-[11px] italic text-ink-light">{selectedDefinition.description}</p>
+              <p className="mt-1 text-[11px] text-ink-light">{buildingIncomeLabel(selectedDefinition, economy.balance)}</p>
+            </>}
           </Panel>
         </div>
       )}

--- a/components/game/monks.tsx
+++ b/components/game/monks.tsx
@@ -6,6 +6,8 @@ import { useFrame } from "@react-three/fiber"
 import * as THREE from "three"
 
 import { isSelected, useCameraStore } from "@/lib/game/camera-store"
+import { selectElement } from "@/lib/game/selection"
+import { CharacterHitTarget, CharacterSelectionShadow } from "./character-selection"
 import { surfaceHeight } from "@/lib/game/map/bridges"
 import { TERRAIN } from "@/lib/game/map/terrain"
 import { tileAt, tileToWorldX, tileToWorldZ, type GameMap } from "@/lib/game/map/types"
@@ -37,9 +39,6 @@ const PAUSE_MIN_SECONDS = 2
 const PAUSE_MAX_SECONDS = 7
 /** Standing within this many tiles of the hovel's centre counts as keeping vigil. */
 const VIGIL_RADIUS = 1.8
-
-/** A click that dragged further than this many pixels is a pan, not a select. */
-const CLICK_SLOP_PX = 6
 
 interface Spot {
   x: number
@@ -185,11 +184,7 @@ export function Monks({ map, monks, flying = false }: { map: GameMap; monks: Mon
       {monks.map((monk, index) => {
         const id = new THREE.Color(...encodeObjectId(residentObjectId(index)))
         const selected = isSelected(selection, { kind: "monk", id: monk.id })
-        const select = (event: { delta: number; stopPropagation: () => void }) => {
-          if (event.delta > CLICK_SLOP_PX) return
-          event.stopPropagation()
-          useCameraStore.getState().select(selected ? null : { kind: "monk", id: monk.id })
-        }
+        const select = (event: { delta: number; stopPropagation: () => void }) => selectElement({ kind: "monk", id: monk.id }, event)
         return (
           <group
             key={monk.id}
@@ -209,13 +204,13 @@ export function Monks({ map, monks, flying = false }: { map: GameMap; monks: Mon
               <boxGeometry args={BODY} />
               <meshBasicMaterial color={id} toneMapped={false} />
             </mesh>
+            <mesh position={[0, BODY[1] + CROWN[1] / 2, 0]} layers-mask={OUTLINE_ID_LAYER_MASK}>
+              <boxGeometry args={CROWN} />
+              <meshBasicMaterial color={id} toneMapped={false} />
+            </mesh>
             {flying && <MonkRocketGear phase={index} outlineColor={id} onClick={select} />}
-            {selected && (
-              <mesh position={[0, flying ? 1.4 : BODY[1] + 0.35, 0]}>
-                <boxGeometry args={[0.2, 0.05, 0.2]} />
-                <meshBasicMaterial color="#d8a93f" />
-              </mesh>
-            )}
+            <CharacterHitTarget onClick={select} />
+            {selected && <CharacterSelectionShadow map={map} flying={flying} />}
           </group>
         )
       })}

--- a/components/game/outline-pass.tsx
+++ b/components/game/outline-pass.tsx
@@ -6,8 +6,11 @@ import * as THREE from "three"
 import { usePixelScene } from "@/components/pixel-canvas"
 
 import { useCameraStore } from "@/lib/game/camera-store"
+import { useBuildStore } from "@/lib/game/build-store"
+import { SELECTION_OUTLINE_COLOR, SELECTION_OUTLINE_OPACITY, SELECTION_FILL, SELECTION_FILL_OPACITY, selectionObjectId } from "@/lib/game/selection"
 import {
   OUTLINE_ID_LAYER,
+  SELECTED_CHARACTER_LAYER,
   type OutlineMode,
 } from "@/lib/game/render/outline"
 
@@ -40,9 +43,17 @@ const VERTEX_SHADER = /* glsl */ `
 const FRAGMENT_SHADER = /* glsl */ `
   uniform sampler2D tId;
   uniform sampler2D tDepth;
+  uniform sampler2D tCharacter;
+  uniform sampler2D tCharacterDepth;
+  uniform bool uCharacterSelected;
   uniform vec2 uTexel;
   uniform int uMode; // 1 = overlap only, 2 = full silhouette
   uniform vec3 uColor;
+  uniform float uSelectedId;
+  uniform vec3 uSelectionColor;
+  uniform float uSelectionOutlineOpacity;
+  uniform vec3 uSelectionFill;
+  uniform float uSelectionOpacity;
   varying vec2 vUv;
 
   float idAt(vec2 uv) {
@@ -61,10 +72,57 @@ const FRAGMENT_SHADER = /* glsl */ `
     return dN < dC - 1.0e-5;                // neighbour must be in front
   }
 
+  bool selectedNeighbour(vec2 uv, float dC) {
+    return abs(idAt(uv) - uSelectedId) < 0.5
+      && texture2D(tDepth, uv).x < dC - 1.0e-5;
+  }
+
   void main() {
     float idC = idAt(vUv);
-    if (uMode == 1 && idC < 0.5) discard; // overlap halos land only on objects
     float dC = texture2D(tDepth, vUv).x;
+    if (uCharacterSelected) {
+      vec4 character = texture2D(tCharacter, vUv);
+      if (character.a > 0.5) {
+        bool hidden = abs(idC - uSelectedId) > 0.5
+          && texture2D(tCharacterDepth, vUv).x > dC + 1.0e-5;
+        if (hidden) {
+          // A 50% mask over just the overlapping silhouette lets the real
+          // character show through while keeping the foreground readable.
+          gl_FragColor = vec4(mix(character.rgb, uSelectionFill, uSelectionOpacity), 0.5);
+        } else {
+          gl_FragColor = vec4(uSelectionFill, uSelectionOpacity);
+        }
+        return;
+      }
+      bool characterEdge =
+        texture2D(tCharacter, vUv + vec2(uTexel.x, 0.0)).a > 0.5 ||
+        texture2D(tCharacter, vUv - vec2(uTexel.x, 0.0)).a > 0.5 ||
+        texture2D(tCharacter, vUv + vec2(0.0, uTexel.y)).a > 0.5 ||
+        texture2D(tCharacter, vUv - vec2(0.0, uTexel.y)).a > 0.5;
+      if (characterEdge) {
+        gl_FragColor = vec4(uSelectionColor, uSelectionOutlineOpacity);
+        return;
+      }
+    }
+    if (!uCharacterSelected && uSelectedId > 0.5 && abs(idC - uSelectedId) < 0.5) {
+      gl_FragColor = vec4(uSelectionFill, uSelectionOpacity);
+      return;
+    }
+    // A thin halo belongs outside the shape, on its background side only.
+    // Nearer objects still hide the selected object and its highlight.
+    if (!uCharacterSelected && uSelectedId > 0.5) {
+      bool selectedEdge =
+        selectedNeighbour(vUv + vec2(uTexel.x, 0.0), dC) ||
+        selectedNeighbour(vUv - vec2(uTexel.x, 0.0), dC) ||
+        selectedNeighbour(vUv + vec2(0.0, uTexel.y), dC) ||
+        selectedNeighbour(vUv - vec2(0.0, uTexel.y), dC);
+      if (selectedEdge) {
+        gl_FragColor = vec4(uSelectionColor, uSelectionOutlineOpacity);
+        return;
+      }
+    }
+    if (uMode == 0) discard;
+    if (uMode == 1 && idC < 0.5) discard; // overlap halos land only on objects
     bool edge =
       occludedBy(vUv + vec2(uTexel.x, 0.0), idC, dC) ||
       occludedBy(vUv - vec2(uTexel.x, 0.0), idC, dC) ||
@@ -75,7 +133,7 @@ const FRAGMENT_SHADER = /* glsl */ `
   }
 `
 
-export function OutlinePass() {
+export function OutlinePass({ objects }: { objects?: Omit<Parameters<typeof selectionObjectId>[1], "piles"> }) {
   const { gl, scene } = useThree()
 
   // ID + depth buffer at drawing-buffer resolution. Nearest filtering is load-
@@ -89,21 +147,39 @@ export function OutlinePass() {
     })
   }, [])
 
+  const characterTarget = useMemo(() => new THREE.WebGLRenderTarget(1, 1, {
+    minFilter: THREE.NearestFilter,
+    magFilter: THREE.NearestFilter,
+    type: THREE.HalfFloatType,
+    generateMipmaps: false,
+    depthTexture: new THREE.DepthTexture(1, 1),
+  }), [])
+
   useEffect(
     () => () => {
       target.depthTexture?.dispose()
       target.dispose()
+      characterTarget.depthTexture?.dispose()
+      characterTarget.dispose()
     },
-    [target],
+    [target, characterTarget],
   )
 
   const pass = useMemo(() => {
     const uniforms = {
       tId: { value: null as THREE.Texture | null },
       tDepth: { value: null as THREE.Texture | null },
+      tCharacter: { value: characterTarget.texture },
+      tCharacterDepth: { value: characterTarget.depthTexture },
+      uCharacterSelected: { value: false },
       uTexel: { value: new THREE.Vector2() },
       uMode: { value: 0 },
       uColor: { value: new THREE.Color(OUTLINE_COLOR) },
+      uSelectedId: { value: 0 },
+      uSelectionColor: { value: new THREE.Color(SELECTION_OUTLINE_COLOR) },
+      uSelectionOutlineOpacity: { value: SELECTION_OUTLINE_OPACITY },
+      uSelectionFill: { value: new THREE.Color(SELECTION_FILL) },
+      uSelectionOpacity: { value: SELECTION_FILL_OPACITY },
     }
     const geometry = new THREE.BufferGeometry()
     // One triangle covering the whole screen — no quad seam, no matrices.
@@ -117,6 +193,7 @@ export function OutlinePass() {
       fragmentShader: FRAGMENT_SHADER,
       depthTest: false,
       depthWrite: false,
+      transparent: true,
     })
     const mesh = new THREE.Mesh(geometry, material)
     mesh.frustumCulled = false
@@ -124,7 +201,7 @@ export function OutlinePass() {
     quadScene.add(mesh)
     const quadCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1)
     return { uniforms, geometry, material, quadScene, quadCamera }
-  }, [])
+  }, [characterTarget])
 
   useEffect(
     () => () => {
@@ -138,9 +215,13 @@ export function OutlinePass() {
   const bufferSize = useMemo(() => new THREE.Vector2(), [])
 
   const frameRef = usePixelScene((camera, destination) => {
-    const mode = useCameraStore.getState().outlineMode
+    const { outlineMode: mode, selection } = useCameraStore.getState()
+    const selectedId = objects
+      ? selectionObjectId(selection, { ...objects, piles: useBuildStore.getState().piles }) : 0
+    const needsOutline = mode !== "off" || selectedId !== 0
+    const characterSelected = selectedId !== 0 && (selection?.kind === "monk" || selection?.kind === "traveler")
 
-    if (mode !== "off") {
+    if (needsOutline) {
       // Resolution can change during the camera tween in this same frame.
       // Reuse the target object and only resize its storage when needed.
       if (destination) bufferSize.set(destination.width, destination.height)
@@ -155,6 +236,13 @@ export function OutlinePass() {
       camera.layers.set(OUTLINE_ID_LAYER)
       gl.setRenderTarget(target)
       gl.render(scene, camera)
+      if (characterSelected) {
+        characterTarget.setSize(target.width, target.height)
+        gl.setClearColor(0x000000, 0)
+        camera.layers.set(SELECTED_CHARACTER_LAYER)
+        gl.setRenderTarget(characterTarget)
+        gl.render(scene, camera)
+      }
       gl.setRenderTarget(destination)
       camera.layers.set(0)
       gl.setClearColor(prevClearColor, prevClearAlpha)
@@ -164,7 +252,7 @@ export function OutlinePass() {
     gl.setRenderTarget(destination)
     gl.render(scene, camera)
 
-    if (mode !== "off") {
+    if (needsOutline) {
       pass.uniforms.tId.value = target.texture
       pass.uniforms.tDepth.value = target.depthTexture
       // One world texel of ink: outlines enlarge with the scene's pixels.
@@ -173,6 +261,8 @@ export function OutlinePass() {
         1 / target.height,
       )
       pass.uniforms.uMode.value = MODE_INT[mode]
+      pass.uniforms.uSelectedId.value = selectedId
+      pass.uniforms.uCharacterSelected.value = characterSelected
       const prevAutoClear = gl.autoClear
       gl.autoClear = false
       gl.render(pass.quadScene, pass.quadCamera)

--- a/components/game/shrine.tsx
+++ b/components/game/shrine.tsx
@@ -4,7 +4,7 @@ import { useMemo, useRef } from "react"
 import { useFrame } from "@react-three/fiber"
 import * as THREE from "three"
 
-import { isSelected, useCameraStore } from "@/lib/game/camera-store"
+import { selectElement } from "@/lib/game/selection"
 import { TILE_HEIGHT } from "@/lib/game/map/terrain"
 import { tileToWorldX, tileToWorldZ, type GameMap } from "@/lib/game/map/types"
 import type { Relic } from "@/lib/game/relic"
@@ -19,7 +19,7 @@ import {
  * The monks' hovel: four low walls with a doorway toward the track, a ring of
  * thatch around an open centre, and the relic on a plinth in the middle where
  * the sky can see it. It pulses — faintly — so the eye finds it from any zoom.
- * Click any part of it to select the relic; the HUD tells you what it is.
+ * The building and the relic have separate selections and inspectors.
  */
 
 const WALL_HEIGHT = 0.6
@@ -45,9 +45,6 @@ const HALO_BASE = 0.07
 const HALO_SWING = 0.05
 const LIGHT_BASE = 0.55
 const LIGHT_SWING = 0.2
-
-/** A click that dragged further than this many pixels is a pan, not a select. */
-const CLICK_SLOP_PX = 6
 
 const WALL_COLOR = "#8c7658"
 const FLOOR_COLOR = "#5a4a38"
@@ -97,7 +94,6 @@ function roofPieces(roofColor: string): Piece[] {
 }
 
 export function Shrine({ map, relic }: { map: GameMap; relic: Relic }) {
-  const selected = useCameraStore((s) => isSelected(s.selection, { kind: "relic" }))
   const relicMaterial = useRef<THREE.MeshStandardMaterial>(null)
   const haloMaterial = useRef<THREE.MeshBasicMaterial>(null)
   const light = useRef<THREE.PointLight>(null)
@@ -143,19 +139,15 @@ export function Shrine({ map, relic }: { map: GameMap; relic: Relic }) {
     if (light.current) light.current.intensity = LIGHT_BASE + LIGHT_SWING * phase
   })
 
-  if (!layout) return null
+  if (!layout || !hovel) return null
 
-  const select = (event: { delta: number; stopPropagation: () => void }) => {
-    if (event.delta > CLICK_SLOP_PX) return
-    event.stopPropagation()
-    useCameraStore.getState().select(selected ? null : { kind: "relic" })
-  }
+  const select = (event: { delta: number; stopPropagation: () => void }) => selectElement({ kind: "relic" }, event)
 
   return (
     <group position={[layout.centreX, layout.baseY, layout.centreZ]}>
       {layout.pieces.map((piece, i) => (
         <group key={i} position={piece.position}>
-          <mesh onClick={select}>
+          <mesh onClick={(event) => selectElement({ kind: "building", id: hovel.id }, event)}>
             <boxGeometry args={piece.args} />
             <meshLambertMaterial color={piece.color} />
           </mesh>
@@ -201,13 +193,6 @@ export function Shrine({ map, relic }: { map: GameMap; relic: Relic }) {
         distance={3.5}
         decay={2}
       />
-
-      {selected && (
-        <mesh position={[0, WALL_HEIGHT + 0.6, 0]}>
-          <boxGeometry args={[0.2, 0.05, 0.2]} />
-          <meshBasicMaterial color="#d8a93f" />
-        </mesh>
-      )}
     </group>
   )
 }

--- a/components/game/traveler-figure.tsx
+++ b/components/game/traveler-figure.tsx
@@ -1,5 +1,8 @@
 "use client"
 
+import type * as THREE from "three"
+import { OUTLINE_ID_LAYER_MASK } from "@/lib/game/render/outline"
+
 import type { TravelerTypeDef } from "@/lib/game/travelers"
 
 /**
@@ -28,29 +31,33 @@ export const AWNING_NAME = "vendor-awning"
 
 export type FigureClickHandler = (event: { delta: number; stopPropagation: () => void }) => void
 
-function VendorCart({ onClick, awning }: { onClick?: FigureClickHandler; awning: boolean }) {
+function FigureBox({ name, position, args, color, idColor, onClick }: {
+  name?: string
+  position: [number, number, number]
+  args: [number, number, number]
+  color: string
+  idColor?: THREE.Color
+  onClick?: FigureClickHandler
+}) {
+  return <group position={position} onClick={onClick}>
+    <mesh name={name}><boxGeometry args={args} /><meshLambertMaterial color={color} /></mesh>
+    {idColor && <mesh layers-mask={OUTLINE_ID_LAYER_MASK}>
+      <boxGeometry args={args} /><meshBasicMaterial color={idColor} toneMapped={false} />
+    </mesh>}
+  </group>
+}
+
+function VendorCart({ onClick, awning, idColor }: { onClick?: FigureClickHandler; awning: boolean; idColor?: THREE.Color }) {
   return (
     <group position={[0, 0, CART_OFFSET_Z]}>
-      {/* Unnamed on purpose: travelerScreenPoints counts "traveler" meshes 1:1. */}
-      <mesh position={[0, 0.18, 0]} onClick={onClick}>
-        <boxGeometry args={CART_BED} />
-        <meshLambertMaterial color="#6f4f2a" />
-      </mesh>
-      {/* Wine and victuals riding on the bed. */}
-      <mesh position={[0, 0.33, 0]}>
-        <boxGeometry args={[0.28, 0.14, 0.34]} />
-        <meshLambertMaterial color="#8a2f2f" />
-      </mesh>
+      <FigureBox position={[0, 0.18, 0]} args={CART_BED} color="#6f4f2a" idColor={idColor} onClick={onClick} />
+      <FigureBox position={[0, 0.33, 0]} args={[0.28, 0.14, 0.34]} color="#8a2f2f" idColor={idColor} onClick={onClick} />
       {[-0.26, 0.26].map((x) => (
-        <mesh key={x} position={[x, 0.12, 0]}>
-          <boxGeometry args={[0.06, 0.24, 0.24]} />
-          <meshLambertMaterial color="#3a2c1a" />
-        </mesh>
+        <FigureBox key={x} position={[x, 0.12, 0]} args={[0.06, 0.24, 0.24]} color="#3a2c1a" idColor={idColor} onClick={onClick} />
       ))}
-      <mesh name={AWNING_NAME} position={[0, 0.75, 0.05]} visible={awning}>
-        <boxGeometry args={[0.62, 0.04, 0.72]} />
-        <meshLambertMaterial color="#d8d0b8" />
-      </mesh>
+      <group name={AWNING_NAME} visible={awning}>
+        <FigureBox position={[0, 0.75, 0.05]} args={[0.62, 0.04, 0.72]} color="#d8d0b8" idColor={idColor} onClick={onClick} />
+      </group>
     </group>
   )
 }
@@ -58,20 +65,19 @@ function VendorCart({ onClick, awning }: { onClick?: FigureClickHandler; awning:
 export function TravelerFigure({
   type,
   onClick,
+  idColor,
   /** Initial awning state for vendors; the sim flips it live on the road. */
   awning = false,
 }: {
   type: TravelerTypeDef
+  idColor?: THREE.Color
   onClick?: FigureClickHandler
   awning?: boolean
 }) {
   return (
     <>
-      <mesh name="traveler" position={[0, BLOCK_HEIGHT / 2, 0]} onClick={onClick}>
-        <boxGeometry args={[BLOCK_WIDTH, BLOCK_HEIGHT, BLOCK_WIDTH]} />
-        <meshLambertMaterial color={type.color} />
-      </mesh>
-      {type.id === "vendor" && <VendorCart onClick={onClick} awning={awning} />}
+      <FigureBox name="traveler" position={[0, BLOCK_HEIGHT / 2, 0]} args={[BLOCK_WIDTH, BLOCK_HEIGHT, BLOCK_WIDTH]} color={type.color} idColor={idColor} onClick={onClick} />
+      {type.id === "vendor" && <VendorCart onClick={onClick} awning={awning} idColor={idColor} />}
     </>
   )
 }

--- a/components/game/travelers.tsx
+++ b/components/game/travelers.tsx
@@ -5,6 +5,8 @@ import { useFrame } from "@react-three/fiber"
 import * as THREE from "three"
 
 import { isSelected, useCameraStore } from "@/lib/game/camera-store"
+import { selectElement } from "@/lib/game/selection"
+import { CharacterHitTarget, CharacterSelectionShadow } from "./character-selection"
 import { useBalanceStore } from "@/lib/game/balance-store"
 import { lumberCamps } from "@/lib/game/settlement"
 import { useBuildStore } from "@/lib/game/build-store"
@@ -21,10 +23,6 @@ import {
 
 import {
   AWNING_NAME,
-  BLOCK_HEIGHT,
-  BLOCK_WIDTH,
-  CART_BED,
-  CART_OFFSET_Z,
   TravelerFigure,
 } from "./traveler-figure"
 
@@ -39,9 +37,6 @@ import {
 
 /** Campers fold down to this fraction of standing height. */
 const CAMP_SCALE = 0.35
-
-/** A click that dragged further than this many pixels is a pan, not a select. */
-const CLICK_SLOP_PX = 6
 
 export function Travelers({
   map,
@@ -128,12 +123,8 @@ export function Travelers({
     <group>
       {travelers.map((traveler, index) => {
         const selected = isSelected(selection, { kind: "traveler", id: traveler.id })
-        const [r, g, b] = encodeObjectId(travelerObjectId(index))
-        const select = (event: { delta: number; stopPropagation: () => void }) => {
-          if (event.delta > CLICK_SLOP_PX || useBuildStore.getState().tool) return
-          event.stopPropagation()
-          useCameraStore.getState().select(selected ? null : { kind: "traveler", id: traveler.id })
-        }
+        const idColor = new THREE.Color(...encodeObjectId(travelerObjectId(index)))
+        const select = (event: { delta: number; stopPropagation: () => void }) => selectElement({ kind: "traveler", id: traveler.id }, event)
         return (
           <group
             key={traveler.id}
@@ -141,33 +132,16 @@ export function Travelers({
               groupRefs.current[index] = node
             }}
           >
-            <TravelerFigure type={traveler.type} onClick={select} />
-            <mesh name="carried-logs" visible={false} position={[0, 0.35, 0.2]} rotation={[0, 0, Math.PI / 2]}>
-              <cylinderGeometry args={[0.12, 0.12, 0.6, 6]} />
-              <meshLambertMaterial color="#89613c" />
-            </mesh>
-
-            {/* ID silhouettes for the outline pass; inherit the group's motion. */}
-            <mesh position={[0, BLOCK_HEIGHT / 2, 0]} layers-mask={OUTLINE_ID_LAYER_MASK}>
-              <boxGeometry args={[BLOCK_WIDTH, BLOCK_HEIGHT, BLOCK_WIDTH]} />
-              <meshBasicMaterial color={new THREE.Color(r, g, b)} toneMapped={false} />
-            </mesh>
-            {traveler.type.id === "vendor" && (
-              <mesh
-                position={[0, 0.18, CART_OFFSET_Z]}
-                layers-mask={OUTLINE_ID_LAYER_MASK}
-              >
-                <boxGeometry args={CART_BED} />
-                <meshBasicMaterial color={new THREE.Color(r, g, b)} toneMapped={false} />
+            <TravelerFigure type={traveler.type} onClick={select} idColor={idColor} />
+            <group name="carried-logs" visible={false} position={[0, 0.35, 0.2]} rotation={[0, 0, Math.PI / 2]} onClick={select}>
+              <mesh><cylinderGeometry args={[0.12, 0.12, 0.6, 6]} /><meshLambertMaterial color="#89613c" /></mesh>
+              <mesh layers-mask={OUTLINE_ID_LAYER_MASK}>
+                <cylinderGeometry args={[0.12, 0.12, 0.6, 6]} /><meshBasicMaterial color={idColor} toneMapped={false} />
               </mesh>
-            )}
+            </group>
 
-            {selected && (
-              <mesh position={[0, BLOCK_HEIGHT + 0.35, 0]}>
-                <boxGeometry args={[0.2, 0.05, 0.2]} />
-                <meshBasicMaterial color="#d8a93f" />
-              </mesh>
-            )}
+            <CharacterHitTarget onClick={select} />
+            {selected && <CharacterSelectionShadow map={map} />}
           </group>
         )
       })}

--- a/components/game/tree-remains.tsx
+++ b/components/game/tree-remains.tsx
@@ -1,28 +1,29 @@
 "use client"
 
-import { useBuildStore } from "@/lib/game/build-store"
-import { useCameraStore } from "@/lib/game/camera-store"
+import * as THREE from "three"
+import { selectElement } from "@/lib/game/selection"
+import { encodeObjectId, OUTLINE_ID_LAYER_MASK } from "@/lib/game/render/outline"
 import type { TreePlacement } from "@/lib/game/trees/placement"
 import { TREE_SPECIES } from "@/lib/game/trees/species"
 import { fallenTimberDimensions, type TreeResource } from "@/lib/game/trees/timber"
 
 /** The trunk stays until hauled away; its stump has a separate decay clock. */
-export function TreeRemains({ id, tree, resource, time }: {
-  id: number; tree: TreePlacement; resource: TreeResource; time: number
+export function TreeRemains({ id, objectId, tree, resource, time }: {
+  id: number; objectId: number; tree: TreePlacement; resource: TreeResource; time: number
 }) {
   const stump = time < (resource.stumpUntil ?? 0)
   const fallen = resource.remainingWood > 0
   if (!stump && !fallen) return null
   const { radius, length, stumpHeight, offsetZ } = fallenTimberDimensions(resource)
-  const select = (event: { delta: number; stopPropagation: () => void }) => {
-    if (event.delta > 6 || useBuildStore.getState().tool) return
-    event.stopPropagation()
-    const camera = useCameraStore.getState()
-    camera.select(camera.selection?.kind === "tree" && camera.selection.id === id ? null : { kind: "tree", id })
-  }
+  const select = (event: { delta: number; stopPropagation: () => void }) => selectElement({ kind: "tree", id }, event)
+  const idColor = new THREE.Color(...encodeObjectId(objectId))
   return (
     <group name={`tree-remains-${id}`} position={[tree.x, tree.y, tree.z]} onClick={select}>
       {stump && <group name={`tree-stump-${id}`}>
+        <mesh position={[0, stumpHeight / 2, 0]} layers-mask={OUTLINE_ID_LAYER_MASK}>
+          <cylinderGeometry args={[radius, radius * 1.15, stumpHeight, 7]} />
+          <meshBasicMaterial color={idColor} toneMapped={false} />
+        </mesh>
         <mesh position={[0, stumpHeight / 2, 0]}>
           <cylinderGeometry args={[radius, radius * 1.15, stumpHeight, 7]} />
           <meshLambertMaterial color={TREE_SPECIES[tree.species].trunk.color} />
@@ -37,6 +38,10 @@ export function TreeRemains({ id, tree, resource, time }: {
         </mesh>
       </group>}
       {fallen && <group name={`fallen-tree-${id}`} position={[0, radius, offsetZ]} rotation={[0, 0, Math.PI / 2]}>
+        <mesh layers-mask={OUTLINE_ID_LAYER_MASK}>
+          <cylinderGeometry args={[radius * resource.trunkTaper, radius, length, 7]} />
+          <meshBasicMaterial color={idColor} toneMapped={false} />
+        </mesh>
         <mesh>
           <cylinderGeometry args={[radius * resource.trunkTaper, radius, length, 7]} />
           <meshLambertMaterial color={TREE_SPECIES[tree.species].trunk.color} />

--- a/components/game/trees.tsx
+++ b/components/game/trees.tsx
@@ -5,16 +5,15 @@ import { useFrame } from "@react-three/fiber"
 import * as THREE from "three"
 
 import { useCameraStore } from "@/lib/game/camera-store"
+import { selectElement } from "@/lib/game/selection"
 import { TreeRemains } from "./tree-remains"
 import { useBuildStore } from "@/lib/game/build-store"
 import { simRegistry } from "@/lib/game/sim"
 import { deriveSeed, makeRng, SEED_STREAM } from "@/lib/game/rng"
-import { TILE_HEIGHT } from "@/lib/game/map/terrain"
 import type { GameMap } from "@/lib/game/map/types"
 import {
   encodeObjectId,
   OUTLINE_ID_LAYER_MASK,
-  RELIC_OBJECT_ID,
   treeObjectId,
 } from "@/lib/game/render/outline"
 import { placeTrees, type TreePlacement } from "@/lib/game/trees/placement"
@@ -75,32 +74,22 @@ export function Trees({ map, placements: supplied, ents = false }: { map: GameMa
   const resources = useBuildStore((s) => s.treeResources)
   const time = useBuildStore((s) => s.time)
   const felled = useBuildStore((s) => s.felled)
-  const selectionRing = useRef<THREE.Mesh>(null)
   const species = useTreeTuningStore((s) => s.species)
   const placements = useMemo(() => supplied ?? placeTrees(map, species), [map, species, supplied])
 
   const selected = selection?.kind === "tree" ? placements[selection.id] : null
   const resource = selection?.kind === "tree" ? resources.get(selection.id) : null
   const visible = !resource || resource.health > 0 || resource.remainingWood > 0 || time < (resource.stumpUntil ?? 0)
-  useFrame(() => {
-    if (selectionRing.current && selected) selectionRing.current.position.set(selected.x, selected.y + 0.025, selected.z)
-  })
   useEffect(() => {
     if (selection?.kind === "tree" && (!selected || !visible)) useCameraStore.getState().select(null)
   }, [selection, selected, visible])
-  const selectTree = (id: number) => {
-    const camera = useCameraStore.getState()
-    camera.select(camera.selection?.kind === "tree" && camera.selection.id === id ? null : { kind: "tree", id })
-  }
+  const selectTree = (id: number, event: { delta: number; stopPropagation: () => void }) => selectElement({ kind: "tree", id }, event)
   return (
     <group>
       <TreeField placements={placements} hidden={felled} onSelect={selectTree} entMap={ents ? map : undefined}
         seed={deriveSeed(map.seed ?? 0, SEED_STREAM.treeShapes)} idBase={map.buildings.length} />
       {Array.from(resources, ([id, resource]) => resource.health <= 0 && placements[id]
-        ? <TreeRemains key={id} id={id} tree={placements[id]} resource={resource} time={time} /> : null)}
-      {selected && visible && <mesh ref={selectionRing} name="tree-selection-ring" position={[selected.x, selected.y + 0.025, selected.z]} rotation={[-Math.PI / 2, 0, 0]}>
-        <ringGeometry args={[0.25, 0.32, 24]} /><meshBasicMaterial color="#e4bb58" depthTest={false} />
-      </mesh>}
+        ? <TreeRemains key={id} id={id} objectId={treeObjectId(map.buildings.length, id)} tree={placements[id]} resource={resource} time={time} /> : null)}
     </group>
   )
 }
@@ -131,7 +120,7 @@ export function TreeField({
   /** Only the game enables Ents; galleries retain their static tree lineup. */
   entMap?: GameMap
   hidden?: ReadonlySet<number>
-  onSelect?: (index: number) => void
+  onSelect?: (index: number, event: { delta: number; stopPropagation: () => void }) => void
 }) {
   const species = useTreeTuningStore((s) => s.species)
   const variance = useTreeTuningStore((s) => s.variance)
@@ -142,10 +131,9 @@ export function TreeField({
     // Trees take the ID block between the buildings and the relic. On huge maps
     // IDs wrap rather than overflow: two trees sharing an ID only lose the
     // outline between themselves, and they are far apart.
-    const idSpan = RELIC_OBJECT_ID - 1 - idBase
     placements.forEach((placement, index) => {
       const shape = placement.shape ?? generateTree(species[placement.species], rng, variance)
-      const objectId = treeObjectId(idBase, index % idSpan)
+      const objectId = treeObjectId(idBase, index)
       let list = grouped.get(placement.species)
       if (!list) grouped.set(placement.species, (list = []))
       list.push({ index, placement, shape, objectId, ent: entMap ? createEnt(placement, entMap.seed ?? 0, index) : undefined })
@@ -173,7 +161,7 @@ function SpeciesBatch({ def, trees, entMap, onSelect }: {
   def: TreeSpeciesDef
   trees: GrownTree[]
   entMap?: GameMap
-  onSelect?: (index: number) => void
+  onSelect?: (index: number, event: { delta: number; stopPropagation: () => void }) => void
 }) {
   const crownOwners = useMemo(() => trees.flatMap((tree) => tree.shape.crown.map(() => tree.index)), [trees])
   const select = (crown: boolean) => (event: { instanceId?: number; delta: number; stopPropagation: () => void }) => {
@@ -181,7 +169,7 @@ function SpeciesBatch({ def, trees, entMap, onSelect }: {
     const index = crown ? crownOwners[event.instanceId] : trees[event.instanceId]?.index
     if (index === undefined) return
     event.stopPropagation()
-    onSelect(index)
+    onSelect(index, event)
   }
   const trunkGeometry = useMemo(() => makeTrunkGeometry(def.trunk.taper), [def.trunk.taper])
   const crownGeometry = useMemo(() => makeCrownGeometry(def.crown.shape), [def.crown.shape])

--- a/components/game/wood-pile.tsx
+++ b/components/game/wood-pile.tsx
@@ -2,20 +2,21 @@
 
 import { useLayoutEffect, useMemo, useRef } from "react"
 import * as THREE from "three"
-import { useBuildStore } from "@/lib/game/build-store"
-import { isSelected, useCameraStore } from "@/lib/game/camera-store"
+import { selectElement } from "@/lib/game/selection"
+import { encodeObjectId, OUTLINE_ID_LAYER_MASK } from "@/lib/game/render/outline"
 import { WOOD_PER_LOG, pileLogCount, type WoodPile as Pile } from "@/lib/game/trees/timber"
 
 /** A stack of logs, with pale cut ends, kept within its patch of the camp yard. */
-export function WoodPile({ pile }: { pile: Pile }) {
-  const selection = useCameraStore((s) => s.selection)
-  const selected = isSelected(selection, { kind: "pile", id: pile.id })
+export function WoodPile({ pile, objectId }: { pile: Pile; objectId: number }) {
+  const idColor = useMemo(() => new THREE.Color(...encodeObjectId(objectId)), [objectId])
+  const barkId = useRef<THREE.InstancedMesh>(null)
+  const endsId = useRef<THREE.InstancedMesh>(null)
   const count = pileLogCount(pile.wood)
   const bark = useRef<THREE.InstancedMesh>(null)
   const ends = useRef<THREE.InstancedMesh>(null)
   const matrix = useMemo(() => new THREE.Matrix4(), [])
   useLayoutEffect(() => {
-    if (!bark.current || !ends.current) return
+    if (!bark.current || !ends.current || !barkId.current || !endsId.current) return
     const rotation = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(1, 0, 0), Math.PI / 2)
     for (let i = 0; i < count; i++) {
       const fraction = Math.min(1, (pile.wood - i * WOOD_PER_LOG) / WOOD_PER_LOG)
@@ -24,34 +25,37 @@ export function WoodPile({ pile }: { pile: Pile }) {
       const y = 0.13 + layer * 0.145
       matrix.compose(new THREE.Vector3(x, y, 0), rotation, new THREE.Vector3(1, fraction, 1))
       bark.current.setMatrixAt(i, matrix)
+      barkId.current.setMatrixAt(i, matrix)
       for (let end = 0; end < 2; end++) {
         matrix.compose(new THREE.Vector3(x, y, (end === 0 ? -1 : 1) * (0.3 * fraction + 0.006)), rotation, new THREE.Vector3(1, 1, 1))
         ends.current.setMatrixAt(i * 2 + end, matrix)
+        endsId.current.setMatrixAt(i * 2 + end, matrix)
       }
     }
-    for (const mesh of [bark.current, ends.current]) {
+    for (const mesh of [bark.current, ends.current, barkId.current, endsId.current]) {
       mesh.instanceMatrix.needsUpdate = true
       mesh.computeBoundingSphere()
     }
   }, [count, matrix, pile.wood])
-  const select = (event: { delta: number; stopPropagation: () => void }) => {
-    if (event.delta > 6 || useBuildStore.getState().tool) return
-    event.stopPropagation()
-    useCameraStore.getState().select(selected ? null : { kind: "pile", id: pile.id })
-  }
+  const select = (event: { delta: number; stopPropagation: () => void }) => selectElement({ kind: "pile", id: pile.id }, event)
   return (
     <group name={`wood-pile-${pile.id}`} onClick={select}>
       <instancedMesh key={`bark-${count}`} ref={bark} args={[undefined, undefined, count]}>
         <cylinderGeometry args={[0.075, 0.082, 0.6, 7]} />
-        <meshLambertMaterial color={selected ? "#ae7b39" : "#765036"} />
+        <meshLambertMaterial color="#765036" />
       </instancedMesh>
       <instancedMesh key={`ends-${count}`} ref={ends} args={[undefined, undefined, count * 2]}>
         <cylinderGeometry args={[0.069, 0.069, 0.012, 7]} />
-        <meshLambertMaterial color={selected ? "#f2ce77" : "#d2ad71"} />
+        <meshLambertMaterial color="#d2ad71" />
       </instancedMesh>
-      {selected && <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.045, 0]}>
-        <ringGeometry args={[0.4, 0.46, 24]} /><meshBasicMaterial color="#e4bb58" />
-      </mesh>}
+      <instancedMesh key={`bark-id-${count}`} ref={barkId} args={[undefined, undefined, count]} layers-mask={OUTLINE_ID_LAYER_MASK}>
+        <cylinderGeometry args={[0.075, 0.082, 0.6, 7]} />
+        <meshBasicMaterial color={idColor} toneMapped={false} />
+      </instancedMesh>
+      <instancedMesh key={`ends-id-${count}`} ref={endsId} args={[undefined, undefined, count * 2]} layers-mask={OUTLINE_ID_LAYER_MASK}>
+        <cylinderGeometry args={[0.069, 0.069, 0.012, 7]} />
+        <meshBasicMaterial color={idColor} toneMapped={false} />
+      </instancedMesh>
     </group>
   )
 }

--- a/lib/game/render/outline.ts
+++ b/lib/game/render/outline.ts
@@ -13,6 +13,9 @@
 export const OUTLINE_ID_LAYER = 1
 export const OUTLINE_ID_LAYER_MASK = 1 << OUTLINE_ID_LAYER
 
+/** Only the selected character's visible meshes enter this isolated colour pass. */
+export const SELECTED_CHARACTER_LAYER = 2
+
 /**
  * Rendering modes, in the order the O key cycles through them:
  *  - overlap:    outline only where an object overlaps a different object.
@@ -63,9 +66,10 @@ export function buildingObjectId(buildingIndex: number): number {
   return 1 + buildingIndex
 }
 
-/** Trees follow the buildings, one ID per tree so each reads as its own object. */
+/** Trees follow buildings, wrapping below the relic if the ID block fills up. */
 export function treeObjectId(buildingCount: number, treeIndex: number): number {
-  return 1 + buildingCount + treeIndex
+  const span = RELIC_OBJECT_ID - 1 - buildingCount
+  return 1 + buildingCount + treeIndex % span
 }
 
 /**
@@ -98,6 +102,11 @@ export function placedObjectId(placedIndex: number): number {
  * the shrine that houses it rather than merging into the walls.
  */
 export const RELIC_OBJECT_ID = 0x800000
+
+/** Wood stacks use the block immediately above the relic, clear of tree IDs. */
+export function pileObjectId(pileIndex: number): number {
+  return RELIC_OBJECT_ID + 1 + pileIndex
+}
 
 /**
  * Default road-edge thickness in CSS pixels. Object outlines use one rendered

--- a/lib/game/selection.test.ts
+++ b/lib/game/selection.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { useBuildStore } from "./build-store"
+import { useCameraStore, type Selection } from "./camera-store"
+import { selectElement, selectionObjectId } from "./selection"
+import { buildingObjectId, pileObjectId, RELIC_OBJECT_ID, residentObjectId, travelerObjectId, treeObjectId } from "./render/outline"
+
+const objects = {
+  buildings: [{ id: "hovel" }, { id: "lumberCamp-1" }],
+  travelers: [{ id: 41 }, { id: 9 }],
+  monks: [{ id: 72 }, { id: 18 }],
+  piles: [{ id: "pile-a" }, { id: "pile-b" }],
+}
+const selections: Selection[] = [
+  { kind: "tree", id: 6 }, { kind: "building", id: "lumberCamp-1" },
+  { kind: "traveler", id: 9 }, { kind: "monk", id: 18 },
+  { kind: "pile", id: "pile-b" }, { kind: "relic" },
+]
+
+afterEach(() => {
+  useCameraStore.getState().select(null)
+  useBuildStore.getState().reset()
+})
+
+describe("shared selection", () => {
+  it.each(selections)("toggles $kind and replaces the previous selection", (candidate) => {
+    const event = { delta: 0, stopPropagation: vi.fn() }
+    useCameraStore.getState().select({ kind: "tree", id: 999 })
+    selectElement(candidate, event)
+    expect(useCameraStore.getState().selection).toEqual(candidate)
+    expect(event.stopPropagation).toHaveBeenCalledOnce()
+    selectElement(candidate, event)
+    expect(useCameraStore.getState().selection).toBeNull()
+  })
+
+  it.each(selections)("ignores drags and active building tools for $kind", (candidate) => {
+    const previous: Selection = { kind: "tree", id: 999 }
+    useCameraStore.getState().select(previous)
+    const event = { delta: 7, stopPropagation: vi.fn() }
+    selectElement(candidate, event)
+    useBuildStore.getState().setTool("lumberCamp")
+    selectElement(candidate, { ...event, delta: 0 })
+    expect(useCameraStore.getState().selection).toEqual(previous)
+    expect(event.stopPropagation).not.toHaveBeenCalled()
+  })
+
+  it("maps stable game identities to distinct rendered IDs", () => {
+    const ids = selections.map((selection) => selectionObjectId(selection, objects))
+    expect(ids).toEqual([
+      treeObjectId(2, 6), buildingObjectId(1), travelerObjectId(1),
+      residentObjectId(1), pileObjectId(1), RELIC_OBJECT_ID,
+    ])
+    expect(new Set(ids).size).toBe(ids.length)
+    expect(selectionObjectId({ kind: "pile", id: "pile-b" }, { ...objects, piles: [objects.piles[1]] })).toBe(pileObjectId(0))
+  })
+
+  it("clears the effect when a selected identity is gone", () => {
+    expect(selectionObjectId(null, objects)).toBe(0)
+    expect(selectionObjectId({ kind: "building", id: "gone" }, objects)).toBe(0)
+    expect(selectionObjectId({ kind: "traveler", id: -1 }, objects)).toBe(0)
+    expect(selectionObjectId({ kind: "monk", id: -1 }, objects)).toBe(0)
+    expect(selectionObjectId({ kind: "pile", id: "gone" }, objects)).toBe(0)
+  })
+})

--- a/lib/game/selection.ts
+++ b/lib/game/selection.ts
@@ -1,0 +1,40 @@
+import { useBuildStore } from "./build-store"
+import { isSelected, useCameraStore, type Selection } from "./camera-store"
+import {
+  buildingObjectId, pileObjectId, RELIC_OBJECT_ID, residentObjectId,
+  travelerObjectId, treeObjectId,
+} from "./render/outline"
+
+export const SELECTION_COLOR = "#e4bb58"
+export const SELECTION_OUTLINE_COLOR = "#ffffff"
+export const SELECTION_OUTLINE_OPACITY = 0.65
+export const SELECTION_FILL = "#fff2ba"
+export const SELECTION_FILL_OPACITY = 0.06
+
+/** All world selections share drag rejection, build-tool priority, and toggle behavior. */
+export function selectElement(candidate: Selection, event: { delta: number; stopPropagation: () => void }) {
+  if (event.delta > 6 || useBuildStore.getState().tool) return
+  event.stopPropagation()
+  const camera = useCameraStore.getState()
+  camera.select(isSelected(camera.selection, candidate) ? null : candidate)
+}
+
+/** Resolve inspector identities to the same IDs used by the visible geometry. */
+export function selectionObjectId(selection: Selection | null, objects: {
+  buildings: readonly { id: string }[]
+  travelers: readonly { id: number }[]
+  monks: readonly { id: number }[]
+  piles: readonly { id: string }[]
+}): number {
+  if (!selection) return 0
+  if (selection.kind === "relic") return RELIC_OBJECT_ID
+  if (selection.kind === "tree") return treeObjectId(objects.buildings.length, selection.id)
+  const list = selection.kind === "building" ? objects.buildings
+    : selection.kind === "traveler" ? objects.travelers
+      : selection.kind === "monk" ? objects.monks : objects.piles
+  const index = list.findIndex((object) => object.id === selection.id)
+  if (index < 0) return 0
+  return selection.kind === "building" ? buildingObjectId(index)
+    : selection.kind === "traveler" ? travelerObjectId(index)
+      : selection.kind === "monk" ? residentObjectId(index) : pileObjectId(index)
+}


### PR DESCRIPTION
Unifies selection across trees, characters, buildings, the relic, and wood piles with thin white outer outlines, subtle brightening, and shared click/toggle behavior, replacing tree base rings and overhead markers.
Characters gain larger click targets and a soft ground glow, and retain their true silhouette behind foreground objects through a 50% mask over the overlapping area, including carts and carried items.
Buildings and the shrine are independently selectable, and lumber-camp inspectors show live stored-wood totals.

Validation: typecheck and 321 tests passed; browser checks covered selection with outlines disabled, expanded character targets, obscured-character rendering, and camp stock updating from 0 to 137 wood without browser errors.
