### PR TITLE
Prevent monks from climbing cliffs and ground character feet on slopes

### DIFF
--- a/assets/WALKING.md
+++ b/assets/WALKING.md
@@ -73,7 +73,9 @@ the same leg phase. Fixed FPS is a comparison tool, not the normal movement mode
 
 `walkContact()` selects the supporting foot of the **displayed** rig pose.
 `plantFoot()` anchors it in world space between atlas frames, including its
-height on slopes. Apply the correction to body and outline together. Keep the shared render order
+height on slopes. In the game, pass the map to `CharacterSprite` so new contacts
+sample the walking surface beneath the supporting foot and both depth passes
+follow the local terrain grade. Apply the correction to body and outline together. Keep the shared render order
 and terrain depth shader on both passes; character ground shadows remain disabled.
 Reset the contact at support changes, turns/view changes, stopping or teleports.
 Do not smooth away the correction or cap distance-driven poses at an unrelated

--- a/components/game/character-sprite.tsx
+++ b/components/game/character-sprite.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import type { GameMap } from "@/lib/game/map/types"
+import { walkingSurface } from "@/lib/game/map/walking-surface"
 import { personRecipe } from "@/lib/game/base-person/design"
 import { BASE_PERSON } from "@/lib/game/base-person/pose"
 import { walkContact, plantFoot, type FootPlant, DEFAULT_WALK_STRIDE } from "@/lib/game/base-person/gait"
@@ -23,7 +25,8 @@ import type { FigureClickHandler } from "./traveler-figure"
 
 let nextSpriteOrder = 1
 
