### PR TITLE
Match traveler names to character appearance

### DIFF
--- a/lib/game/travelers.test.ts
+++ b/lib/game/travelers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import { generateTravelers, travelerCountForMap, TRAVELER_TYPES } from "./travelers"
+import { POPULATION_PROFILES, travelerAppearance } from "./base-person/population"
 
 describe("travelerCountForMap", () => {
   it("preserves the default crowd and scales with map area", () => {
@@ -28,6 +29,25 @@ describe("travelerCountForMap", () => {
 })
 
 describe("generateTravelers", () => {
+  it("matches first names to the rendered population profile across seeds and callings", () => {
+    const women = new Set([
+      "Berta", "Dilys", "Frida", "Hawise", "Isolde", "Maude", "Osanna",
+      "Quenild", "Sybil", "Wilmot", "Ysabel",
+    ])
+    const callings = { Male: new Set<string>(), Female: new Set<string>() }
+    for (const seed of [0, 7, 12345, 31337]) {
+      for (const traveler of generateTravelers(seed, 500)) {
+        const { variant } = travelerAppearance(seed, traveler.id)
+        const { bodyType } = POPULATION_PROFILES[variant]
+        expect(women.has(traveler.name.split(" ")[0]), traveler.name).toBe(bodyType === "Female")
+        callings[bodyType].add(traveler.type.id)
+      }
+    }
+    for (const seen of Object.values(callings)) {
+      expect([...seen].sort()).toEqual(Object.keys(TRAVELER_TYPES).sort())
+    }
+  })
+
   it("is fully determined by its seed", () => {
     const a = generateTravelers(12345, 20)
     const b = generateTravelers(12345, 20)

--- a/lib/game/travelers.ts
+++ b/lib/game/travelers.ts
@@ -1,4 +1,5 @@
 import { deriveSeed, makeRng, SEED_STREAM } from "./rng"
+import { travelerAppearance } from "./base-person/population"
 import type { GameMap } from "./map/types"
 
 /**
@@ -165,12 +166,16 @@ const THIRST: StatRange = { min: 20, max: 80 }
 const STAMINA: StatRange = { min: 40, max: 100 }
 const AGE: StatRange = { min: 16, max: 60 }
 
-const FIRST_NAMES = [
-  "Aldous", "Berta", "Cedric", "Dilys", "Edmund", "Frida", "Godwin", "Hawise",
-  "Isolde", "Jocelin", "Kenrick", "Leofric", "Maude", "Norbert", "Osanna",
-  "Piers", "Quenild", "Roger", "Sybil", "Tancred", "Ulric", "Venn", "Wilmot",
-  "Ysabel",
-]
+const FIRST_NAMES = {
+  Male: [
+    "Aldous", "Cedric", "Edmund", "Godwin", "Jocelin", "Kenrick", "Leofric",
+    "Norbert", "Piers", "Roger", "Tancred", "Ulric", "Venn",
+  ],
+  Female: [
+    "Berta", "Dilys", "Frida", "Hawise", "Isolde", "Maude", "Osanna",
+    "Quenild", "Sybil", "Wilmot", "Ysabel",
+  ],
+}
 
 const BYNAMES = [
   "of the Vale", "the Stout", "of Greyford", "the Lame", "Longstride",
@@ -281,9 +286,12 @@ export function generateTravelers(seed: number, count: number): Traveler[] {
     if (i === count - 1 && count >= 6 && !travelers.some((t) => t.type.id === "vendor")) {
       type = TRAVELER_TYPES.vendor
     }
+    // Match the body's seeded assignment used by the scene without consuming
+    // another roll from the stream that determines attributes and movement.
+    const firstNames = FIRST_NAMES[travelerAppearance(seed, i).bodyType]
     travelers.push({
       id: i,
-      name: `${FIRST_NAMES[Math.floor(rng() * FIRST_NAMES.length)]} ${
+      name: `${firstNames[Math.floor(rng() * firstNames.length)]} ${
         BYNAMES[Math.floor(rng() * BYNAMES.length)]
       }`,
       type,


### PR DESCRIPTION
Travelers now receive first names from women's or men's name lists according to the same seeded appearance assignment used by the renderer. This preserves deterministic generation and the existing attribute and movement rolls.

Added regression coverage across multiple seeds and every calling; all 37 targeted traveler, population, and settlement tests pass, along with `npm run typecheck`.
