### PR TITLE
Fix character outline artifacts and match selection border thickness

### DIFF
--- a/components/game/character-sprite.tsx
+++ b/components/game/character-sprite.tsx
@@ -76,7 +76,9 @@ export function CharacterSprite({ type, onClick, outlineColor, selected = false,
   const lastFrame = useRef({ texture: null as THREE.Texture | null, frame: -1, row: -1 })
   const outlineMaterial = useMemo(() => {
     if (!outlineColor) return null
-    const material = new THREE.SpriteMaterial({ map: textures[1], alphaTest: 0.5, toneMapped: false })
+    // SpriteMaterial defaults to transparent. Blending an ID with the background
+    // invents different objects along translucent ink edges, causing false halos.
+    const material = new THREE.SpriteMaterial({ map: textures[1], alphaTest: 0.5, transparent: false, toneMapped: false })
     // Every traveler shares one compiled ID shader; identity is a uniform.
     // Embedding IDs in shader source compiled a new program for every person.
     const id = new THREE.Vector3(...outlineColor)

--- a/components/game/outline-pass.tsx
+++ b/components/game/outline-pass.tsx
@@ -119,7 +119,7 @@ const FRAGMENT_SHADER = /* glsl */ `
       gl_FragColor = vec4(uSelectionFill, uSelectionOpacity);
       finishColor(); return;
     }
-    // A thin halo belongs outside the shape, on its background side only.
+    // The halo belongs outside the shape, on its background side only.
     // Nearer objects still hide the selected object and its highlight.
     if (!uCharacterSelected && uSelectedId > 0.5) {
       bool selectedEdge =
@@ -318,8 +318,14 @@ export function OutlinePass({ objects }: { objects?: Omit<Parameters<typeof sele
       if (needsOutline) {
         pass.uniforms.tId.value = ids.texture
         pass.uniforms.tDepth.value = ids.depthTexture
-        // One texel at each subject's own resolution: coarse scenery, fine figures.
-        pass.uniforms.uTexel.value.set(1 / ids.width, 1 / ids.height)
+        // One world texel for every border, including display-resolution figures.
+        // The crop converts the world buffer's texel size to display UVs, keeping
+        // selections and overlap halos equally thick through zoom and DPR changes.
+        if (characterPass) {
+          pass.uniforms.uTexel.value.set(1 / (target.width * stage.scale.x), 1 / (target.height * stage.scale.y))
+        } else {
+          pass.uniforms.uTexel.value.set(1 / ids.width, 1 / ids.height)
+        }
         pass.uniforms.uMode.value = MODE_INT[mode]
         pass.uniforms.uSelectedId.value = selectedId
         pass.uniforms.uCharacterSelected.value = characterSelected


### PR DESCRIPTION
Fixes jagged dark artifacts on walking and idle characters by disabling transparency blending in the object-ID material, preventing translucent sprite edges from being decoded as false overlaps. Character selection and overlap outlines now use one world texel, matching tree and scenery borders through zoom and display pixel-ratio changes.

Validated with TypeScript checking, all 422 tests, and browser GPU readback confirming only the character and background IDs appear around walking and idle sprites.
