### PR TITLE
Match scenery and outline pixels to character scale

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,14 @@
 
 ## Rules
 
+- **Pixels must be uniform throughout the app.** Use the character's apparent
+  pixel size as the reference for trees, scenery, edges, selection outlines,
+  shadows, and effects, regardless of whether artwork is procedural, generated,
+  or a static asset. Match visual pixel size through asset/material settings and
+  outline sampling in the existing renderer. Do not replace render passes or
+  increase unbounded render-target sizes to enforce this visual rule. Check the
+  result beside a character at the same zoom, including selection and overlap.
+
 - **Property panels are opt-in development tools.** For a branch that needs the
   World tuning sidebar, set `NEXT_PUBLIC_PROPERTY_PANELS=1` in that workspace's
   gitignored `.env.local` and restart `npm run dev` (or run

--- a/components/game/game-shell.tsx
+++ b/components/game/game-shell.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useState } from "react"
 
 import { useBuildStore } from "@/lib/game/build-store"
 import { useCameraStore } from "@/lib/game/camera-store"
+import { CHARACTER_PIXELS_PER_UNIT } from "@/lib/game/render/pixel-scale"
 import { DEFAULT_MOVEMENT } from "@/lib/game/motion"
 import type { CharacterModel } from "@/lib/game/character-assets"
 import { DEFAULT_ROAD_LOOK, DEFAULT_ROAD_TIER } from "@/lib/game/map/road"
@@ -155,7 +156,7 @@ export function GameShell({
   })
   const [pixelationOverrides, setPixelationOverrides] = useState<PixelationProps>({})
   const pixelationSettings = {
-    pixelsPerUnit: pixelationOverrides.pixelsPerUnit ?? pixelation?.pixelsPerUnit ?? 25,
+    pixelsPerUnit: pixelationOverrides.pixelsPerUnit ?? pixelation?.pixelsPerUnit ?? CHARACTER_PIXELS_PER_UNIT,
     outputDpr: pixelationOverrides.outputDpr ?? pixelation?.outputDpr ?? 1,
     pixelated: pixelationOverrides.pixelated ?? pixelation?.pixelated ?? true,
   }

