### PR TITLE
Round road bends and blend junction surfaces

### DIFF
--- a/components/game/terrain-tiles.tsx
+++ b/components/game/terrain-tiles.tsx
@@ -12,6 +12,7 @@ import {
   DEFAULT_ROAD_LOOK,
   DEFAULT_ROAD_TIER,
   isRoadTerrain,
+  junctionShoulders,
   ROAD_TIERS,
   roadContinues,
   roadEdge,
@@ -28,6 +29,7 @@ import {
 } from "@/lib/game/map/terrain"
 import { tileAt, tileToWorldX, tileToWorldZ, type GameMap } from "@/lib/game/map/types"
 import { OUTLINE_ID_LAYER_MASK } from "@/lib/game/render/outline"
+import { ROAD_SHAPE_GLSL } from "@/lib/game/render/road-shape"
 import { DEFAULT_TRAFFIC } from "@/lib/game/travelers"
 
 /** Top of the base slab. Must sit below the shortest terrain height. */
@@ -160,13 +162,14 @@ interface TileMaterialOptions {
  * tint; nothing green is ever painted, so the grass on and beside a road
  * tile is one continuous surface.
  *
- * Where the surface ends is the distance from the nearest side flagged open
- * in `aRoadOpen`. The bare ruts cover between the outer and inner edges in
- * `aLand` (see roadWear) plus a world-space waver, so grass runs along the
- * verges and down the middle, and the bare part widens with traffic — never
- * past the road's own tiles. Paved tiers are cut straight and laid edge to
- * edge. A dark line can be drawn along the outer edge, and the surface's
- * opacity and shade tuned, through the `look` uniforms.
+ * `aRoadOpen` identifies the entrances joined by straight tracks and tangent
+ * curves. Their ruts merge at junctions, while `aRoadCorners` fills broad road
+ * patches. `aRoadShoulders` rounds inside junction corners across adjoining
+ * grass tiles; `aGrass` marks those tiles as shoulder-only in the road batch.
+ * The outer and inner edges in `aLand` (see roadWear), plus a
+ * world-space waver, leave grassy verges and a median that wears with traffic.
+ * Paved tiers fill the same curved footprint. The `look` uniforms tune the
+ * surface and an outline along the combined outer edge.
  *
  * With `gridOrigin` set, the global grid lattice is drawn on top.
  */
@@ -200,9 +203,13 @@ function makeTileMaterial({
         varying vec4 vOverlay;
         #ifdef USE_ROAD_MAP
           attribute vec4 aRoadOpen;
+          attribute vec4 aRoadCorners;
+          attribute vec4 aRoadShoulders;
           attribute vec4 aLandOverlay;
           attribute vec3 aLand;
           varying vec4 vRoadOpen;
+          varying vec4 vRoadCorners;
+          varying vec4 vRoadShoulders;
           varying vec4 vLandOverlay;
           varying vec3 vLand;
           varying vec2 vTileLocal;
@@ -224,6 +231,8 @@ function makeTileMaterial({
           vOverlay = aOverlay;
           #ifdef USE_ROAD_MAP
             vRoadOpen = aRoadOpen;
+            vRoadCorners = aRoadCorners;
+            vRoadShoulders = aRoadShoulders;
             vLandOverlay = aLandOverlay;
             vLand = aLand;
             // Tile-local XZ in world axes, matching the road edge flags.
@@ -253,9 +262,12 @@ function makeTileMaterial({
           uniform float roadEdgeWidth;
           uniform float roadPixelRatio;
           varying vec4 vRoadOpen;
+          varying vec4 vRoadCorners;
+          varying vec4 vRoadShoulders;
           varying vec4 vLandOverlay;
           varying vec3 vLand;
           varying vec2 vTileLocal;
+          ${ROAD_SHAPE_GLSL}
         #endif
         float tileHash(vec2 p) {
           return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
@@ -312,39 +324,30 @@ function makeTileMaterial({
             #endif
             vec3 road = mix(roadTex.rgb * roadShade, vOverlay.rgb, vOverlay.a) * roadColor;
 
-            // Distance in from the nearest open side of this road tile (1.0
-            // with none open: a junction, road on every side).
-            float d = 1.0;
-            d = min(d, mix(1.0, 1.0 - vTileLocal.x, vRoadOpen.x));
-            d = min(d, mix(1.0, vTileLocal.x, vRoadOpen.y));
-            d = min(d, mix(1.0, 1.0 - vTileLocal.y, vRoadOpen.z));
-            d = min(d, mix(1.0, vTileLocal.y, vRoadOpen.w));
-
             // The rut's outer edge: traffic's verge, wavering by world-space
             // noise so the edge is ragged but continuous from tile to tile;
             // the tier says how much it wavers.
             float waver = tileNoise(world * 3.7) * 0.65 + tileNoise(world * 8.3) * 0.35;
             float edge = vEdge + ${EDGE_WAVER} * roadEdgeWear * (waver - 0.5);
 
-            // A cart track: bare from the outer edge in to the inner one, then
-            // a strip of grass down the middle (mirrored about the road's
-            // centre at 0.5, and never in a tile with no open side — that is
-            // a junction, trodden from every way). Grass creeps into the ruts
-            // unevenly: fine noise shifts each fragment's distance so tufts
-            // fray the edges, thickest along the verge and thinning toward
-            // where the wheels and feet actually go.
+            // Union the individual wheel tracks, so turning traffic wears
+            // through the median at a fork instead of leaving a square seam.
+            // Noise over world position frays the verges continuously.
             float tuft = tileNoise(world * 7.0) * 0.6 + tileNoise(world * 15.0) * 0.4;
-            float dn = d + (tuft - 0.5) * 0.2 * roadEdgeWear;
-            float outer = smoothstep(edge - 0.06, edge + 0.12, dn);
-            float middle = smoothstep(vInner - 0.06, vInner + 0.04, dn)
-              * (1.0 - smoothstep(1.0 - vInner - 0.04, 1.0 - vInner + 0.06, dn));
-            float bare = outer * (1.0 - middle);
+            vec2 shape = roadShape(vTileLocal, 1.0 - vRoadOpen, vRoadCorners,
+              edge, vInner, (tuft - 0.5) * 0.2 * roadEdgeWear);
+            // Grass tiles at a junction carry only the adjoining shoulder.
+            if (vGrass > 0.5) shape = vec2(0.0, -1.0);
+            shape = max(shape, roadShoulders(vTileLocal, vRoadShoulders,
+              edge, (tuft - 0.5) * 0.2 * roadEdgeWear));
+            float bare = shape.x;
+            float d = shape.y;
             float cover = bare * roadTex.a * roadOpacity;
 
             // A line along the edge, sized on screen like the outlines the
             // trees wear: fwidth(d) is one device pixel in tile units, so the
             // width holds at every zoom instead of scaling with the tiles.
-            float px = fwidth(d);
+            float px = max(fwidth(d), 0.00001);
             float halfLine = 0.5 * roadEdgeWidth * roadPixelRatio * px;
             float line = (1.0 - smoothstep(halfLine - 0.5 * px, halfLine + 0.5 * px, abs(d - edge))) * roadEdgeLine;
 
@@ -384,8 +387,8 @@ function makeTileMaterial({
 /**
  * Attach the per-instance data makeTileMaterial reads: `aGrass` and
  * `aOverlay` on every tile. A road geometry also carries which sides face
- * open land, where traffic puts the rut edges, and what the land here looks
- * like (grass overlay and grain).
+ * open land, its filled corners and junction shoulders, where traffic puts
+ * the rut edges, and what the land here looks like (grass overlay and grain).
  */
 function addTileAttributes(geometry: THREE.BufferGeometry, slots: number, road: boolean): void {
   const n = Math.max(1, slots)
@@ -393,6 +396,8 @@ function addTileAttributes(geometry: THREE.BufferGeometry, slots: number, road: 
   geometry.setAttribute("aOverlay", new THREE.InstancedBufferAttribute(new Float32Array(n * 4), 4))
   if (road) {
     geometry.setAttribute("aRoadOpen", new THREE.InstancedBufferAttribute(new Float32Array(n * 4), 4))
+    geometry.setAttribute("aRoadCorners", new THREE.InstancedBufferAttribute(new Float32Array(n * 4), 4))
+    geometry.setAttribute("aRoadShoulders", new THREE.InstancedBufferAttribute(new Float32Array(n * 4), 4))
     geometry.setAttribute("aLandOverlay", new THREE.InstancedBufferAttribute(new Float32Array(n * 4), 4))
     // Grain and the two rut edges packed together: vertex attributes are a
     // scarce resource (16 is a common limit) and the instance matrix alone
@@ -553,9 +558,10 @@ export function TerrainTiles({
     ...bridges.connectors, ...bridges.ramps,
   ].map((tile) => tile.z * map.width + tile.x)), [bridges, map.width])
   const tier = ROAD_TIERS[clampRoadTier(roadTier)]
+  const shoulders = useMemo(() => junctionShoulders(map, coveredLand), [map, coveredLand])
   const roadCount = useMemo(
-    () => map.tiles.reduce((n, t, i) => (isRoadTerrain(t) && !coveredLand.has(i) ? n + 1 : n), 0),
-    [map, coveredLand],
+    () => map.tiles.reduce((n, t, i) => ((isRoadTerrain(t) || shoulders.has(i)) && !coveredLand.has(i) ? n + 1 : n), 0),
+    [map, coveredLand, shoulders],
   )
 
   // The look is uniforms shared with the material: tuned in place, no recompile.
@@ -651,6 +657,9 @@ export function TerrainTiles({
         mesh,
         next: 0,
         open: attr(geometry, "aRoadOpen"),
+        corners: attr(geometry, "aRoadCorners"),
+        shoulders: attr(geometry, "aRoadShoulders"),
+        grass: attr(geometry, "aGrass"),
         landOverlay: attr(geometry, "aLandOverlay"),
         land: attr(geometry, "aLand"),
         overlay: attr(geometry, "aOverlay"),
@@ -704,7 +713,8 @@ export function TerrainTiles({
         // Where this tile sits on the forest-shade ramp.
         shadeTint(index, tint)
 
-        if (isRoadTerrain(terrain)) {
+        if (isRoadTerrain(terrain) || shoulders.has(index)) {
+          const shoulderOnly = !isRoadTerrain(terrain)
           // The texture carries the road's colour; the instance carries the
           // weathering from whatever surrounds this stretch, plus the grain.
           const [r, g, b] = roadTint(map, x, z, tier.tier)
@@ -730,6 +740,7 @@ export function TerrainTiles({
           }
           if (swardAround > 0) landOverlay.divideScalar(swardAround)
           else landOverlay.copy(paintLand(map, "grass", x, z, tint, land).overlay)
+          if (shoulderOnly) landOverlay.copy(paintLand(map, terrain, x, z, tint, land).overlay)
           // The grain a land tile here would have had, from the same draw
           // (under the same canopy), and the rut edges for this road's own
           // traffic.
@@ -741,8 +752,11 @@ export function TerrainTiles({
             const i = target.next++
             target.mesh.setMatrixAt(i, matrix)
             target.mesh.setColorAt(i, color)
-            target.overlay.setXYZW(i, tint.r, tint.g, tint.b, def.shadeBlend)
+            target.overlay.setXYZW(i, tint.r, tint.g, tint.b, shoulderOnly ? TERRAIN.path.shadeBlend : def.shadeBlend)
             target.open.setXYZW(i, edge.open[0], edge.open[1], edge.open[2], edge.open[3])
+            target.corners.setXYZW(i, ...edge.filledCorners)
+            target.shoulders.setXYZW(i, ...(shoulders.get(index) ?? [0, 0, 0, 0]))
+            target.grass.setX(i, shoulderOnly ? 1 : 0)
             target.landOverlay.setXYZW(i, landOverlay.x, landOverlay.y, landOverlay.z, landOverlay.w)
             target.land.setXYZ(i, landJitter, wear.edge, wear.inner)
           }
@@ -766,6 +780,9 @@ export function TerrainTiles({
       target.mesh.instanceMatrix.needsUpdate = true
       if (target.mesh.instanceColor) target.mesh.instanceColor.needsUpdate = true
       target.open.needsUpdate = true
+      target.corners.needsUpdate = true
+      target.shoulders.needsUpdate = true
+      target.grass.needsUpdate = true
       target.landOverlay.needsUpdate = true
       target.land.needsUpdate = true
       target.overlay.needsUpdate = true
@@ -785,6 +802,7 @@ export function TerrainTiles({
     roadGeometry,
     groundGeometry,
     coveredLand,
+    shoulders,
   ])
 
   const dirt = useLoader(THREE.TextureLoader, DIRT_TEXTURE_URL)

--- a/lib/game/game.test.ts
+++ b/lib/game/game.test.ts
@@ -10,6 +10,7 @@ import {
   MAX_ROAD_TIER,
   ROAD_TIERS,
   isRoadTerrain,
+  junctionShoulders,
   roadEdge,
   roadTint,
   roadWear,
@@ -510,6 +511,54 @@ describe("road edges", () => {
     const map = parseAsciiMap(["=..", "==.", ".=."])
     // The bend tile: road continues west and south; grass east and north-east.
     expect(roadEdge(map, 1, 1).open).toEqual([1, 0, 0, 1])
+  })
+
+  it("keeps forks and crossroads curved when their diagonal corners are grass", () => {
+    for (const rows of [["...", "===", ".-."], [".=.", "===", ".-."]]) {
+      expect(roadEdge(parseAsciiMap(rows), 1, 1).filledCorners).toEqual([0, 0, 0, 0])
+    }
+  })
+
+  it("fills the same shared corner on all four tiles of a broad road patch", () => {
+    const map = parseAsciiMap(["....", ".==.", ".--.", "...."])
+    expect(roadEdge(map, 1, 1).filledCorners).toEqual([1, 0, 0, 0])
+    expect(roadEdge(map, 2, 1).filledCorners).toEqual([0, 0, 1, 0])
+    expect(roadEdge(map, 1, 2).filledCorners).toEqual([0, 1, 0, 0])
+    expect(roadEdge(map, 2, 2).filledCorners).toEqual([0, 0, 0, 1])
+    const plaza = parseAsciiMap(["===", "===", "==="])
+    expect(roadEdge(plaza, 1, 1).filledCorners).toEqual([1, 1, 1, 1])
+  })
+
+  it("continues into a bridge without widening onto its neighbouring water", () => {
+    const map = parseAsciiMap(["....", ".=#.", ".-=.", "...."])
+    expect(roadEdge(map, 1, 1).open).toEqual([0, 1, 0, 1])
+    expect(roadEdge(map, 1, 1).filledCorners).toEqual([0, 0, 0, 0])
+  })
+})
+
+describe("junction shoulders", () => {
+  it("shares both inside curves of a T across their four adjoining tiles", () => {
+    const map = parseAsciiMap([".....", ".....", "=====", "..=..", "..=.."])
+    const shoulders = junctionShoulders(map)
+    expect(shoulders.get(2 * 5 + 2)).toEqual([1, 0, 3, 0])
+    // The same southeast shoulder at the junction, main road, branch, grass.
+    expect(shoulders.get(2 * 5 + 3)?.[2]).toBe(1)
+    expect(shoulders.get(3 * 5 + 2)?.[1]).toBe(1)
+    expect(shoulders.get(3 * 5 + 3)?.[3]).toBe(1)
+    expect(shoulders.size).toBe(6)
+  })
+
+  it("keeps shoulders off water, bridge approaches, and building footprints", () => {
+    const map = parseAsciiMap([".....", ".....", "=====", ".~=..", "..=.."])
+    expect(junctionShoulders(map).has(3 * 5 + 1)).toBe(false)
+    expect(junctionShoulders(map, new Set([2 * 5 + 2])).size).toBe(0)
+    map.buildings.push({ id: "test", label: "House", x: 3, z: 3, w: 1, d: 1, height: 1, color: "brown", roofColor: "brown" })
+    expect(junctionShoulders(map).size).toBe(0)
+  })
+
+  it("leaves ordinary bends and straight roads alone", () => {
+    expect(junctionShoulders(parseAsciiMap([".....", ".....", "===..", "..=..", "..=.."])).size).toBe(0)
+    expect(junctionShoulders(parseAsciiMap([".....", "=====", "....."])).size).toBe(0)
   })
 })
 

--- a/lib/game/map/road.ts
+++ b/lib/game/map/road.ts
@@ -96,8 +96,8 @@ export function isRoadTerrain(terrain: TerrainId | null): terrain is RoadTerrain
  * a little way in from either side, grass between them down the middle and
  * grass along the verges outside. Feet and wheels widen the ruts — outward
  * into the verge, inward into the middle strip — until at this many
- * travelers and up the surface is bare from side to side of its tiles. It
- * never leaves them.
+ * travelers and up the surface is bare from side to side of its tiles.
+ * The renderer adds small curved shoulders where junctions meet grassy land.
  */
 export const TRAFFIC_FOR_BARE_ROAD = 30
 
@@ -213,6 +213,8 @@ export interface RoadEdge {
    * edge of the world.
    */
   open: SideFlags
+  /** Solid 2x2 road patches at corners, in ++, +-, -+, -- order. */
+  filledCorners: SideFlags
 }
 
 
@@ -242,5 +244,57 @@ export function roadEdge(map: GameMap, x: number, z: number): RoadEdge {
     const [dx, dz] = EDGE_DIRS[side]
     if (!roadContinues(tileAt(map, x + dx, z + dz))) open[side] = 1
   }
-  return { open }
+  const filledCorners: SideFlags = [0, 0, 0, 0]
+  for (let corner = 0; corner < 4; corner++) {
+    const xSide = corner < 2 ? 0 : 1
+    const zSide = corner % 2 === 0 ? 2 : 3
+    const dx = xSide === 0 ? 1 : -1
+    const dz = zSide === 2 ? 1 : -1
+    // Off-map and bridges continue a lane but do not create a paved plaza.
+    if (
+      isRoadTerrain(tileAt(map, x + dx, z)) &&
+      isRoadTerrain(tileAt(map, x, z + dz)) &&
+      isRoadTerrain(tileAt(map, x + dx, z + dz))
+    ) {
+      filledCorners[corner] = 1
+    }
+  }
+  return { open, filledCorners }
+}
+
+/**
+ * Rounded inside shoulders at T/cross junctions. Each shared corner records
+ * which quadrant faces grass (1: ++, 2: +-, 3: -+, 4: --). All four tiles
+ * receive the same shape so its surface and outline cross their seams.
+ */
+export function junctionShoulders(map: GameMap, excluded: ReadonlySet<number> = new Set()): Map<number, SideFlags> {
+  const shoulders = new Map<number, SideFlags>()
+  const road = (x: number, z: number) => isRoadTerrain(tileAt(map, x, z)) && !excluded.has(z * map.width + x)
+  for (let z = 0; z < map.depth; z++) {
+    for (let x = 0; x < map.width; x++) {
+      if (!road(x, z)) continue
+      if (EDGE_DIRS.filter(([dx, dz]) => road(x + dx, z + dz)).length < 3) continue
+      for (const dx of [-1, 1]) {
+        for (const dz of [-1, 1]) {
+          if (!road(x + dx, z) || !road(x, z + dz)) continue
+          // Shoulders may use a grassy verge, never water or occupied land.
+          if (tileAt(map, x + dx, z + dz) !== "grass" || excluded.has((z + dz) * map.width + x + dx)) continue
+          if (map.buildings.some(b => x + dx >= b.x && x + dx < b.x + b.w && z + dz >= b.z && z + dz < b.z + b.d)) continue
+          const code = (dx > 0 ? 1 : 3) + (dz > 0 ? 0 : 1)
+          const cornerX = x + (dx > 0 ? 1 : 0)
+          const cornerZ = z + (dz > 0 ? 1 : 0)
+          for (const tx of [x, x + dx]) {
+            for (const tz of [z, z + dz]) {
+              const index = tz * map.width + tx
+              const flags = shoulders.get(index) ?? [0, 0, 0, 0]
+              const corner = (cornerX - tx === 1 ? 0 : 2) + (cornerZ - tz === 1 ? 0 : 1)
+              flags[corner] = code
+              shoulders.set(index, flags)
+            }
+          }
+        }
+      }
+    }
+  }
+  return shoulders
 }

--- a/lib/game/render/road-shape.ts
+++ b/lib/game/render/road-shape.ts
@@ -1,0 +1,105 @@
+/**
+ * Road coverage in tile-local XZ. Opposite entrances share a straight track;
+ * adjacent entrances share a radius-0.5 arc tangent to both tile boundaries.
+ * Taking the union of each track's ruts lets wheels wear through the grass
+ * median when paths cross, without drawing an edge through the junction.
+ * Junctions have a worn apron and rounded shoulders extending onto grass.
+ *
+ * Returns (bare coverage, distance inward from the combined road boundary).
+ * Connections use +x, -x, +z, -z; filled corners use ++, +-, -+, --.
+ */
+export const ROAD_SHAPE_GLSL = /* glsl */ `
+  vec2 roadStrip(float distanceToTrack, float edge, float inner, float roughness) {
+    float d = 0.5 - distanceToTrack;
+    float dn = d + roughness;
+    float outer = smoothstep(edge - 0.06, edge + 0.12, dn);
+    float middle = smoothstep(inner - 0.06, inner + 0.04, dn);
+    return vec2(outer * (1.0 - middle), d);
+  }
+
+  // Keep the two nearest tracks so their shoulders can be rounded together.
+  // Sorting distances makes the result independent of entrance/rotation order.
+  vec3 addRoadStrip(vec3 shape, vec2 strip) {
+    return vec3(max(shape.x, strip.x), max(shape.y, strip.y), max(shape.z, min(shape.y, strip.y)));
+  }
+
+  vec2 roadShoulder(vec2 p, vec2 corner, float code, float edge, float roughness) {
+    if (code < 0.5) return vec2(0.0, -1.0);
+    vec2 direction = vec2(code < 2.5 ? 1.0 : -1.0, mod(code, 2.0) > 0.5 ? 1.0 : -1.0);
+    vec2 q = (p - corner) * direction;
+    vec2 inset = q + edge;
+    // A concave circular curb, tangent to both verges. Limit the footprint
+    // to this corner so it cannot spread into another lane or grass median.
+    float radius = 0.45;
+    float depth = min(radius - max(inset.x, inset.y), length(inset - radius) - radius);
+    depth = min(depth, 0.48 - max(abs(q.x), abs(q.y)));
+    return vec2(smoothstep(-0.06, 0.12, depth + roughness), depth + edge);
+  }
+
+  vec2 roadShoulders(vec2 p, vec4 corners, float edge, float roughness) {
+    vec2 shape = roadShoulder(p, vec2(1.0, 1.0), corners.x, edge, roughness);
+    shape = max(shape, roadShoulder(p, vec2(1.0, 0.0), corners.y, edge, roughness));
+    shape = max(shape, roadShoulder(p, vec2(0.0, 1.0), corners.z, edge, roughness));
+    return max(shape, roadShoulder(p, vec2(0.0, 0.0), corners.w, edge, roughness));
+  }
+
+  vec2 roadShape(vec2 p, vec4 connected, vec4 filledCorners, float edge, float inner, float roughness) {
+    vec3 shape = vec3(0.0, -1.0, -1.0);
+    if (connected.x * connected.y > 0.5)
+      shape = addRoadStrip(shape, roadStrip(abs(p.y - 0.5), edge, inner, roughness));
+    if (connected.z * connected.w > 0.5)
+      shape = addRoadStrip(shape, roadStrip(abs(p.x - 0.5), edge, inner, roughness));
+    if (connected.x * connected.z > 0.5)
+      shape = addRoadStrip(shape, roadStrip(abs(length(p - vec2(1.0, 1.0)) - 0.5), edge, inner, roughness));
+    if (connected.x * connected.w > 0.5)
+      shape = addRoadStrip(shape, roadStrip(abs(length(p - vec2(1.0, 0.0)) - 0.5), edge, inner, roughness));
+    if (connected.y * connected.z > 0.5)
+      shape = addRoadStrip(shape, roadStrip(abs(length(p - vec2(0.0, 1.0)) - 0.5), edge, inner, roughness));
+    if (connected.y * connected.w > 0.5)
+      shape = addRoadStrip(shape, roadStrip(abs(length(p) - 0.5), edge, inner, roughness));
+
+    float entrances = dot(connected, vec4(1.0));
+    if (entrances > 2.5) {
+      // Turning traffic fans out at the mouth of a junction. Round the union
+      // of its shoulders and wear an apron through the crossing wheel tracks,
+      // rather than preserving overlapping grass medians as tiny islands.
+      // Both effects fade out before the tile boundary, matching every lane.
+      float boundary = min(min(p.x, p.y), min(1.0 - p.x, 1.0 - p.y));
+      float fade = smoothstep(0.0, 0.2, boundary);
+      float rounding = 0.22 * fade;
+      float h = max(rounding - (shape.y - shape.z), 0.0) / max(rounding, 0.00001);
+      float rounded = shape.y + h * h * rounding * 0.25;
+      float oldOuter = smoothstep(edge - 0.06, edge + 0.12, shape.y + roughness);
+      float outer = smoothstep(edge - 0.06, edge + 0.12, rounded + roughness);
+      shape.x = max(shape.x, outer - oldOuter);
+      shape.y = rounded;
+
+      // For a T, bias the apron toward the side road; the main road's far
+      // verge remains intact. A crossroads wears evenly around its centre.
+      vec2 branch = vec2(connected.x - connected.y, connected.z - connected.w);
+      vec2 local = p - 0.5 - branch * 0.06;
+      float radius = length(local) / 0.46;
+      float apron = (1.0 - smoothstep(0.2, 1.0, radius)) * fade;
+      shape.x = mix(shape.x, outer, apron);
+    }
+
+    // Rounded ends, including a lone road tile, stop at the tile centre.
+    if (entrances < 1.5) {
+      vec2 direction = vec2(connected.x - connected.y, connected.z - connected.w);
+      vec2 local = p - 0.5;
+      float along = clamp(dot(local, direction), 0.0, 0.5);
+      shape.xy = roadStrip(length(local - direction * along), edge, inner, roughness);
+    }
+
+    // A 2x2 road patch is continuous ground, not four separate curves with a
+    // grass pinhole where they meet. Each tile agrees on the shared corner.
+    vec2 local = p - 0.5;
+    float fill = -1.0;
+    if (filledCorners.x > 0.5) fill = max(fill, min(local.x, local.y));
+    if (filledCorners.y > 0.5) fill = max(fill, min(local.x, -local.y));
+    if (filledCorners.z > 0.5) fill = max(fill, min(-local.x, local.y));
+    if (filledCorners.w > 0.5) fill = max(fill, min(-local.x, -local.y));
+    shape.xy = max(shape.xy, vec2(smoothstep(-0.06, 0.06, fill), fill + edge));
+    return shape.xy;
+  }
+`


### PR DESCRIPTION
Round road bends and dead ends, merge wheel ruts through junctions, and add curved shoulders and worn centers at T intersections across all four road tiers.
Keep broad road patches continuous and prevent junction shoulders from extending onto water, bridge approaches, or building footprints.

Validation: all 327 tests pass; browser checks cover all road tiers and four junction orientations, with 2,542 GPU samples checking junction symmetry and existing lane boundaries.
Type checking remains blocked by the pre-existing `SettlementPanel` prop mismatch in `components/game/game-hud.tsx:717`.