-export function CharacterSprite({ type, onClick, outlineColor, selected = false, characterModel = "callings", characterScale = 1, characterFps, walkTuning, appearance, visualOverride, name = "traveler" }: {
+export function CharacterSprite({ map, type, onClick, outlineColor, selected = false, characterModel = "callings", characterScale = 1, characterFps, walkTuning, appearance, visualOverride, name = "traveler" }: {
+  map?: GameMap
   visualOverride?: ReturnType<typeof populationVisual>
   name?: "traveler" | "monk"
   type: TravelerTypeId
@@ -50,6 +53,7 @@ export function CharacterSprite({ type, onClick, outlineColor, selected = false,
   const rigBody = useMemo(() => visual.design ? personRecipe(visual.design).body : null, [visual.design])
   const poseRoot = useRef<THREE.Group>(null)
   const footPlant = useRef<FootPlant | null>(null)
+  useEffect(() => { footPlant.current = null }, [map, rigBody])
   const origin = useMemo(() => new THREE.Vector3(), [])
   const contact = useMemo(() => new THREE.Vector3(), [])
   const corrected = useMemo(() => new THREE.Vector3(), [])
@@ -80,14 +84,16 @@ export function CharacterSprite({ type, onClick, outlineColor, selected = false,
   }), [sources, textureEntries, visual.rowOffset])
   useEffect(() => () => textures.forEach((texture) => texture.dispose()), [textures])
   const worldTexel = usePixelWorldTexel()
+  const groundPlane = useMemo(() => ({ value: new THREE.Vector4() }), [])
+  const groundAt = useMemo(() => map ? (x: number, z: number) => walkingSurface(map, x, z).height : undefined, [map])
   const viewport = useMemo(() => new THREE.Vector4(), [])
   const material = useMemo(() => {
     const material = new THREE.SpriteMaterial({ map: textures[1], alphaTest: 0.5, transparent: false, toneMapped: false })
-    material.onBeforeCompile = (shader) => applySpriteDepth(shader, viewport, worldTexel)
+    material.onBeforeCompile = (shader) => applySpriteDepth(shader, viewport, worldTexel, groundPlane)
     material.onBeforeRender = renderer => { renderer.getCurrentViewport(viewport) }
-    material.customProgramCacheKey = () => "person-depth-v3"
+    material.customProgramCacheKey = () => "person-depth-v4"
     return material
-  }, [textures, viewport, worldTexel])
+  }, [textures, viewport, worldTexel, groundPlane])
   useEffect(() => () => material.dispose(), [material])
   const center = useMemo(() => new THREE.Vector2(...visual.center), [visual])
   const sprite = useRef<THREE.Sprite>(null)
@@ -106,15 +112,15 @@ export function CharacterSprite({ type, onClick, outlineColor, selected = false,
     // Embedding IDs in shader source compiled a new program for every person.
     const id = new THREE.Vector3(...outlineColor)
     material.onBeforeCompile = (shader) => {
-      applySpriteDepth(shader, viewport, worldTexel)
+      applySpriteDepth(shader, viewport, worldTexel, groundPlane)
       shader.uniforms.travelerId = { value: id }
       shader.fragmentShader = "uniform vec3 travelerId;\n" + shader.fragmentShader.replace("#include <map_fragment>",
         "#include <map_fragment>\ndiffuseColor.rgb = travelerId;")
     }
     material.onBeforeRender = renderer => { renderer.getCurrentViewport(viewport) }
-    material.customProgramCacheKey = () => "traveler-id-v5"
+    material.customProgramCacheKey = () => "traveler-id-v6"
     return material
-  }, [textures, viewport, worldTexel, outlineColor?.[0], outlineColor?.[1], outlineColor?.[2]])
+  }, [textures, viewport, worldTexel, groundPlane, outlineColor?.[0], outlineColor?.[1], outlineColor?.[2]])
   useEffect(() => () => outlineMaterial?.dispose(), [outlineMaterial])
 
   useFrame(({ camera }, delta) => {
@@ -164,7 +170,7 @@ export function CharacterSprite({ type, onClick, outlineColor, selected = false,
         contact.set(x * Math.cos(yaw) + z * Math.sin(yaw), 0, -x * Math.sin(yaw) + z * Math.cos(yaw))
         parent.getWorldPosition(origin)
         const key = `${requested}:${foot.side}:${direction}:${yaw.toFixed(4)}:${pitch.toFixed(4)}:${size}`
-        const planted = plantFoot(footPlant.current, key, origin, contact)
+        const planted = plantFoot(footPlant.current, key, origin, contact, groundAt)
         footPlant.current = planted.plant
         corrected.set(origin.x + planted.offset.x, origin.y + planted.offset.y, origin.z + planted.offset.z)
         poseRoot.current.position.copy(parent.worldToLocal(corrected))
@@ -173,6 +179,14 @@ export function CharacterSprite({ type, onClick, outlineColor, selected = false,
         poseRoot.current.position.set(0, 0, 0)
       }
     }
+    // Ground and body/selection passes share the same local terrain plane.
+    // Flying monks release contact and use the normal airborne depth model.
+    if (map && parent.userData.activity !== "flying" && poseRoot.current) {
+      poseRoot.current.getWorldPosition(corrected)
+      const surface = walkingSurface(map, corrected.x, corrected.z)
+      groundPlane.value.set(-surface.dx, 1, -surface.dz,
+        surface.dx * corrected.x + surface.dz * corrected.z - surface.height)
+    } else groundPlane.value.set(0, 0, 0, 0)
     const previous = lastFrame.current
     // Distance timing must display the current pose even at low animation FPS.
     if (previous.texture === texture && previous.row === row && previous.frame === frame) return

--- a/components/game/monks.tsx
+++ b/components/game/monks.tsx
@@ -1,9 +1,8 @@
 "use client"
 
-import { groundHeight } from "@/lib/game/map/elevation"
-import { bridgeLayout } from "@/lib/game/map/bridges"
+import { walkingSurface } from "@/lib/game/map/walking-surface"
 
-import { buildingAt } from "@/lib/game/settlement"
+import { monkWander, type WanderSpot } from "@/lib/game/monk-wander"
 import { Suspense, useEffect, useMemo, useRef } from "react"
 import { useFrame } from "@react-three/fiber"
 import * as THREE from "three"
@@ -12,9 +11,7 @@ import { useSimulationStore } from "@/lib/game/simulation-store"
 import { isSelected, useCameraStore } from "@/lib/game/camera-store"
 import { selectElement } from "@/lib/game/selection"
 import { CharacterHitTarget, CharacterSelectionShadow } from "./character-selection"
-import { surfaceHeight } from "@/lib/game/map/bridges"
-import { TERRAIN } from "@/lib/game/map/terrain"
-import { tileAt, tileToWorldX, tileToWorldZ, type GameMap } from "@/lib/game/map/types"
+import type { GameMap } from "@/lib/game/map/types"
 import { monkRegistry, type Monk, type MonkActivity } from "@/lib/game/monks"
 import { createMonkFlight, monkGroundTime, stepMonkFlight, type MonkFlight } from "@/lib/game/monk-flight"
 import { deriveSeed, makeRng, SEED_STREAM } from "@/lib/game/rng"
@@ -32,48 +29,19 @@ import { MonkRocketGear, ROCKET_EXHAUST_NAME } from "./monk-rocket-gear"
  * between trips, keeping their rocket-powered gear equipped.
  */
 
-/** How far from the footprint the brothers will wander, in tiles. */
-const WANDER_RADIUS = 3
 const PAUSE_MIN_SECONDS = 2
 const PAUSE_MAX_SECONDS = 7
 /** Standing within this many tiles of the hovel's centre counts as keeping vigil. */
 const VIGIL_RADIUS = 1.8
 
-interface Spot {
-  x: number
-  y: number
-  z: number
-}
-
 interface MonkState {
   x: number
   y: number
   z: number
-  target: Spot
+  route: WanderSpot[]
   pause: number
   flight?: MonkFlight
   flightWait: number
-}
-
-/** Open ground around the hovel a monk may stand on: never the walls, never the woods. */
-function wanderSpots(map: GameMap): { spots: Spot[]; centre: { x: number; z: number } | null } {
-  const hovel = map.buildings.find((b) => b.id === map.site?.hovelId)
-  if (!hovel) return { spots: [], centre: null }
-  const centre = {
-    x: tileToWorldX(map, hovel.x) + (hovel.w - 1) / 2,
-    z: tileToWorldZ(map, hovel.z) + (hovel.d - 1) / 2,
-  }
-  const spots: Spot[] = []
-  for (let z = hovel.z - WANDER_RADIUS; z < hovel.z + hovel.d + WANDER_RADIUS; z++) {
-    for (let x = hovel.x - WANDER_RADIUS; x < hovel.x + hovel.w + WANDER_RADIUS; x++) {
-      const inFootprint = x >= hovel.x && x < hovel.x + hovel.w && z >= hovel.z && z < hovel.z + hovel.d
-      if (inFootprint || buildingAt(map, x, z)) continue
-      const terrain = tileAt(map, x, z)
-      if (!terrain || !TERRAIN[terrain].passable || terrain === "forest") continue
-      spots.push({ x: tileToWorldX(map, x), y: surfaceHeight(map, x, z), z: tileToWorldZ(map, z) })
-    }
-  }
-  return { spots, centre }
 }
 
 export function Monks({ map, monks, flying = false, characterScale = 1 }: { map: GameMap; monks: Monk[]; flying?: boolean; characterScale?: number }) {
@@ -81,21 +49,23 @@ export function Monks({ map, monks, flying = false, characterScale = 1 }: { map:
   const groupRefs = useRef<Array<THREE.Group | null>>([])
 
   const world = useMemo(() => {
-    const { spots, centre } = wanderSpots(map)
+    const wander = monkWander(map)
+    const { spots, centre } = wander
     const rng = makeRng(deriveSeed(map.seed ?? 0, SEED_STREAM.monkWander))
     const flightRng = makeRng(deriveSeed(map.seed ?? 0, SEED_STREAM.monkFlight))
-    const pick = (): Spot => {
+    const pick = (): WanderSpot => {
       const spot = spots[Math.floor(rng() * spots.length)]
       // Jitter within the tile so two brothers never stand on the same spot.
-      return { x: spot.x + (rng() - 0.5) * 0.5, y: spot.y, z: spot.z + (rng() - 0.5) * 0.5 }
+      const x = spot.x + (rng() - 0.5) * 0.5, z = spot.z + (rng() - 0.5) * 0.5
+      return { x, y: walkingSurface(map, x, z).height, z }
     }
     const states: MonkState[] = (spots.length ? monks : []).map((_, index) => {
       const start = pick()
       // One immediate demonstration; the other brothers take off in their own time.
-      return { ...start, target: pick(), pause: rng() * PAUSE_MAX_SECONDS, flightWait: index * 8 }
+      return { ...start, route: wander.route(start, pick()), pause: rng() * PAUSE_MAX_SECONDS, flightWait: index * 8 }
     })
     const activities = new Map<number, MonkActivity>()
-    return { spots, centre, rng, flightRng, pick, states, activities }
+    return { spots, centre, rng, flightRng, pick, states, activities, wander }
   }, [map, monks])
 
   // Publish activities so the HUD's monk panel can poll them.
@@ -153,7 +123,7 @@ export function Monks({ map, monks, flying = false, characterScale = 1 }: { map:
         }
         s.flight = undefined
         s.flightWait = monkGroundTime(world.flightRng)
-        s.target = world.pick()
+        s.route = world.wander.route(s, world.pick())
         s.pause = PAUSE_MIN_SECONDS + world.rng() * (PAUSE_MAX_SECONDS - PAUSE_MIN_SECONDS)
       }
       if (exhaust) exhaust.visible = false
@@ -169,27 +139,29 @@ export function Monks({ map, monks, flying = false, characterScale = 1 }: { map:
       } else {
         group.userData.activity = "walking"
         world.activities.set(monks[i].id, "walking")
-        const dx = s.target.x - s.x
-        const dz = s.target.z - s.z
+        const target = s.route[0] ?? s
+        const dx = target.x - s.x
+        const dz = target.z - s.z
         const dist = Math.hypot(dx, dz)
         const step = monkWalkSpeed(characterScale) * dt
         if (dist <= step) {
-          s.x = s.target.x
-          s.z = s.target.z
-          s.y = s.target.y
-          s.target = world.pick()
-          s.pause = PAUSE_MIN_SECONDS + world.rng() * (PAUSE_MAX_SECONDS - PAUSE_MIN_SECONDS)
+          s.x = target.x
+          s.z = target.z
+          s.y = target.y
+          s.route.shift()
+          if (!s.route.length) {
+            s.route = world.wander.route(s, world.pick())
+            s.pause = PAUSE_MIN_SECONDS + world.rng() * (PAUSE_MAX_SECONDS - PAUSE_MIN_SECONDS)
+          }
         } else {
           s.x += (dx / dist) * step
           s.z += (dz / dist) * step
-          s.y += (s.target.y - s.y) * Math.min(1, step / dist)
+          s.y += (target.y - s.y) * Math.min(1, step / dist)
           group.rotation.y = Math.atan2(dx, dz)
         }
       }
-      const tx = Math.floor(s.x + map.width / 2), tz = Math.floor(s.z + map.depth / 2)
-      const bridge = bridgeLayout(map).rise[tz * map.width + tx]
-      const y = map.elevation && !bridge
-        ? groundHeight(map, s.x + map.width / 2 - 0.5, s.z + map.depth / 2 - 0.5) : s.y
+      const y = walkingSurface(map, s.x, s.z).height
+      s.y = y
       group.position.set(s.x, y, s.z)
       group.userData.distance = Math.hypot(s.x - previousX, s.z - previousZ)
       group.userData.moving = group.userData.distance > 0
@@ -212,7 +184,7 @@ export function Monks({ map, monks, flying = false, characterScale = 1 }: { map:
             }}
           >
             <Suspense fallback={null}>
-              <CharacterSprite name="monk" type="friar" characterModel="base" characterScale={characterScale}
+              <CharacterSprite map={map} name="monk" type="friar" characterModel="base" characterScale={characterScale}
                 visualOverride={MONK_VISUAL} selected={selected} onClick={select}
                 outlineColor={[id.r, id.g, id.b]}
                 walkTuning={MONK_WALK_TUNING} />

--- a/components/game/traveler-figure.tsx
+++ b/components/game/traveler-figure.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import type { GameMap } from "@/lib/game/map/types"
 import type * as THREE from "three"
 import { OUTLINE_ID_LAYER_MASK } from "@/lib/game/render/outline"
 
@@ -68,6 +69,7 @@ function VendorCart({ onClick, awning, idColor }: { onClick?: FigureClickHandler
 }
 
 export function TravelerFigure({
+  map,
   type,
   onClick,
   idColor,
@@ -81,6 +83,7 @@ export function TravelerFigure({
   walkTuning,
   appearance,
 }: {
+  map?: GameMap
   type: TravelerTypeDef
   appearance?: TravelerAppearance
   selected?: boolean
@@ -98,7 +101,7 @@ export function TravelerFigure({
   return (
     <>
       <Suspense fallback={null}>
-        <CharacterSprite appearance={appearance} selected={selected} type={type.id} onClick={onClick} outlineColor={outlineColor ?? (idColor ? [idColor.r, idColor.g, idColor.b] : undefined)} characterModel={characterModel} characterScale={characterScale} characterFps={characterFps} walkTuning={walkTuning} />
+        <CharacterSprite map={map} appearance={appearance} selected={selected} type={type.id} onClick={onClick} outlineColor={outlineColor ?? (idColor ? [idColor.r, idColor.g, idColor.b] : undefined)} characterModel={characterModel} characterScale={characterScale} characterFps={characterFps} walkTuning={walkTuning} />
       </Suspense>
       {type.id === "vendor" && <VendorCart onClick={onClick} awning={awning} idColor={idColor} />}
     </>

--- a/components/game/travelers.tsx
+++ b/components/game/travelers.tsx
@@ -1,7 +1,6 @@
 "use client"
 
-import { groundHeight } from "@/lib/game/map/elevation"
-import { bridgeLayout } from "@/lib/game/map/bridges"
+import { walkingSurface } from "@/lib/game/map/walking-surface"
 
 import { useEffect, useMemo, useRef } from "react"
 import { useFrame } from "@react-three/fiber"
@@ -171,10 +170,7 @@ export function Travelers({
 
       const logs = group.getObjectByName("carried-logs")
       if (logs) logs.visible = s.carrying > 0
-      const tx = Math.floor(s.x + map.width / 2), tz = Math.floor(s.z + map.depth / 2)
-      const bridge = bridgeLayout(map).rise[tz * map.width + tx]
-      const y = map.elevation && !bridge
-        ? groundHeight(map, s.x + map.width / 2 - 0.5, s.z + map.depth / 2 - 0.5) : s.y
+      const y = walkingSurface(map, s.x, s.z).height
       group.position.set(s.x, y, s.z)
       // Keep baked bodies at their authored proportions.
       group.scale.y = 1
@@ -197,7 +193,7 @@ export function Travelers({
               groupRefs.current[index] = node
             }}
           >
-            <TravelerFigure appearance={appearances[index]} selected={selected} type={traveler.type} onClick={select} idColor={idColor}
+            <TravelerFigure map={map} appearance={appearances[index]} selected={selected} type={traveler.type} onClick={select} idColor={idColor}
               characterModel={characterModel} characterScale={characterScale} characterFps={characterFps} walkTuning={walkTuning} />
             <group name="carried-logs" visible={false} position={[0, 0.35, 0.2]} rotation={[0, 0, Math.PI / 2]} onClick={select}>
               <mesh><cylinderGeometry args={[0.12, 0.12, 0.6, 6]} /><meshLambertMaterial color="#89613c" /></mesh>

--- a/lib/game/base-person/gait.ts
+++ b/lib/game/base-person/gait.ts
@@ -41,9 +41,11 @@ export interface FootPlant {
 }
 
 /** Preserve the rig's support contact between atlas frames, including turns. */
-export function plantFoot(previous: FootPlant | null, key: string, origin: GroundPoint, foot: GroundPoint) {
+export function plantFoot(previous: FootPlant | null, key: string, origin: GroundPoint, foot: GroundPoint,
+  groundHeight?: (x: number, z: number) => number) {
   const reset = !previous || previous.key !== key || Math.hypot(origin.x - previous.origin.x, origin.z - previous.origin.z) > 1
   const anchor = reset ? { x: origin.x + foot.x, y: (origin.y ?? 0) + (foot.y ?? 0), z: origin.z + foot.z } : previous.anchor
+  if (reset && groundHeight) anchor.y = groundHeight(anchor.x, anchor.z)
   return {
     plant: { key, anchor, origin: { ...origin } },
     offset: { x: anchor.x - origin.x - foot.x, y: (anchor.y ?? 0) - (origin.y ?? 0) - (foot.y ?? 0), z: anchor.z - origin.z - foot.z },

--- a/lib/game/map/walking-surface.test.ts
+++ b/lib/game/map/walking-surface.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+import { walkingSurface } from "./walking-surface"
+import { DEFAULT_ELEVATION } from "./elevation"
+import type { GameMap } from "./types"
+import { plantFoot } from "../base-person/gait"
+import { parseAsciiMap } from "./prototype-map"
+import { BRIDGE_RISE } from "./bridges"
+
+describe("slope ground contacts", () => {
+  const map: GameMap = {
+    width: 1, depth: 1, tiles: ["grass"], buildings: [],
+    elevation: { settings: DEFAULT_ELEVATION, height: [0.2], corners: [0, 0.2, 0.3, 0.6], slope: [0], cliffs: [0] },
+  }
+  it("uses the exact grade of each rendered triangle", () => {
+    expect(walkingSurface(map, -0.25, -0.25)).toEqual({ height: 0.325, dx: 0.2, dz: 0.3 })
+    expect(walkingSurface(map, 0.25, 0.25)).toMatchObject({ dx: 0.3 })
+    expect(walkingSurface(map, 0.25, 0.25).dz).toBeCloseTo(0.4)
+  })
+  it.each([0.3, -0.3])("plants on the ground under the foot at grade %s, not under the body", grade => {
+    const height = (x: number, z: number) => 0.2 + grade * z + 0.1 * x
+    const origin = { x: 0, y: height(0, 0), z: 0 }
+    const foot = { x: 0.1, z: 0.2 }
+    const first = plantFoot(null, "left", origin, foot, height)
+    expect(origin.y + first.offset.y).toBeCloseTo(height(0.1, 0.2))
+    const moved = { x: 0, y: height(0, 0.03), z: 0.03 }
+    const next = plantFoot(first.plant, "left", moved, foot, height)
+    expect(moved.y + next.offset.y).toBeCloseTo(height(0.1, 0.2))
+    expect(moved.z + next.offset.z + foot.z).toBeCloseTo(0.2)
+    const switched = plantFoot(next.plant, "right", moved, { x: -0.1, z: 0.15 }, height)
+    expect(moved.y + switched.offset.y).toBeCloseTo(height(-0.1, 0.18))
+  })
+  it("follows both bridge ramps continuously at off-centre foot contacts", () => {
+    const bridge = parseAsciiMap(["===#==="])
+    for (const direction of [-1, 1]) for (const distance of [0.6, 1, 1.4]) {
+      const surface = walkingSurface(bridge, distance * direction, 0)
+      expect(surface.height).toBeCloseTo(0.2 + BRIDGE_RISE * (1.5 - distance))
+      expect(surface.dx).toBe(-direction * BRIDGE_RISE)
+      expect(surface.dz).toBe(0)
+    }
+    expect(walkingSurface(bridge, 0, 0).height).toBeCloseTo(0.2 + BRIDGE_RISE)
+  })
+})

--- a/lib/game/map/walking-surface.ts
+++ b/lib/game/map/walking-surface.ts
@@ -1,0 +1,33 @@
+import { BRIDGE_RISE, bridgeLayout, ropeDeckHeight } from "./bridges"
+import { groundHeight } from "./elevation"
+import { TILE_HEIGHT } from "./terrain"
+import type { GameMap } from "./types"
+
+/** Height and grade of the rendered triangle/deck, sampled in centred world coordinates. */
+export function walkingSurface(map: GameMap, wx: number, wz: number) {
+  const x = wx + map.width / 2 - 0.5, z = wz + map.depth / 2 - 0.5
+  const tx = Math.max(0, Math.min(map.width - 1, Math.floor(x + 0.5)))
+  const tz = Math.max(0, Math.min(map.depth - 1, Math.floor(z + 0.5)))
+  const index = tz * map.width + tx, layout = bridgeLayout(map)
+  const span = layout.ropeAt.get(index)
+  if (span) {
+    const first = span.tiles[0], last = span.tiles[span.tiles.length - 1]
+    const along = (x - (first.x + last.x) / 2) * span.dx + (z - (first.z + last.z) / 2) * span.dz
+    const grade = 8 * (span.ropeSag ?? 0) * along / span.tiles.length ** 2
+    return { height: ropeDeckHeight(span, along), dx: grade * span.dx, dz: grade * span.dz }
+  }
+  const rise = layout.rise[index]
+  if (rise > 0) {
+    const ramp = layout.ramps.find(r => r.x === tx && r.z === tz)
+    const dx = ramp ? BRIDGE_RISE * ramp.dx : 0, dz = ramp ? BRIDGE_RISE * ramp.dz : 0
+    return { height: TILE_HEIGHT + rise + (x - tx) * dx + (z - tz) * dz, dx, dz }
+  }
+  if (!map.elevation) return { height: TILE_HEIGHT, dx: 0, dz: 0 }
+  const c = map.elevation.corners, i = index * 4
+  const first = x - tx + z - tz <= 0
+  return {
+    height: groundHeight(map, x, z),
+    dx: first ? c[i + 1] - c[i] : c[i + 3] - c[i + 2],
+    dz: first ? c[i + 2] - c[i] : c[i + 3] - c[i + 1],
+  }
+}

--- a/lib/game/monk-wander.test.ts
+++ b/lib/game/monk-wander.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest"
+import { monkWander } from "./monk-wander"
+import { DEFAULT_ELEVATION, elevationStep, finishElevation } from "./map/elevation"
+import { tileToWorldX, tileToWorldZ, worldToTileX, worldToTileZ, type GameMap } from "./map/types"
+import { buildingAt } from "./settlement"
+
+function grounds(): GameMap {
+  const map: GameMap = {
+    width: 9, depth: 9, tiles: Array(81).fill("grass"),
+    buildings: [{ id: "hovel", x: 4, z: 4, w: 1, d: 1, height: 1, label: "Hovel", color: "", roofColor: "" }],
+    site: { hovelId: "hovel", door: { x: 4, z: 5 }, junction: 0, branch: [] },
+    elevation: { settings: DEFAULT_ELEVATION, height: Array(81).fill(0), corners: [], cliffs: [], slope: [] },
+  }
+  return map
+}
+
+describe("monks wandering around the shrine", () => {
+  it("never spawns or chooses a destination on an isolated raised tile", () => {
+    const map = grounds()
+    map.elevation!.height[5 * 9 + 5] = 2
+    finishElevation(map.elevation!, 9, 9, new Uint8Array(81), Array(81).fill(0))
+    const wander = monkWander(map)
+    expect(wander.spots.length).toBeGreaterThan(10)
+    expect(wander.spots.some(p => worldToTileX(map, p.x) === 5 && worldToTileZ(map, p.z) === 5)).toBe(false)
+  })
+
+  it("routes both ways around buildings, water, woods and cliffs, including jittered endpoints", () => {
+    const map = grounds()
+    map.elevation!.height[5 * 9 + 5] = 2
+    map.tiles[3 * 9 + 4] = "water"
+    map.tiles[4 * 9 + 5] = "forest"
+    finishElevation(map.elevation!, 9, 9, new Uint8Array(81), Array(81).fill(0))
+    const wander = monkWander(map)
+    for (const a of [wander.spots[0], wander.spots.at(-1)!]) for (const b of wander.spots) {
+      const start = { ...a, x: a.x + 0.24, z: a.z - 0.24 }
+      const goal = { ...b, x: b.x - 0.24, z: b.z + 0.24 }
+      const path = wander.route(start, goal)
+      expect(path.at(-1)).toEqual(goal)
+      let previous = start
+      for (const point of path) {
+        let last = worldToTileZ(map, previous.z) * 9 + worldToTileX(map, previous.x)
+        for (let tick = 0; tick <= 20; tick++) {
+          const x = worldToTileX(map, previous.x + (point.x - previous.x) * tick / 20)
+          const z = worldToTileZ(map, previous.z + (point.z - previous.z) * tick / 20)
+          const next = z * 9 + x
+          expect(buildingAt(map, x, z)).toBeFalsy()
+          expect(map.tiles[next]).toBe("grass")
+          expect(Number.isFinite(elevationStep(map.elevation, last, next))).toBe(true)
+          last = next
+        }
+        previous = point
+      }
+    }
+  })
+
+  it("allows an elevated destination reached by a continuous slope", () => {
+    const map = grounds()
+    for (let z = 0; z < 9; z++) for (let x = 0; x < 9; x++) map.elevation!.height[z * 9 + x] = x * 0.2
+    finishElevation(map.elevation!, 9, 9, new Uint8Array(81), Array(81).fill(0))
+    const wander = monkWander(map)
+    const goal = { x: tileToWorldX(map, 7), y: 1.6, z: tileToWorldZ(map, 5) }
+    expect(wander.route(wander.spots[0], goal).at(-1)).toEqual(goal)
+  })
+
+  it("has no wanderers without an accessible shrine door", () => {
+    const map = grounds()
+    map.tiles[5 * 9 + 4] = "water"
+    expect(monkWander(map).spots).toEqual([])
+  })
+})

--- a/lib/game/monk-wander.ts
+++ b/lib/game/monk-wander.ts
@@ -1,0 +1,61 @@
+import { surfaceHeight } from "./map/bridges"
+import { elevationStep } from "./map/elevation"
+import { ROUTE_DIRS } from "./map/route"
+import { TERRAIN } from "./map/terrain"
+import { tileAt, tileToWorldX, tileToWorldZ, worldToTileX, worldToTileZ, type GameMap } from "./map/types"
+import { buildingAt } from "./settlement"
+
+export interface WanderSpot { x: number; y: number; z: number }
+
+/** Only the open ground connected to the shrine door belongs to its grounds. */
+export function monkWander(map: GameMap, radius = 3) {
+  const hovel = map.buildings.find(b => b.id === map.site?.hovelId)
+  const centre = hovel ? {
+    x: tileToWorldX(map, hovel.x) + (hovel.w - 1) / 2,
+    z: tileToWorldZ(map, hovel.z) + (hovel.d - 1) / 2,
+  } : null
+  const candidates = new Map<number, WanderSpot>()
+  if (hovel) for (let z = hovel.z - radius; z < hovel.z + hovel.d + radius; z++) {
+    for (let x = hovel.x - radius; x < hovel.x + hovel.w + radius; x++) {
+      const terrain = tileAt(map, x, z)
+      if (!terrain || !TERRAIN[terrain].passable || buildingAt(map, x, z)) continue
+      candidates.set(z * map.width + x, { x: tileToWorldX(map, x), y: surfaceHeight(map, x, z), z: tileToWorldZ(map, z) })
+    }
+  }
+  const neighbours = (i: number) => ROUTE_DIRS.flatMap(([dx, dz]) => {
+    const x = i % map.width + dx, z = Math.floor(i / map.width) + dz, n = z * map.width + x
+    if (x < 0 || x >= map.width || !candidates.has(n)) return []
+    if (map.tiles[i] !== "bridge" && map.tiles[n] !== "bridge" && !Number.isFinite(elevationStep(map.elevation, i, n))) return []
+    return [n]
+  })
+  const door = map.site ? map.site.door.z * map.width + map.site.door.x : -1
+  const reachable = new Set<number>()
+  const queue: number[] = []
+  if (candidates.has(door)) { reachable.add(door); queue.push(door) }
+  for (let head = 0; head < queue.length; head++) for (const n of neighbours(queue[head])) {
+    if (!reachable.has(n)) { reachable.add(n); queue.push(n) }
+  }
+  const key = (p: WanderSpot) => worldToTileZ(map, p.z) * map.width + worldToTileX(map, p.x)
+  return {
+    centre,
+    spots: queue.map(i => candidates.get(i)!),
+    /** Visit tile centres at corners so jitter never cuts across a wall or cliff. */
+    route(start: WanderSpot, goal: WanderSpot): WanderSpot[] {
+      const a = key(start), b = key(goal)
+      if (!reachable.has(a) || !reachable.has(b)) return []
+      if (a === b) return [goal]
+      const parents = new Map<number, number>([[a, -1]]), open = [a]
+      for (let head = 0; head < open.length; head++) {
+        const current = open[head]
+        if (current === b) break
+        for (const n of neighbours(current)) if (!parents.has(n)) {
+          parents.set(n, current); open.push(n)
+        }
+      }
+      if (!parents.has(b)) return []
+      const path: WanderSpot[] = []
+      for (let i = b; i !== -1; i = parents.get(i)!) path.push(candidates.get(i)!)
+      return [...path.reverse(), goal]
+    },
+  }
+}

--- a/lib/game/render/sprite-depth.ts
+++ b/lib/game/render/sprite-depth.ts
@@ -12,22 +12,35 @@ import type * as THREE from "three"
  * Keep that extra clearance off the upright plane to preserve body occlusion.
  * Like the game's cameras, this depth model is orthographic.
  */
-export function applySpriteDepth(shader: Parameters<THREE.Material["onBeforeCompile"]>[0], viewport: THREE.Vector4, worldTexel = { value: 0 }) {
+export function applySpriteDepth(shader: Parameters<THREE.Material["onBeforeCompile"]>[0], viewport: THREE.Vector4, worldTexel = { value: 0 },
+  groundPlane = { value: { x: 0, y: 0, z: 0, w: 0 } }) {
   shader.uniforms.spriteWorldTexel = worldTexel
   shader.uniforms.spriteViewport = { value: viewport }
-  shader.vertexShader = "flat varying vec4 vSpritePlanes;\nuniform float spriteWorldTexel;\n" + shader.vertexShader.replace(
+  shader.uniforms.spriteGroundPlane = groundPlane
+  shader.vertexShader = "flat varying vec4 vSpritePlanes;\nflat varying float vSpriteGroundX;\nuniform float spriteWorldTexel;\nuniform vec4 spriteGroundPlane;\n" + shader.vertexShader.replace(
     "#include <fog_vertex>", `#include <fog_vertex>
     vec4 anchor = projectionMatrix * modelViewMatrix[3];
     float anchorY = anchor.y * 0.5 + 0.5;
     float depthScale = abs(projectionMatrix[2][2]) * 0.5;
     float anchorDepth = anchor.z * 0.5 + 0.5 - 0.005 * depthScale;
     float pitch = max(0.01, abs(viewMatrix[1][2] / viewMatrix[1][1]));
-    vec2 slopes = vec2(pitch, -1.08 / pitch) * (2.0 / projectionMatrix[1][1]) * depthScale;
-    vec2 clearance = vec2(0.0, 0.5 * spriteWorldTexel / pitch * depthScale);
-    vSpritePlanes = vec4(anchorDepth + anchorY * slopes - clearance, slopes);`)
-  shader.fragmentShader = "flat varying vec4 vSpritePlanes;\nuniform vec4 spriteViewport;\n" + shader.fragmentShader.replace(
+    // Project the actual ground normal into camera space. Both screen axes
+    // matter on a diagonal hillside; a horizontal toe plane cuts into it.
+    vec3 normal = spriteGroundPlane.y > 0.0 ? spriteGroundPlane.xyz : vec3(0.0, 1.0, 0.0);
+    vec3 viewNormal = mat3(viewMatrix) * normal;
+    float toward = max(0.05, viewNormal.z);
+    vec2 grade = viewNormal.xy / toward;
+    float planeOffset = spriteGroundPlane.y > 0.0
+      ? dot(spriteGroundPlane, modelMatrix[3]) / toward : 0.0;
+    vec2 slopes = vec2(pitch, -grade.y) * (2.0 / projectionMatrix[1][1]) * depthScale;
+    vSpriteGroundX = -grade.x * (2.0 / projectionMatrix[0][0]) * depthScale;
+    float clearance = 0.5 * spriteWorldTexel * (abs(grade.x) + abs(grade.y)) * depthScale;
+    vSpritePlanes = vec4(anchorDepth + anchorY * slopes, slopes);
+    vSpritePlanes.y += (anchor.x * 0.5 + 0.5) * vSpriteGroundX + planeOffset * depthScale - clearance;`)
+  shader.fragmentShader = "flat varying vec4 vSpritePlanes;\nflat varying float vSpriteGroundX;\nuniform vec4 spriteViewport;\n" + shader.fragmentShader.replace(
     "#include <logdepthbuf_fragment>", `#include <logdepthbuf_fragment>
     float screenY = (gl_FragCoord.y - spriteViewport.y) / spriteViewport.w;
     vec2 depths = vSpritePlanes.xy - screenY * vSpritePlanes.zw;
+    depths.y -= (gl_FragCoord.x - spriteViewport.x) / spriteViewport.z * vSpriteGroundX;
     gl_FragDepth = clamp(min(depths.x, depths.y), 0.0, 1.0);`)
 }

--- a/scripts/test-sprite-depth.mjs
+++ b/scripts/test-sprite-depth.mjs
@@ -36,11 +36,12 @@ test("sprites preserve overlaps, terrain contact, and scenery occlusion", async 
       gl.setSize(384, 384)
       const viewport = new THREE.Vector4()
       const worldTexel = { value: 0 }
+      const groundPlane = { value: new THREE.Vector4() }
       const scene = new THREE.Scene()
       const camera = new THREE.OrthographicCamera(-1.2, 1.2, 1.2, -1.2, 0.1, 400)
       const makeSprite = (color, order) => {
         const material = new THREE.SpriteMaterial({ color, transparent: false, toneMapped: false })
-        material.onBeforeCompile = shader => applySpriteDepth(shader, viewport, worldTexel)
+        material.onBeforeCompile = shader => applySpriteDepth(shader, viewport, worldTexel, groundPlane)
         material.onBeforeRender = renderer => renderer.getCurrentViewport(viewport)
         const sprite = new THREE.Sprite(material)
         sprite.center.set(0.5, 0.2421875)
@@ -122,6 +123,9 @@ test("sprites preserve overlaps, terrain contact, and scenery occlusion", async 
       const copyCamera = new THREE.Camera()
       let floorCompared = 0, floorClipped = 0
       back.visible = false
+      for (const [dx, dz] of [[0, 0], [0.3, 0], [-0.3, 0], [0.2, 0.25], [-0.2, -0.25]]) {
+        groundPlane.value.set(-dx, 1, -dz, 0)
+        floor.quaternion.setFromUnitVectors(new THREE.Vector3(0, 0, 1), new THREE.Vector3(-dx, 1, -dz).normalize())
       for (const resolution of [30, 60, 120]) {
         const ground = new THREE.WebGLRenderTarget(resolution, resolution, {
           depthTexture: new THREE.DepthTexture(resolution, resolution),
@@ -132,7 +136,7 @@ test("sprites preserve overlaps, terrain contact, and scenery occlusion", async 
           camera.updateProjectionMatrix()
           worldTexel.value = 2.4 / zoom / resolution
           for (const shift of [0, 0.003, 0.013, 0.025]) {
-            front.position.set(shift, 0, shift)
+            front.position.set(shift, (dx + dz) * shift, shift)
             const expected = new Uint8Array(480 * 480 * 4), actual = expected.slice()
             gl.autoClear = true
             gl.setRenderTarget(output)
@@ -154,6 +158,7 @@ test("sprites preserve overlaps, terrain contact, and scenery occlusion", async 
         }
         ground.depthTexture.dispose()
         ground.dispose()
+      }
       }
       output.dispose()
       floor.geometry.dispose()


### PR DESCRIPTION
Monks now spawn and wander only on ground connected to the shrine door, following tile routes around cliffs, buildings, water, and woods while still allowing continuous slopes.
Characters sample terrain and bridge surfaces beneath their supporting feet, and body and selection depth passes follow the local slope to prevent foot clipping; the shared walking documentation and regression tests cover this contract.
Validation passed: 18 focused tests, GPU depth and occlusion checks, TypeScript, and base, population, and monk asset validation.
The full suite recorded 470 passes and five timeouts in unchanged map-generation/environment tests; full-scene screenshot capture also timed out, while isolated rendering checks passed.