--- a/components/game/outline-pass.tsx
+++ b/components/game/outline-pass.tsx
@@ -51,6 +51,7 @@ const FRAGMENT_SHADER = /* glsl */ `
   uniform bool uCharacterPass;
   uniform float uCharacterIdMin;
   uniform vec2 uTexel;
+  uniform vec2 uPixelOffset;
   uniform int uMode; // 1 = overlap only, 2 = full silhouette
   uniform vec3 uColor;
   uniform float uSelectedId;
@@ -89,13 +90,16 @@ const FRAGMENT_SHADER = /* glsl */ `
   }
 
   void main() {
-    float idC = idAt(vUv);
-    float dC = texture2D(tDepth, vUv).x;
+    // Sample selection and overlap edges on the scenery pixel grid even when
+    // character IDs are drawn at display resolution. This changes only edges.
+    vec2 pixelUv = (floor(vUv / uTexel + uPixelOffset) + 0.5 - uPixelOffset) * uTexel;
+    float idC = idAt(pixelUv);
+    float dC = texture2D(tDepth, pixelUv).x;
     if (uCharacterSelected) {
-      vec4 character = texture2D(tCharacter, vUv);
+      vec4 character = texture2D(tCharacter, pixelUv);
       if (character.a > 0.5) {
         bool hidden = abs(idC - uSelectedId) > 0.5
-          && texture2D(tCharacterDepth, vUv).x > dC + 1.0e-5;
+          && texture2D(tCharacterDepth, pixelUv).x > dC + 1.0e-5;
         if (hidden) {
           // A 50% mask over just the overlapping silhouette lets the real
           // character show through while keeping the foreground readable.
@@ -106,10 +110,10 @@ const FRAGMENT_SHADER = /* glsl */ `
         finishColor(); return;
       }
       bool characterEdge =
-        texture2D(tCharacter, vUv + vec2(uTexel.x, 0.0)).a > 0.5 ||
-        texture2D(tCharacter, vUv - vec2(uTexel.x, 0.0)).a > 0.5 ||
-        texture2D(tCharacter, vUv + vec2(0.0, uTexel.y)).a > 0.5 ||
-        texture2D(tCharacter, vUv - vec2(0.0, uTexel.y)).a > 0.5;
+        texture2D(tCharacter, pixelUv + vec2(uTexel.x, 0.0)).a > 0.5 ||
+        texture2D(tCharacter, pixelUv - vec2(uTexel.x, 0.0)).a > 0.5 ||
+        texture2D(tCharacter, pixelUv + vec2(0.0, uTexel.y)).a > 0.5 ||
+        texture2D(tCharacter, pixelUv - vec2(0.0, uTexel.y)).a > 0.5;
       if (characterEdge) {
         gl_FragColor = vec4(uSelectionColor, uSelectionOutlineOpacity);
         finishColor(); return;
@@ -123,10 +127,10 @@ const FRAGMENT_SHADER = /* glsl */ `
     // Nearer objects still hide the selected object and its highlight.
     if (!uCharacterSelected && uSelectedId > 0.5) {
       bool selectedEdge =
-        selectedNeighbour(vUv + vec2(uTexel.x, 0.0), dC) ||
-        selectedNeighbour(vUv - vec2(uTexel.x, 0.0), dC) ||
-        selectedNeighbour(vUv + vec2(0.0, uTexel.y), dC) ||
-        selectedNeighbour(vUv - vec2(0.0, uTexel.y), dC);
+        selectedNeighbour(pixelUv + vec2(uTexel.x, 0.0), dC) ||
+        selectedNeighbour(pixelUv - vec2(uTexel.x, 0.0), dC) ||
+        selectedNeighbour(pixelUv + vec2(0.0, uTexel.y), dC) ||
+        selectedNeighbour(pixelUv - vec2(0.0, uTexel.y), dC);
       if (selectedEdge) {
         gl_FragColor = vec4(uSelectionColor, uSelectionOutlineOpacity);
         finishColor(); return;
@@ -135,10 +139,10 @@ const FRAGMENT_SHADER = /* glsl */ `
     if (uMode == 0) discard;
     if (uMode == 1 && idC < 0.5) discard; // overlap halos land only on objects
     bool edge =
-      occludedBy(vUv + vec2(uTexel.x, 0.0), idC, dC) ||
-      occludedBy(vUv - vec2(uTexel.x, 0.0), idC, dC) ||
-      occludedBy(vUv + vec2(0.0, uTexel.y), idC, dC) ||
-      occludedBy(vUv - vec2(0.0, uTexel.y), idC, dC);
+      occludedBy(pixelUv + vec2(uTexel.x, 0.0), idC, dC) ||
+      occludedBy(pixelUv - vec2(uTexel.x, 0.0), idC, dC) ||
+      occludedBy(pixelUv + vec2(0.0, uTexel.y), idC, dC) ||
+      occludedBy(pixelUv - vec2(0.0, uTexel.y), idC, dC);
     if (!edge) discard;
     gl_FragColor = vec4(uColor, 1.0);
     finishColor();
@@ -224,6 +228,7 @@ export function OutlinePass({ objects }: { objects?: Omit<Parameters<typeof sele
       uCharacterPass: { value: false },
       uCharacterIdMin: { value: MAX_OBJECT_ID - 0x2000 + 1 },
       uTexel: { value: new THREE.Vector2() },
+      uPixelOffset: { value: new THREE.Vector2() },
       uMode: { value: 0 },
       uColor: { value: new THREE.Color(OUTLINE_COLOR) },
       uSelectedId: { value: 0 },
@@ -323,8 +328,12 @@ export function OutlinePass({ objects }: { objects?: Omit<Parameters<typeof sele
         // selections and overlap halos equally thick through zoom and DPR changes.
         if (characterPass) {
           pass.uniforms.uTexel.value.set(1 / (target.width * stage.scale.x), 1 / (target.height * stage.scale.y))
+          pass.uniforms.uPixelOffset.value.set(
+            ((1 - stage.scale.x) * 0.5 + stage.offset.x) * target.width,
+            ((1 - stage.scale.y) * 0.5 + stage.offset.y) * target.height)
         } else {
           pass.uniforms.uTexel.value.set(1 / ids.width, 1 / ids.height)
+          pass.uniforms.uPixelOffset.value.set(0, 0)
         }
         pass.uniforms.uMode.value = MODE_INT[mode]
         pass.uniforms.uSelectedId.value = selectedId

--- a/components/pixel-canvas.tsx
+++ b/components/pixel-canvas.tsx
@@ -5,8 +5,10 @@ import { Canvas, useFrame, type CanvasProps } from "@react-three/fiber"
 import * as THREE from "three"
 import { CHARACTER_COLOR_LAYER, tagPixelCharacters, withoutPixelCharacters } from "@/lib/game/render/pixel-characters"
 
+import { CHARACTER_PIXELS_PER_UNIT } from "@/lib/game/render/pixel-scale"
+
 export interface PixelationProps {
-  /** Rendered pixels per world unit. Lower is chunkier and cheaper. Default: 25.
+  /** Rendered pixels per world unit. Lower is chunkier and cheaper. Default: native character density.
    * Clamped to 1–64 and GPU texture limits. */
   pixelsPerUnit?: number
   /** Turn off the low-resolution world render for comparison. Default: true. */
@@ -117,6 +119,7 @@ function PixelRenderPass({ pixelsPerUnit, pixelated }: Required<Pick<PixelationP
       right: new THREE.Vector3(),
       up: new THREE.Vector3(),
       center: new THREE.Vector3(),
+      displaySize: new THREE.Vector2(),
       stage: { phase: "all", scale: uniforms.uScale.value, offset: uniforms.uOffset.value } as PixelSceneStage,
     }
   }, [])
@@ -145,7 +148,10 @@ function PixelRenderPass({ pixelsPerUnit, pixelated }: Required<Pick<PixelationP
       const width = (cam.right - cam.left) / cam.zoom
       const height = (cam.top - cam.bottom) / cam.zoom
       const maxSize = Math.floor(gl.capabilities.maxTextureSize / BUFFER_STEP) * BUFFER_STEP
-      const density = Math.min(pixelsPerUnit, (maxSize - 2) / Math.max(width, height))
+      gl.getDrawingBufferSize(r.displaySize)
+      // Match character detail without drawing pixels smaller than the display.
+      const density = Math.min(pixelsPerUnit, r.displaySize.x / width,
+        r.displaySize.y / height, (maxSize - 2) / Math.max(width, height))
       // Two extra texels cover the subpixel camera offset at either edge.
       const bufferWidth = Math.ceil((width * density + 2) / BUFFER_STEP) * BUFFER_STEP
       const bufferHeight = Math.ceil((height * density + 2) / BUFFER_STEP) * BUFFER_STEP
@@ -217,13 +223,13 @@ function PixelRenderPass({ pixelsPerUnit, pixelated }: Required<Pick<PixelationP
 export function PixelCanvas({
   children,
   style,
-  pixelsPerUnit = 25,
+  pixelsPerUnit = CHARACTER_PIXELS_PER_UNIT,
   pixelated = true,
   outputDpr = 1,
   ...props
 }: Omit<CanvasProps, "dpr" | "gl"> & PixelationProps) {
   const renderer = useMemo<PixelRenderer>(() => ({ scene: { current: null }, frame: { current: null }, characters: new Set() }), [])
-  const density = Number.isFinite(pixelsPerUnit) ? THREE.MathUtils.clamp(pixelsPerUnit, 1, 64) : 25
+  const density = Number.isFinite(pixelsPerUnit) ? THREE.MathUtils.clamp(pixelsPerUnit, 1, 64) : CHARACTER_PIXELS_PER_UNIT
   const dpr = Number.isFinite(outputDpr) ? THREE.MathUtils.clamp(outputDpr, 0.5, 2) : 1
   return (
     <Canvas

--- a/lib/game/render/pixel-scale.ts
+++ b/lib/game/render/pixel-scale.ts
@@ -1,0 +1,3 @@
+/** One native pixel of the default character: 48px figure, 0.74 units, 1.5× size. */
+export const CHARACTER_PIXEL_SIZE = 0.74 * 1.5 / 48
+export const CHARACTER_PIXELS_PER_UNIT = 1 / CHARACTER_PIXEL_SIZE


### PR DESCRIPTION
Trees and scenery now use the default character's native pixel density, capped at display resolution, while selection and overlap outlines sample the same pixel grid within the existing render passes.
Adds a repository rule requiring uniform apparent pixel sizes across procedural, generated, and static artwork.
Validated with `npm run typecheck`, the two existing character-rendering tests, and browser checks for selection, rotation, and zoom without rendering errors.
Zoom comparisons performed comparably to the original settings, but occasional stalls remain in both versions and this PR does not claim to resolve all reported performance issues.
