### PR TITLE
Make resting monks kneel on the ground

### DIFF
--- a/lib/game/base-person/activity.test.ts
+++ b/lib/game/base-person/activity.test.ts
@@ -3,7 +3,7 @@ import { activityClip } from "./activity"
 
 describe("simulation sprite poses", () => {
   it.each([
-    ["vigil", "praying"], ["resting", "sitting"], ["walking", "idle"], ["flying", "idle"],
+    ["vigil", "praying"], ["resting", "praying"], ["walking", "idle"], ["flying", "idle"],
     ["camping", "sleeping"], ["idle", "sitting"], ["visiting", "praying"],
     ["working", "woodcutting"], ["gathering", "gathering"], ["vending", "idle"],
   ] as const)("shows %s as %s", (activity, clip) => {

--- a/lib/game/base-person/activity.ts
+++ b/lib/game/base-person/activity.ts
@@ -10,8 +10,9 @@ export function activityClip(activity: Activity | MonkActivity | undefined, movi
   if (moving) return "walk"
   switch (activity) {
     case "camping": return "sleeping"
-    case "resting":
     case "idle": return "sitting"
+    // Resident monks rest on open ground, so use their existing kneeling pose.
+    case "resting":
     case "vigil":
     case "visiting": return "praying"
     case "working": return "woodcutting"


### PR DESCRIPTION
Resting monks now use their existing kneeling prayer animation when paused on open ground, replacing ground sitting. Updated the activity mapping test to cover the new pose.

Validation: all 19 tests in the activity, monk, and pose suites pass, along with `npm run typecheck` and `git diff --check`.
