### PR TITLE
Unify monk and traveler character scaling

### DIFF
--- a/components/game/game-canvas.tsx
+++ b/components/game/game-canvas.tsx
@@ -134,7 +134,7 @@ export function GameCanvas({
       <Buildings map={map} />
       <Shrine map={map} relic={relic} />
       <PixelCharacters>
-        <Monks map={map} monks={monks} flying={blasterPastor} />
+        <Monks map={map} monks={monks} flying={blasterPastor} characterScale={characterScale} />
         <Travelers map={map} travelers={travelers} speed={walkSpeed} relic={relic} trees={trees} shrineRenown={baseRenown}
           characterModel={characterModel} characterScale={characterScale} characterFps={characterFps} walkTuning={walkTuning} movement={movement} />
       </PixelCharacters>

--- a/components/game/monks.tsx
+++ b/components/game/monks.tsx
@@ -77,7 +77,7 @@ function wanderSpots(map: GameMap): { spots: Spot[]; centre: { x: number; z: num
   return { spots, centre }
 }
 
-export function Monks({ map, monks, flying = false }: { map: GameMap; monks: Monk[]; flying?: boolean }) {
+export function Monks({ map, monks, flying = false, characterScale = 1 }: { map: GameMap; monks: Monk[]; flying?: boolean; characterScale?: number }) {
   const selection = useCameraStore((s) => s.selection)
   const groupRefs = useRef<Array<THREE.Group | null>>([])
 
@@ -213,7 +213,7 @@ export function Monks({ map, monks, flying = false }: { map: GameMap; monks: Mon
             }}
           >
             <Suspense fallback={null}>
-              <CharacterSprite name="monk" type="friar" characterModel="base" characterScale={1.2}
+              <CharacterSprite name="monk" type="friar" characterModel="base" characterScale={characterScale}
                 visualOverride={MONK_VISUAL} selected={selected} onClick={select}
                 outlineColor={[id.r, id.g, id.b]}
                 walkTuning={{ sync: true, stride: 0.44 }} />

--- a/lib/game/base-person/population.test.ts
+++ b/lib/game/base-person/population.test.ts
@@ -7,14 +7,12 @@ import { populationDesign, POPULATION_PROFILES, travelerAppearance } from "./pop
 import { DEFAULT_POPULATION, populationVisual } from "./population-assets"
 
 describe("road character population", () => {
-  it("keeps identity stable across ordering and crowd size, with mixed bodies and sizes", () => {
+  it("keeps identity stable across ordering and crowd size, with mixed bodies at a uniform scale", () => {
     const people = Array.from({ length: 200 }, (_, id) => travelerAppearance(12345, id))
     expect(new Set(people.map(p => p.variant)).size).toBe(6)
-    expect(new Set(people.map(p => p.scale)).size).toBeGreaterThan(15)
+    expect(new Set(people.map(p => p.scale))).toEqual(new Set([1]))
     for (let id = 0; id < people.length; id++) {
       expect(travelerAppearance(12345, id)).toEqual(people[id])
-      expect(people[id].scale).toBeGreaterThanOrEqual(0.9)
-      expect(people[id].scale).toBeLessThanOrEqual(1.1)
       expect(POPULATION_PROFILES[people[id].variant].bodyType).toBe(people[id].bodyType)
       if (id % 2 === 1) expect(people[id].bodyType).not.toBe(people[id - 1].bodyType)
     }

--- a/lib/game/base-person/population.ts
+++ b/lib/game/base-person/population.ts
@@ -22,7 +22,7 @@ export function travelerAppearance(seed: number, id: number): TravelerAppearance
   const female = ((id & 1) ^ (pair < 0.5 ? 0 : 1)) === 1
   const random = makeRng(deriveSeed(root, id + 104729))
   return { variant: (female ? 3 : 0) + Math.floor(random() * 3),
-    scale: Math.round((0.9 + random() * 0.2) * 100) / 100, bodyType: female ? "Female" : "Male" }
+    scale: 1, bodyType: female ? "Female" : "Male" }
 }
 
 export function populationDesign(type: Pick<TravelerTypeDef, "color">, variant: number, base: PersonDesign = DEFAULT_DESIGN): PersonDesign {


### PR DESCRIPTION
Monks now use the same character size setting as travelers, increasing their default size by 25% and keeping subsequent size adjustments in sync. Remove random traveler scaling while preserving body profiles and stable character identities, and update the population regression test to require a uniform scale.

Validation: TypeScript check and 28 relevant tests passed; a Playwright browser check reported no runtime errors.
