### PR TITLE
Keep shrine visitors on opposite sides of the path

### DIFF
--- a/lib/game/hospitality.test.ts
+++ b/lib/game/hospitality.test.ts
@@ -9,6 +9,7 @@ import { TILE_HEIGHT, type TerrainId } from "./map/terrain"
 import { tileToWorldX, tileToWorldZ, worldToTileX, worldToTileZ, type GameMap } from "./map/types"
 import { generateRelic, visitChance } from "./relic"
 import { createSim, stepSim, type SimState } from "./sim"
+import { DEFAULT_MOVEMENT, LINEAR_MOVEMENT } from "./motion"
 import { generateTravelers, TRAVELER_TYPES, type Traveler } from "./travelers"
 import { treeResource, treeStage, STUMP_LIFETIME_DAYS, TIMBER_LOAD, stackWood, type WoodPile } from "./trees/timber"
 import type { TreePlacement } from "./trees/placement"
@@ -44,6 +45,49 @@ function run(sim: SimState, travelers: Traveler[], map: GameMap, seconds: number
 const obscure = { sanctity: 0, spectacle: 0, doubt: 100 }
 
 describe("shrine hospitality", () => {
+  it.each([LINEAR_MOVEMENT, DEFAULT_MOVEMENT])("keeps shrine visitors on opposite sides in both directions (%j)", (movement) => {
+    const { map, traveler } = fixture()
+    const travelers = [traveler(0), traveler(1)]
+    const sim = createSim(travelers, map, [], obscure)
+    for (const [index, s] of [...sim.travelers.values()].entries()) {
+      s.activity = index === 0 ? "toRelic" : "fromRelic"
+      s.branchProgress = 2
+      s.lane = (index === 0 ? 1 : -1) * s.laneOffset
+    }
+    for (let tick = 0; tick < 10; tick++) {
+      stepSim(sim, travelers, map, 1, 0.1, movement)
+      for (const [index, s] of [...sim.travelers.values()].entries()) {
+        const direction = index === 0 ? 1 : -1
+        expect((s.x - tileToWorldX(map, 10)) * direction).toBeCloseTo(s.laneOffset)
+      }
+    }
+  })
+
+  it.each([1, -1] as const)("keeps lane changes continuous through a complete shrine visit (road direction %i)", (direction) => {
+    const { map, traveler } = fixture()
+    const t = traveler(0, direction)
+    t.attributes.hunger = 0
+    const sim = createSim([t], map, [], obscure)
+    const s = sim.travelers.get(0)!
+    let returning = false
+    let rejoined = false
+    for (let tick = 0; tick < 6000; tick++) {
+      const before = { x: s.x, z: s.z }
+      stepSim(sim, [t], map, 1, 0.01, DEFAULT_MOVEMENT)
+      expect(Math.hypot(s.x - before.x, s.z - before.z)).toBeLessThan(0.025)
+      returning ||= s.activity === "fromRelic"
+      if (returning && s.activity === "walking") {
+        expect(s.x).toBeCloseTo(tileToWorldX(map, 10))
+        expect(s.z).toBeCloseTo(tileToWorldZ(map, 4) - direction * s.laneOffset)
+        stepSim(sim, [t], map, 1, 0.01, DEFAULT_MOVEMENT)
+        expect(s.z).toBeCloseTo(tileToWorldZ(map, 4) - direction * s.laneOffset)
+        rejoined = true
+        break
+      }
+    }
+    expect(rejoined).toBe(true)
+  })
+
   for (const need of ["hunger", "thirst", "stamina"] as const) {
     for (const direction of [1, -1] as const) {
       it(`draws a traveler with empty ${need} from direction ${direction}, restores needs and returns them`, () => {
@@ -371,13 +415,15 @@ describe("settlement route heights", () => {
       const sim = createSim([t], map)
       const s = sim.travelers.get(0)!
       s.activity = activity
+      s.lane = (activity === "fromRelic" ? -1 : 1) * s.laneOffset
       s.branchProgress = activity === "fromRelic" ? 2 : 1
       s.workRoute = map.site!.branch
       s.workProgress = 1
       s.y = TILE_HEIGHT
       stepSim(sim, [t], map, 1, 0.5)
       expect(s.y).toBeCloseTo(TILE_HEIGHT + BRIDGE_RISE * 0.75)
-      expect(s.x).toBeCloseTo(tileToWorldX(map, 10))
+      const lane = activity === "toRelic" ? s.laneOffset : activity === "fromRelic" ? -s.laneOffset : 0
+      expect(s.x).toBeCloseTo(tileToWorldX(map, 10) + lane)
       expect(s.z).toBeCloseTo(tileToWorldZ(map, 5.5))
     },
   )

--- a/lib/game/sim.ts
+++ b/lib/game/sim.ts
@@ -174,6 +174,8 @@ export interface SimTraveler {
   jobless: boolean
   employer: string | null
   branchProgress: number
+  /** Road lane used when entering the shrine, including a reversed approach for shelter. */
+  branchEntryLane: number
   visitCooldown: number
   visits: number
   workRoute: TilePos[] | null
@@ -350,6 +352,22 @@ function currentRoutePoint(map: GameMap, s: SimTraveler, pathEase = 0): WorldPoi
   return roadWorldPoint(map, s.progress, s.lane, pathEase)
 }
 
+/** Join the shrine's walking lanes to the traveler's road lane over the first tile. */
+function shrineWorldPoint(map: GameMap, s: SimTraveler, pathEase = 0): WorldPoint {
+  const site = map.site!
+  const point = routeWorldPoint(map, site.branch, s.branchProgress, s.lane, undefined, pathEase)
+  if (s.branchProgress < 1) {
+    const start = routeWorldPoint(map, site.branch, 0, s.lane)
+    const roadLane = s.activity === "toRelic" ? s.branchEntryLane : s.direction * s.laneOffset
+    const road = roadWorldPoint(map, site.junction, roadLane, pathEase)
+    const blend = 1 - s.branchProgress
+    point.x += (road.x - start.x) * blend
+    point.y += (road.y - start.y) * blend
+    point.z += (road.z - start.z) * blend
+  }
+  return point
+}
+
 /** Cross to the new left lane over a short walk, including when seeking food. */
 function stepLane(s: SimTraveler, direction: 1 | -1, distance: number): void {
   const target = direction * s.laneOffset
@@ -399,6 +417,7 @@ export function createSim(
       jobless: t.attributes.jobless,
       employer: null,
       branchProgress: 0,
+      branchEntryLane: lane,
       visitCooldown: 0,
       visits: 0,
       workRoute: null,
@@ -702,7 +721,8 @@ export function stepSim(
         const inbound = s.activity === "toRelic"
         s.branchProgress = Math.max(0, Math.min(branch.length - 1,
           s.branchProgress + (inbound ? 1 : -1) * worldSpeed * dt))
-        const at = routeWorldPoint(map, branch, s.branchProgress)
+        stepLane(s, inbound ? 1 : -1, worldSpeed * dt)
+        const at = shrineWorldPoint(map, s, movement.pathEase)
         s.x = at.x
         s.y = at.y
         s.z = at.z
@@ -710,6 +730,7 @@ export function stepSim(
           s.activity = "visiting"
           s.timer = 2 * GAME_HOUR_SECONDS
         } else if (!inbound && s.branchProgress <= 0) {
+          s.lane = s.direction * s.laneOffset
           s.activity = "walking"
           s.visitCooldown = 30
         }
@@ -880,7 +901,9 @@ export function stepSim(
               s.branchProgress = 0
               s.activity = "toRelic"
               s.targetId = null
-              const at = routeWorldPoint(map, site.branch, 0)
+              s.branchEntryLane = s.lane
+              s.lane = s.laneOffset
+              const at = shrineWorldPoint(map, s, movement.pathEase)
               s.x = at.x
               s.y = at.y
               s.z = at.z


### PR DESCRIPTION
Shrine visitors previously bypassed keep-left and walked along the centerline in both directions. Apply individual walking lanes to shrine visits, with gradual turnarounds and continuous transitions into the main road lane, including reversed approaches for shelter. Add regression coverage for opposing traffic, complete visits, and bridge heights.

Validation: all 452 tests pass with `npm test -- --maxWorkers=2 --testTimeout=30000`, and `npm run typecheck` passes; reduced concurrency avoids timeouts on the busy development machine.
