### PR TITLE
Keep characters on grid routes and add monk shrine prayers

### DIFF
--- a/components/game/monks.tsx
+++ b/components/game/monks.tsx
@@ -2,6 +2,7 @@
 
 import { walkingSurface } from "@/lib/game/map/walking-surface"
 
+import { createMonkRoutine, stepMonkRoutine, type MonkRoutine } from "@/lib/game/monk-routine"
 import { monkWander, type WanderSpot } from "@/lib/game/monk-wander"
 import { Suspense, useEffect, useMemo, useRef } from "react"
 import { useFrame } from "@react-three/fiber"
@@ -21,25 +22,14 @@ import { monkVisual, monkWalkSpeed, MONK_WALK_TUNING } from "@/lib/game/base-per
 import { MonkRocketGear, ROCKET_EXHAUST_NAME } from "./monk-rocket-gear"
 
 /**
- * The brothers drift between the open tiles around the hovel,
- * stand a while, and drift on — enough that the place is plainly
- * lived in. Ambient motion only; they aren't in the traveler sim. Click one
+ * The brothers follow the grid around the shrine and regularly enter through
+ * its gates to kneel beside the relic. Ambient motion only; they aren't in the traveler sim. Click one
  * to select him — the HUD names him and his office. Blaster Pastor sends them
  * on occasional cruises across the map; they return to their life at the shrine
  * between trips, keeping their rocket-powered gear equipped.
  */
 
-const PAUSE_MIN_SECONDS = 2
-const PAUSE_MAX_SECONDS = 7
-/** Extra distance beyond the hovel’s half-width that counts as keeping vigil. */
-const VIGIL_MARGIN = 1.1
-
-interface MonkState {
-  x: number
-  y: number
-  z: number
-  route: WanderSpot[]
-  pause: number
+interface MonkState extends MonkRoutine {
   flight?: MonkFlight
   flightWait: number
 }
@@ -55,19 +45,13 @@ export function Monks({ map, monks, flying = false, characterScale = 1 }: { map:
     const flightRng = makeRng(deriveSeed(map.seed ?? 0, SEED_STREAM.monkFlight))
     const pick = (): WanderSpot => {
       const spot = spots[Math.floor(rng() * spots.length)]
-      // Jitter within the tile so two brothers never stand on the same spot.
-      const x = spot.x + (rng() - 0.5) * 0.5, z = spot.z + (rng() - 0.5) * 0.5
-      return { x, y: walkingSurface(map, x, z).height, z }
+      return spot
     }
-    const states: MonkState[] = (spots.length ? monks : []).map((_, index) => {
-      const start = pick()
-      // One immediate demonstration; the other brothers take off in their own time.
-      return { ...start, route: wander.route(start, pick()), pause: rng() * PAUSE_MAX_SECONDS, flightWait: index * 8 }
-    })
+    const states: MonkState[] = (spots.length ? monks : []).map((_, index) => ({
+      ...createMonkRoutine(wander, index, rng), flightWait: index * 8,
+    }))
     const activities = new Map<number, MonkActivity>()
-    const hovel = map.buildings.find(b => b.id === map.site?.hovelId)
-    const vigilRadius = (hovel ? Math.max(hovel.w, hovel.d) / 2 : 0.7) + VIGIL_MARGIN
-    return { spots, centre, rng, flightRng, pick, states, activities, wander, vigilRadius }
+    return { spots, centre, rng, flightRng, pick, states, activities, wander }
   }, [map, monks])
 
   // Publish activities so the HUD's monk panel can poll them.
@@ -96,7 +80,7 @@ export function Monks({ map, monks, flying = false, characterScale = 1 }: { map:
       const exhaust = group.getObjectByName(ROCKET_EXHAUST_NAME)
       if (flying) {
         s.flightWait -= dt
-        if (!s.flight && s.flightWait <= 0) {
+        if (!s.flight && s.flightWait <= 0 && s.destination === "grounds" && s.activity === "resting") {
           s.flight = createMonkFlight(s, world.pick(), map, world.flightRng)
         }
       }
@@ -125,42 +109,22 @@ export function Monks({ map, monks, flying = false, characterScale = 1 }: { map:
         }
         s.flight = undefined
         s.flightWait = monkGroundTime(world.flightRng)
-        s.route = world.wander.route(s, world.pick())
-        s.pause = PAUSE_MIN_SECONDS + world.rng() * (PAUSE_MAX_SECONDS - PAUSE_MIN_SECONDS)
+        s.route = []
+        s.pause = 2 + world.rng() * 5
+        s.activity = "resting"
+        s.destination = "grounds"
+        s.outings = 0
       }
       if (exhaust) exhaust.visible = false
       group.rotation.x = 0
 
-      if (s.pause > 0) {
-        s.pause -= dt
-        const nearRelic =
-          !!world.centre && Math.hypot(s.x - world.centre.x, s.z - world.centre.z) <= world.vigilRadius
-        group.userData.activity = nearRelic ? "vigil" : "resting"
-        world.activities.set(monks[i].id, group.userData.activity)
-        if (nearRelic && world.centre) group.rotation.y = Math.atan2(world.centre.x - s.x, world.centre.z - s.z)
-      } else {
-        group.userData.activity = "walking"
-        world.activities.set(monks[i].id, "walking")
-        const target = s.route[0] ?? s
-        const dx = target.x - s.x
-        const dz = target.z - s.z
-        const dist = Math.hypot(dx, dz)
-        const step = monkWalkSpeed(characterScale) * dt
-        if (dist <= step) {
-          s.x = target.x
-          s.z = target.z
-          s.y = target.y
-          s.route.shift()
-          if (!s.route.length) {
-            s.route = world.wander.route(s, world.pick())
-            s.pause = PAUSE_MIN_SECONDS + world.rng() * (PAUSE_MAX_SECONDS - PAUSE_MIN_SECONDS)
-          }
-        } else {
-          s.x += (dx / dist) * step
-          s.z += (dz / dist) * step
-          s.y += (target.y - s.y) * Math.min(1, step / dist)
-          group.rotation.y = Math.atan2(dx, dz)
-        }
+      stepMonkRoutine(s, world.wander, world.rng, monkWalkSpeed(characterScale), dt)
+      group.userData.activity = s.activity
+      world.activities.set(monks[i].id, s.activity)
+      if (s.activity === "praying" && world.centre) {
+        group.rotation.y = Math.atan2(world.centre.x - s.x, world.centre.z - s.z)
+      } else if (Math.hypot(s.x - previousX, s.z - previousZ) > 0) {
+        group.rotation.y = Math.atan2(s.x - previousX, s.z - previousZ)
       }
       const y = walkingSurface(map, s.x, s.z).height
       s.y = y

--- a/lib/game/base-person/activity.ts
+++ b/lib/game/base-person/activity.ts
@@ -14,6 +14,7 @@ export function activityClip(activity: Activity | MonkActivity | undefined, movi
     // Resident monks rest on open ground, so use their existing kneeling pose.
     case "resting":
     case "vigil":
+    case "praying":
     case "visiting": return "praying"
     case "working": return "treeFelling"
     // This simulation state processes fallen timber; the gathering pose is reserved for harvesting.

--- a/lib/game/building-navigation.ts
+++ b/lib/game/building-navigation.ts
@@ -1,0 +1,36 @@
+import type { BuildingDef, GameMap, TilePos } from "./map/types"
+
+export function containsTile(building: BuildingDef, p: TilePos): boolean {
+  return p.x >= building.x && p.x < building.x + building.w && p.z >= building.z && p.z < building.z + building.d
+}
+
+/** The roofless shrine has a gate at the centre of each of its four walls. */
+export function shrineGates(building: BuildingDef): Array<{ outside: TilePos; inside: TilePos }> {
+  const x = building.x + Math.floor(building.w / 2), z = building.z + Math.floor(building.d / 2)
+  return [
+    { outside: { x, z: building.z - 1 }, inside: { x, z: building.z } },
+    { outside: { x, z: building.z + building.d }, inside: { x, z: building.z + building.d - 1 } },
+    { outside: { x: building.x - 1, z }, inside: { x: building.x, z } },
+    { outside: { x: building.x + building.w, z }, inside: { x: building.x + building.w - 1, z } },
+  ]
+}
+
+/** Closed buildings block walking. Shrine visits cross walls only at a gate. */
+export function buildingStepAllowed(map: GameMap, buildings: readonly BuildingDef[], from: TilePos, to: TilePos, enterShrine = false): boolean {
+  for (const building of buildings) {
+    // Lumber camps are open yards, with no walls or doors.
+    if (building.id.startsWith("lumberCamp-")) continue
+    const a = containsTile(building, from), b = containsTile(building, to)
+    if (!a && !b) continue
+    if (!enterShrine || building.id !== map.site?.hovelId) return false
+    // Leave the relic table clear.
+    const cx = building.x + Math.floor(building.w / 2), cz = building.z + Math.floor(building.d / 2)
+    if (to.x === cx && to.z === cz) return false
+    if (a && b) continue
+    const same = (p: TilePos, q: TilePos) => p.x === q.x && p.z === q.z
+    if (!shrineGates(building).some(g => a
+      ? same(from, g.inside) && same(to, g.outside)
+      : same(from, g.outside) && same(to, g.inside))) return false
+  }
+  return true
+}

--- a/lib/game/monk-routine.test.ts
+++ b/lib/game/monk-routine.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest"
+import { buildingStepAllowed, containsTile, shrineGates } from "./building-navigation"
+import { activityClip } from "./base-person/activity"
+import { monkWander } from "./monk-wander"
+import { createMonkRoutine, stepMonkRoutine } from "./monk-routine"
+import { makeRng } from "./rng"
+import { settlementRoute } from "./settlement-route"
+import { worldToTileX, worldToTileZ, type GameMap } from "./map/types"
+
+function shrineMap(): GameMap {
+  return {
+    width: 11, depth: 11, tiles: Array(121).fill("grass"),
+    buildings: [{ id: "shrine", x: 4, z: 4, w: 3, d: 3, height: 1, label: "Shrine", color: "", roofColor: "" }],
+    site: { hovelId: "shrine", door: { x: 5, z: 7 }, junction: 0, branch: [] },
+  }
+}
+
+describe("grid routes through shrine doors", () => {
+  it("crosses each wall only at its gate, in either direction", () => {
+    const map = shrineMap(), shrine = map.buildings[0]
+    for (let z = 3; z <= 7; z++) for (let x = 3; x <= 7; x++) {
+      for (const [dx, dz] of [[1, 0], [-1, 0], [0, 1], [0, -1]]) {
+        const a = { x, z }, b = { x: x + dx, z: z + dz }
+        if (containsTile(shrine, a) === containsTile(shrine, b)) continue
+        const gate = shrineGates(shrine).some(g => JSON.stringify(g.inside) === JSON.stringify(containsTile(shrine, a) ? a : b) &&
+          JSON.stringify(g.outside) === JSON.stringify(containsTile(shrine, a) ? b : a))
+        expect(buildingStepAllowed(map, map.buildings, a, b, true)).toBe(gate)
+      }
+    }
+  })
+
+  it("does not allow ordinary routes into closed buildings or across the relic table", () => {
+    const map = shrineMap()
+    expect(settlementRoute(map, map.buildings, { x: 5, z: 7 }, { x: 5, z: 6 })).toBeNull()
+    expect(settlementRoute(map, map.buildings, { x: 5, z: 7 }, { x: 5, z: 5 }, false, true)).toBeNull()
+    expect(settlementRoute(map, map.buildings, { x: 5, z: 7 }, { x: 5, z: 6 }, false, true)).toEqual([{ x: 5, z: 7 }, { x: 5, z: 6 }])
+    map.buildings[0].id = "inn"
+    expect(settlementRoute(map, map.buildings, { x: 5, z: 7 }, { x: 5, z: 6 }, false, true)).toBeNull()
+  })
+
+  it("gives every monk repeated prayers inside, with grid walking and exits through gates", () => {
+    const map = shrineMap(), shrine = map.buildings[0], grounds = monkWander(map), rng = makeRng(42)
+    const monks = Array.from({ length: 4 }, (_, i) => createMonkRoutine(grounds, i, rng))
+    expect(new Set(monks.map(m => JSON.stringify(m.prayerSpot))).size).toBe(4)
+    for (const monk of monks) {
+      let prayers = 0, exits = 0
+      for (let tick = 0; tick < 5000; tick++) {
+        const was = monk.activity
+        const from = { x: worldToTileX(map, monk.x), z: worldToTileZ(map, monk.z) }
+        stepMonkRoutine(monk, grounds, rng, 1, 0.1)
+        const to = { x: worldToTileX(map, monk.x), z: worldToTileZ(map, monk.z) }
+        const tx = monk.x + map.width / 2 - 0.5, tz = monk.z + map.depth / 2 - 0.5
+        expect(Math.min(Math.abs(tx - Math.round(tx)), Math.abs(tz - Math.round(tz)))).toBeLessThan(1e-8)
+        if (from.x !== to.x || from.z !== to.z) expect(buildingStepAllowed(map, map.buildings, from, to, true)).toBe(true)
+        if (containsTile(shrine, from) && !containsTile(shrine, to)) exits++
+        if (monk.activity === "praying") {
+          expect(containsTile(shrine, to)).toBe(true)
+          expect(activityClip(monk.activity, false)).toBe("praying")
+          if (was !== "praying") prayers++
+        }
+      }
+      expect(prayers).toBeGreaterThan(2)
+      expect(exits).toBeGreaterThan(2)
+    }
+  })
+
+  it("holds position and prayer time while paused", () => {
+    const grounds = monkWander(shrineMap()), rng = makeRng(1), monk = createMonkRoutine(grounds, 0, rng)
+    for (let i = 0; i < 1000 && monk.activity !== "praying"; i++) stepMonkRoutine(monk, grounds, rng, 1, 0.1)
+    expect(monk.activity).toBe("praying")
+    const before = structuredClone(monk)
+    stepMonkRoutine(monk, grounds, rng, 1, 0)
+    expect(monk).toEqual(before)
+  })
+})

--- a/lib/game/monk-routine.ts
+++ b/lib/game/monk-routine.ts
@@ -1,0 +1,56 @@
+import type { MonkActivity } from "./monks"
+import type { monkWander, WanderSpot } from "./monk-wander"
+
+type Grounds = ReturnType<typeof monkWander>
+export interface MonkRoutine extends WanderSpot {
+  route: WanderSpot[]
+  pause: number
+  activity: MonkActivity
+  destination: "grounds" | "prayer"
+  outings: number
+  prayerSpot: WanderSpot | undefined
+}
+
+export function createMonkRoutine(grounds: Grounds, index: number, rng: () => number): MonkRoutine {
+  return {
+    ...grounds.spots[index % grounds.spots.length], route: [], pause: index * 2 + rng() * 2,
+    activity: "resting", destination: "grounds", outings: 0,
+    prayerSpot: grounds.prayerSpots[index % grounds.prayerSpots.length],
+  }
+}
+
+/** A regular rhythm of entering, kneeling at the relic, and returning outside. */
+export function stepMonkRoutine(s: MonkRoutine, grounds: Grounds, rng: () => number, speed: number, dt: number): void {
+  if (dt <= 0) return
+  if (s.pause > 0) { s.pause = Math.max(0, s.pause - dt); return }
+  if (!s.route.length) {
+    const pray = s.destination === "grounds" && s.outings === 0 && s.prayerSpot
+    const goal = pray || grounds.spots[Math.floor(rng() * grounds.spots.length)]
+    s.route = grounds.route(s, goal)
+    if (!s.route.length) { s.pause = 2; return }
+    s.destination = pray ? "prayer" : "grounds"
+    s.activity = "walking"
+  }
+  let distance = speed * dt
+  while (s.route.length) {
+    const target = s.route[0]
+    const dx = target.x - s.x, dz = target.z - s.z, length = Math.hypot(dx, dz)
+    if (length > distance) {
+      const t = distance / length
+      s.x += dx * t; s.y += (target.y - s.y) * t; s.z += dz * t
+      return
+    }
+    s.x = target.x; s.y = target.y; s.z = target.z
+    distance -= length
+    s.route.shift()
+  }
+  if (s.destination === "prayer") {
+    s.activity = "praying"
+    s.pause = 10 + rng() * 6
+    s.outings = 2
+  } else {
+    s.activity = "resting"
+    s.pause = 2 + rng() * 5
+    s.outings = Math.max(0, s.outings - 1)
+  }
+}

--- a/lib/game/monk-wander.test.ts
+++ b/lib/game/monk-wander.test.ts
@@ -24,7 +24,7 @@ describe("monks wandering around the shrine", () => {
     expect(wander.spots.some(p => worldToTileX(map, p.x) === 5 && worldToTileZ(map, p.z) === 5)).toBe(false)
   })
 
-  it("routes both ways around buildings, water, woods and cliffs, including jittered endpoints", () => {
+  it("snaps destinations to the grid and routes around buildings, water, woods and cliffs", () => {
     const map = grounds()
     map.elevation!.height[5 * 9 + 5] = 2
     map.tiles[3 * 9 + 4] = "water"
@@ -35,7 +35,7 @@ describe("monks wandering around the shrine", () => {
       const start = { ...a, x: a.x + 0.24, z: a.z - 0.24 }
       const goal = { ...b, x: b.x - 0.24, z: b.z + 0.24 }
       const path = wander.route(start, goal)
-      expect(path.at(-1)).toEqual(goal)
+      expect(path.at(-1)).toEqual(b)
       let previous = start
       for (const point of path) {
         let last = worldToTileZ(map, previous.z) * 9 + worldToTileX(map, previous.x)
@@ -59,7 +59,7 @@ describe("monks wandering around the shrine", () => {
     finishElevation(map.elevation!, 9, 9, new Uint8Array(81), Array(81).fill(0))
     const wander = monkWander(map)
     const goal = { x: tileToWorldX(map, 7), y: 1.6, z: tileToWorldZ(map, 5) }
-    expect(wander.route(wander.spots[0], goal).at(-1)).toEqual(goal)
+    expect(wander.route(wander.spots[0], goal).at(-1)).toMatchObject({ x: goal.x, z: goal.z })
   })
 
   it("has no wanderers without an accessible shrine door", () => {

--- a/lib/game/monk-wander.ts
+++ b/lib/game/monk-wander.ts
@@ -1,3 +1,4 @@
+import { buildingStepAllowed, shrineGates } from "./building-navigation"
 import { surfaceHeight } from "./map/bridges"
 import { elevationStep } from "./map/elevation"
 import { ROUTE_DIRS } from "./map/route"
@@ -18,13 +19,16 @@ export function monkWander(map: GameMap, radius = 3) {
   if (hovel) for (let z = hovel.z - radius; z < hovel.z + hovel.d + radius; z++) {
     for (let x = hovel.x - radius; x < hovel.x + hovel.w + radius; x++) {
       const terrain = tileAt(map, x, z)
-      if (!terrain || !TERRAIN[terrain].passable || buildingAt(map, x, z)) continue
+      const building = buildingAt(map, x, z)
+      if (!terrain || !TERRAIN[terrain].passable || (building && building.id !== hovel.id)) continue
+      if (x === hovel.x + Math.floor(hovel.w / 2) && z === hovel.z + Math.floor(hovel.d / 2)) continue
       candidates.set(z * map.width + x, { x: tileToWorldX(map, x), y: surfaceHeight(map, x, z), z: tileToWorldZ(map, z) })
     }
   }
   const neighbours = (i: number) => ROUTE_DIRS.flatMap(([dx, dz]) => {
     const x = i % map.width + dx, z = Math.floor(i / map.width) + dz, n = z * map.width + x
     if (x < 0 || x >= map.width || !candidates.has(n)) return []
+    if (!buildingStepAllowed(map, map.buildings, { x: i % map.width, z: Math.floor(i / map.width) }, { x, z }, true)) return []
     if (map.tiles[i] !== "bridge" && map.tiles[n] !== "bridge" && !Number.isFinite(elevationStep(map.elevation, i, n))) return []
     return [n]
   })
@@ -38,12 +42,14 @@ export function monkWander(map: GameMap, radius = 3) {
   const key = (p: WanderSpot) => worldToTileZ(map, p.z) * map.width + worldToTileX(map, p.x)
   return {
     centre,
-    spots: queue.map(i => candidates.get(i)!),
-    /** Visit tile centres at corners so jitter never cuts across a wall or cliff. */
+    spots: queue.filter(i => !buildingAt(map, i % map.width, Math.floor(i / map.width))).map(i => candidates.get(i)!),
+    prayerSpots: hovel ? shrineGates(hovel).map(g => g.inside.z * map.width + g.inside.x)
+      .filter(i => reachable.has(i)).map(i => candidates.get(i)!) : [],
+    /** Follow neighbouring tile centres, including the shrine gate crossings. */
     route(start: WanderSpot, goal: WanderSpot): WanderSpot[] {
       const a = key(start), b = key(goal)
       if (!reachable.has(a) || !reachable.has(b)) return []
-      if (a === b) return [goal]
+      if (a === b) return [candidates.get(b)!]
       const parents = new Map<number, number>([[a, -1]]), open = [a]
       for (let head = 0; head < open.length; head++) {
         const current = open[head]
@@ -55,7 +61,7 @@ export function monkWander(map: GameMap, radius = 3) {
       if (!parents.has(b)) return []
       const path: WanderSpot[] = []
       for (let i = b; i !== -1; i = parents.get(i)!) path.push(candidates.get(i)!)
-      return [...path.reverse(), goal]
+      return path.reverse()
     },
   }
 }

--- a/lib/game/monks.ts
+++ b/lib/game/monks.ts
@@ -32,10 +32,11 @@ const PIETY = { min: 75, max: 100 }
 const SKILL_COUNT = { min: 1, max: 3 }
 
 /** What a brother is up to, for the HUD; set by the scene's ambient loop. */
-export type MonkActivity = "vigil" | "walking" | "resting" | "flying"
+export type MonkActivity = "vigil" | "praying" | "walking" | "resting" | "flying"
 
 export const MONK_ACTIVITY_LABELS: Record<MonkActivity, string> = {
   vigil: "Keeping vigil at the relic",
+  praying: "Praying with the relic inside the shrine",
   walking: "About the grounds",
   resting: "At rest",
   flying: "Flying with rocket boosters",

--- a/lib/game/settlement-route.ts
+++ b/lib/game/settlement-route.ts
@@ -1,3 +1,4 @@
+import { buildingStepAllowed } from "./building-navigation"
 import { elevationStep } from "./map/elevation"
 import { ROUTE_DIRS } from "./map/route"
 import { isWoods, TERRAIN } from "./map/terrain"
@@ -10,7 +11,9 @@ export function settlementRoute(
   start: TilePos,
   goal: TilePos,
   logging = false,
+  enterShrine = false,
 ): TilePos[] | null {
+  if (!tileAt(map, start.x, start.z) || !tileAt(map, goal.x, goal.z)) return null
   const key = (p: TilePos) => p.z * map.width + p.x
   const origin = key(start)
   const end = key(goal)
@@ -30,7 +33,7 @@ export function settlementRoute(
       const next = { x: p.x + dx, z: p.z + dz }
       const terrain = tileAt(map, next.x, next.z)
       if (!terrain || !(TERRAIN[terrain].passable || (logging && isWoods(terrain)))) continue
-      if (buildings.some((b) => !b.id.startsWith("lumberCamp-") && next.x >= b.x && next.x < b.x + b.w && next.z >= b.z && next.z < b.z + b.d)) continue
+      if (!buildingStepAllowed(map, buildings, p, next, enterShrine)) continue
       const index = key(next)
       if (map.tiles[current] !== "bridge" && terrain !== "bridge" && !Number.isFinite(elevationStep(map.elevation, current, index))) continue
       if (parents.has(index)) continue

--- a/lib/game/sim.test.ts
+++ b/lib/game/sim.test.ts
@@ -354,7 +354,7 @@ describe("stepSim", () => {
 })
 
 describe("left-hand walking lanes", () => {
-  it.each([1, -1] as const)("follows a diagonal ribbon continuously in direction %i", (direction) => {
+  it.each([1, -1] as const)("follows grid-aligned lanes through a stair-step road in direction %i", (direction) => {
     const map = parseAsciiMap([".........", "===......", "..==.....", "...==....", "....=====", "........."])
     map.road = [[0, 1], [1, 1], [2, 1], [2, 2], [3, 2], [3, 3], [4, 3], [4, 4], [5, 4], [6, 4], [7, 4], [8, 4]]
       .map(([x, z]) => ({ x, z }))
@@ -364,9 +364,9 @@ describe("left-hand walking lanes", () => {
     let previous = { x: s.x, z: s.z }
     for (let tick = 0; tick < 10; tick++) {
       stepSim(sim, [traveler], map, 1, 0.1)
-      // Both coordinates change together; the lane stays on the path tiles.
-      expect(s.x - previous.x).toBeCloseTo(s.z - previous.z)
-      expect((s.x - previous.x) * direction).toBeGreaterThan(0)
+      // Each straight segment follows one grid axis, even with path easing.
+      expect(Math.min(Math.abs(s.x - previous.x), Math.abs(s.z - previous.z))).toBeLessThan(1e-8)
+      expect(Math.hypot(s.x - previous.x, s.z - previous.z)).toBeGreaterThan(0)
       expect(tileAt(map, worldToTileX(map, s.x), worldToTileZ(map, s.z))).toBe("path")
       previous = { x: s.x, z: s.z }
     }
@@ -621,5 +621,51 @@ describe("tracks through the dark forest", () => {
     expect(runUntil(sim, travelers, map, () => s.activity === "walking", 60)).toBe(true)
     expect(s.track).not.toBeNull()
     expect(tileAt(map, worldToTileX(map, s.x), worldToTileZ(map, s.z))).toBe("track")
+  })
+})
+
+describe("off-road grid walking", () => {
+  it.each(["toCamp", "toShop"] as const)("routes %s around a wall and water instead of walking straight through them", (activity) => {
+    const map = makeMap()
+    map.buildings.push({ id: "inn", label: "Inn", x: 12, z: 5, w: 2, d: 2, height: 1, color: "", roofColor: "" })
+    map.tiles[6 * map.width + 11] = "water"
+    const traveler = makeTraveler(0, activity === "toShop" ? "vendor" : "knight", {}, 12 / 23)
+    const sim = createSim([traveler], map), s = sim.travelers.get(0)!
+    s.activity = activity
+    s.spot = { x: tileToWorldX(map, 12), y: TILE_HEIGHT, z: tileToWorldZ(map, 7) }
+    s.walkFrom = { x: s.x, y: s.y, z: s.z }
+    for (let i = 0; i < 2000 && s.activity === activity; i++) {
+      const before = { x: s.x, z: s.z }
+      stepSim(sim, [traveler], map, 1, 0.01, DEFAULT_MOVEMENT)
+      const x = worldToTileX(map, s.x), z = worldToTileZ(map, s.z)
+      expect(x >= 12 && x < 14 && z >= 5 && z < 7).toBe(false)
+      expect(tileAt(map, x, z)).not.toBe("water")
+      expect(Math.hypot(s.x - before.x, s.z - before.z)).toBeLessThanOrEqual(s.moveSpeed * 0.01 + 1e-8)
+    }
+    expect(s.activity).toBe(activity === "toCamp" ? "camping" : "vending")
+    expect(s.x).toBe(s.spot.x)
+    expect(s.z).toBe(s.spot.z)
+    // Force the return journey and check the same obstacles in reverse.
+    s.activity = activity === "toCamp" ? "fromCamp" : "fromShop"
+    s.offRoadRoute = null
+    for (let i = 0; i < 2000 && !["walking"].includes(s.activity); i++) {
+      stepSim(sim, [traveler], map, 1, 0.01)
+      const x = worldToTileX(map, s.x), z = worldToTileZ(map, s.z)
+      expect(x >= 12 && x < 14 && z >= 5 && z < 7).toBe(false)
+      expect(tileAt(map, x, z)).not.toBe("water")
+    }
+    expect(s.activity).toBe("walking")
+    expect(s.z).toBeCloseTo(tileToWorldZ(map, 4) - s.laneOffset)
+  })
+
+  it("does not choose a camping spot across an impassable forest ridge", () => {
+    const map = makeMap(), traveler = makeTraveler(0, "knight", { stamina: 0 })
+    const sim = createSim([traveler], map), s = sim.travelers.get(0)!
+    // A nearby vendor attracts the camper toward the unreachable side.
+    const vendor = { ...s, id: 1, activity: "vending" as const, spot: { x: s.x, y: TILE_HEIGHT, z: tileToWorldZ(map, 2) } }
+    sim.travelers.set(1, vendor)
+    stepSim(sim, [traveler], map, 1, 0.1)
+    expect(s.spot).not.toBeNull()
+    expect(worldToTileZ(map, s.spot!.z)).toBeGreaterThan(4)
   })
 })

--- a/lib/game/sim.ts
+++ b/lib/game/sim.ts
@@ -1,4 +1,4 @@
-import { LINEAR_MOVEMENT, easeProgress, easeSpeed, paceVariation, roundedCorner, type MovementTuning } from "./motion"
+import { LINEAR_MOVEMENT, easeSpeed, paceVariation, type MovementTuning } from "./motion"
 import { DEFAULT_BALANCE, type GameBalance } from "./balance"
 import { buildingAt } from "./settlement"
 import { AXE_DAMAGE_PER_HOUR, STUMP_LIFETIME_DAYS, TIMBER_LOAD, stackWood, treeResource, type TreeResource, type WoodPile } from "./trees/timber"
@@ -10,7 +10,6 @@ import { TREE_SPECIES } from "./trees/species"
 import type { TilePos } from "./map/types"
 import { computeDangerField, encounterChance, type ThreatSource } from "./map/danger"
 import { surfaceHeight, ropeHeightAt } from "./map/bridges"
-import { diagonalRoadPoint } from "./map/road"
 import {
   tileAt,
   tileToWorldX,
@@ -222,6 +221,7 @@ export interface SimTraveler {
   /** The off-road pitch — a camp or a stall, depending on activity. */
   spot: { x: number; y: number; z: number } | null
   walkT: number
+  offRoadRoute: WorldPoint[] | null
   /** Vendor being chased while seeking. */
   targetId: number | null
   /** Vendors only: seconds left in the current walk-or-shop stint. */
@@ -283,8 +283,7 @@ function laneVertex(
   // A doubled-back vertex has no intersection; keep its outgoing normal.
   const nx = divisor > 0 ? (inZ + outZ) / divisor : outZ
   const nz = divisor > 0 ? -(inX + outX) / divisor : -outX
-  const centre = diagonalRoadPoint(map, p.x, p.z)
-  return { x: centre.x + nx * lane * centre.laneScale, z: centre.z + nz * lane * centre.laneScale }
+  return { x: p.x + nx * lane, z: p.z + nz * lane }
 }
 
 interface WorldPoint {
@@ -304,7 +303,6 @@ function routeWorldPoint(
   p: number,
   lane = 0,
   junctions?: { entry: number; exit: number },
-  pathEase = 0,
 ): WorldPoint {
   if (route.length === 1) return {
     x: tileToWorldX(map, route[0].x),
@@ -329,40 +327,30 @@ function routeWorldPoint(
   const ay = surfaceHeight(map, route[i0].x, route[i0].z)
   const by = surfaceHeight(map, route[i0 + 1].x, route[i0 + 1].z)
   const point = { x: ax + (bx - ax) * frac, y: ropeHeightAt(map, a.x + (b.x - a.x) * frac, a.z + (b.z - a.z) * frac) ?? ay + (by - ay) * frac, z: az + (bz - az) * frac }
-  const cornerIndex = Math.round(p)
-  if (pathEase > 0 && cornerIndex > 0 && cornerIndex < route.length - 1) {
-    const previous = route[cornerIndex - 1], corner = route[cornerIndex], next = route[cornerIndex + 1]
-    // Use integer route tiles for bridge heights, and lane vertices for the arc.
-    const height = surfaceHeight(map, corner.x, corner.z)
-    if (surfaceHeight(map, previous.x, previous.z) === height && surfaceHeight(map, next.x, next.z) === height) {
-      const rounded = roundedCorner(vertex(cornerIndex - 1), vertex(cornerIndex), vertex(cornerIndex + 1), p - cornerIndex, pathEase)
-      if (rounded) { point.x = tileToWorldX(map, rounded.x); point.z = tileToWorldZ(map, rounded.z) }
-    }
-  }
   return point
 }
 
-function roadWorldPoint(map: GameMap, p: number, lane: number, pathEase = 0): WorldPoint {
-  return routeWorldPoint(map, map.road!, p, lane, undefined, pathEase)
+function roadWorldPoint(map: GameMap, p: number, lane: number): WorldPoint {
+  return routeWorldPoint(map, map.road!, p, lane)
 }
 
 /** Where on their route — road or track — the traveler currently belongs. */
-function currentRoutePoint(map: GameMap, s: SimTraveler, pathEase = 0): WorldPoint {
+function currentRoutePoint(map: GameMap, s: SimTraveler): WorldPoint {
   if (s.track) {
     const track = map.shortcuts![s.track.index]
-    return routeWorldPoint(map, track.tiles, s.track.progress, s.lane, track, pathEase)
+    return routeWorldPoint(map, track.tiles, s.track.progress, s.lane, track)
   }
-  return roadWorldPoint(map, s.progress, s.lane, pathEase)
+  return roadWorldPoint(map, s.progress, s.lane)
 }
 
 /** Join the shrine's walking lanes to the traveler's road lane over the first tile. */
-function shrineWorldPoint(map: GameMap, s: SimTraveler, pathEase = 0): WorldPoint {
+function shrineWorldPoint(map: GameMap, s: SimTraveler): WorldPoint {
   const site = map.site!
-  const point = routeWorldPoint(map, site.branch, s.branchProgress, s.lane, undefined, pathEase)
+  const point = routeWorldPoint(map, site.branch, s.branchProgress, s.lane)
   if (s.branchProgress < 1) {
     const start = routeWorldPoint(map, site.branch, 0, s.lane)
     const roadLane = s.activity === "toRelic" ? s.branchEntryLane : s.direction * s.laneOffset
-    const road = roadWorldPoint(map, site.junction, roadLane, pathEase)
+    const road = roadWorldPoint(map, site.junction, roadLane)
     const blend = 1 - s.branchProgress
     point.x += (road.x - start.x) * blend
     point.y += (road.y - start.y) * blend
@@ -446,6 +434,7 @@ export function createSim(
       walkFrom: null,
       spot: null,
       walkT: 0,
+      offRoadRoute: null,
       targetId: null,
       timer: t.type.id === "vendor" ? vendWalkSeconds(t.id, 0) : 0,
       cycle: 0,
@@ -458,7 +447,7 @@ export function createSim(
  * Nearest open tile to a world point: grass, dirt, or a forest-floor clearing —
  * never solid woods or the road itself.
  */
-function findClearTile(map: GameMap, wx: number, wz: number): { x: number; z: number } | null {
+function findClearTile(map: GameMap, wx: number, wz: number, start: TilePos): { x: number; z: number } | null {
   const cx = worldToTileX(map, wx)
   const cz = worldToTileZ(map, wz)
   for (let r = 0; r <= CAMP_SEARCH_RADIUS; r++) {
@@ -467,7 +456,8 @@ function findClearTile(map: GameMap, wx: number, wz: number): { x: number; z: nu
         if (Math.max(Math.abs(dx), Math.abs(dz)) !== r) continue
         const terrain = tileAt(map, cx + dx, cz + dz)
         if ((terrain === "grass" || terrain === "dirt" || terrain === "clearing") && !buildingAt(map, cx + dx, cz + dz)) {
-          return { x: cx + dx, z: cz + dz }
+          const goal = { x: cx + dx, z: cz + dz }
+          if (settlementRoute(map, map.buildings, start, goal)) return goal
         }
       }
     }
@@ -500,27 +490,18 @@ function findNearbySpot(
 const STALL_ACTIVITIES: readonly Activity[] = ["toShop", "vending"]
 const CAMP_ACTIVITIES: readonly Activity[] = ["toCamp", "camping"]
 
-/** Spread same-tile pitches apart with a per-traveler hash, not RNG. */
-function pitchJitter(id: number): { x: number; z: number } {
-  return {
-    x: (((id * 73) % 100) / 100 - 0.5) * 0.6,
-    z: (((id * 37) % 100) / 100 - 0.5) * 0.6,
-  }
-}
-
 /** World-space pitch on the nearest clearing to `anchor`, or in place if none. */
 function pitchSpot(
   map: GameMap,
   s: SimTraveler,
   anchor: { x: number; z: number },
 ): { x: number; y: number; z: number } {
-  const tile = findClearTile(map, anchor.x, anchor.z)
-  const jitter = pitchJitter(s.id)
+  const tile = findClearTile(map, anchor.x, anchor.z, { x: worldToTileX(map, s.x), z: worldToTileZ(map, s.z) })
   return tile
     ? {
-        x: tileToWorldX(map, tile.x) + jitter.x,
+        x: tileToWorldX(map, tile.x),
         y: surfaceHeight(map, tile.x, tile.z),
-        z: tileToWorldZ(map, tile.z) + jitter.z,
+        z: tileToWorldZ(map, tile.z),
       }
     : { x: s.x, y: s.y, z: s.z }
 }
@@ -528,6 +509,7 @@ function pitchSpot(
 function startOffRoadWalk(s: SimTraveler, activity: Activity): void {
   s.walkFrom = { x: s.x, y: s.y, z: s.z }
   s.walkT = 0
+  s.offRoadRoute = null
   s.activity = activity
   s.targetId = null
 }
@@ -544,22 +526,42 @@ function startCamping(sim: SimState, s: SimTraveler, traveler: Traveler, map: Ga
   startOffRoadWalk(s, "toCamp")
 }
 
-/** Advance an off-road walk; returns true when the far end is reached. */
+/** Camps and stalls use the same four-neighbour routing as settlement work. */
 function stepOffRoadWalk(
   s: SimTraveler,
-  to: { x: number; y: number; z: number },
+  to: WorldPoint,
   worldSpeed: number,
   dt: number,
-  pathEase = 0,
+  map: GameMap,
 ): boolean {
-  const from = s.walkFrom!
-  const dist = Math.max(0.001, Math.hypot(to.x - from.x, to.z - from.z))
-  s.walkT = Math.min(1, s.walkT + (worldSpeed * dt) / dist)
-  const eased = easeProgress(s.walkT, pathEase)
-  s.x = from.x + (to.x - from.x) * eased
-  s.y = from.y + (to.y - from.y) * eased
-  s.z = from.z + (to.z - from.z) * eased
-  return s.walkT >= 1
+  if (!s.offRoadRoute) {
+    const route = settlementRoute(map, map.buildings,
+      { x: worldToTileX(map, s.x), z: worldToTileZ(map, s.z) },
+      { x: worldToTileX(map, to.x), z: worldToTileZ(map, to.z) })
+    if (!route) return false
+    const points = route.map(p => ({ x: tileToWorldX(map, p.x), y: surfaceHeight(map, p.x, p.z), z: tileToWorldZ(map, p.z) }))
+    // Align to/from the road lane inside its tile; never take a diagonal shortcut.
+    const first = points[0], last = points.at(-1)!
+    s.offRoadRoute = [
+      { x: first.x, y: s.y, z: s.z }, ...points,
+      { x: to.x, y: last.y, z: last.z }, { ...to },
+    ]
+  }
+  let distance = worldSpeed * dt
+  while (s.offRoadRoute.length) {
+    const target = s.offRoadRoute[0]
+    const dx = target.x - s.x, dz = target.z - s.z, length = Math.hypot(dx, dz)
+    if (length > distance) {
+      const t = distance / length
+      s.x += dx * t; s.y += (target.y - s.y) * t; s.z += dz * t
+      return false
+    }
+    s.x = target.x; s.y = target.y; s.z = target.z
+    distance -= length
+    s.offRoadRoute.shift()
+  }
+  s.walkT = 1
+  return true
 }
 
 function routeState(t: Traveler, s: SimTraveler): RouteState {
@@ -751,7 +753,7 @@ export function stepSim(
         s.branchProgress = Math.max(0, Math.min(branch.length - 1,
           s.branchProgress + (inbound ? 1 : -1) * worldSpeed * dt))
         stepLane(s, inbound ? 1 : -1, worldSpeed * dt)
-        const at = shrineWorldPoint(map, s, movement.pathEase)
+        const at = shrineWorldPoint(map, s)
         s.x = at.x
         s.y = at.y
         s.z = at.z
@@ -909,7 +911,7 @@ export function stepSim(
             }
           }
           stepLane(s, s.activity === "fleeing" ? s.direction : direction, worldSpeed * haste * dt)
-          const at = currentRoutePoint(map, s, movement.pathEase)
+          const at = currentRoutePoint(map, s)
           s.x = at.x
           s.y = at.y
           s.z = at.z
@@ -932,7 +934,7 @@ export function stepSim(
               s.targetId = null
               s.branchEntryLane = s.lane
               s.lane = s.laneOffset
-              const at = shrineWorldPoint(map, s, movement.pathEase)
+              const at = shrineWorldPoint(map, s)
               s.x = at.x
               s.y = at.y
               s.z = at.z
@@ -964,7 +966,7 @@ export function stepSim(
           }
         }
         stepLane(s, s.activity === "fleeing" ? s.direction : direction, worldSpeed * haste * dt)
-        const at = currentRoutePoint(map, s, movement.pathEase)
+        const at = currentRoutePoint(map, s)
         s.x = at.x
         s.y = at.y
         s.z = at.z
@@ -972,7 +974,7 @@ export function stepSim(
       }
 
       case "toShop": {
-        if (stepOffRoadWalk(s, s.spot!, worldSpeed, dt, movement.pathEase)) {
+        if (stepOffRoadWalk(s, s.spot!, worldSpeed, dt, map)) {
           s.activity = "vending"
           s.timer = vendShopSeconds(s.id, s.cycle)
         }
@@ -995,8 +997,8 @@ export function stepSim(
       }
 
       case "fromShop": {
-        const back = currentRoutePoint(map, s, movement.pathEase)
-        if (stepOffRoadWalk(s, back, worldSpeed, dt, movement.pathEase)) {
+        const back = currentRoutePoint(map, s)
+        if (stepOffRoadWalk(s, back, worldSpeed, dt, map)) {
           s.activity = "walking"
           s.spot = null
           s.walkFrom = null
@@ -1006,7 +1008,7 @@ export function stepSim(
       }
 
       case "toCamp": {
-        if (stepOffRoadWalk(s, s.spot!, worldSpeed, dt, movement.pathEase)) s.activity = "camping"
+        if (stepOffRoadWalk(s, s.spot!, worldSpeed, dt, map)) s.activity = "camping"
         break
       }
 
@@ -1016,8 +1018,8 @@ export function stepSim(
       }
 
       case "fromCamp": {
-        const back = currentRoutePoint(map, s, movement.pathEase)
-        if (stepOffRoadWalk(s, back, worldSpeed, dt, movement.pathEase)) {
+        const back = currentRoutePoint(map, s)
+        if (stepOffRoadWalk(s, back, worldSpeed, dt, map)) {
           s.activity = "walking"
           s.spot = null
           s.walkFrom = null


### PR DESCRIPTION
Characters follow grid-aligned walking routes, and campers and vendors route around buildings, water, woods, and cliffs instead of taking direct shortcuts.
Shrine access is restricted to its four gates, with the relic table kept clear, and monks regularly enter, kneel facing the relic, pray, and return outside using the existing animation and HUD activity system.
Validation passed: 84 focused movement, hospitality, and monk tests; TypeScript; base, population, and monk asset checks; and browser checks of shrine entry and prayer.
The full suite recorded 520 passes and four map-generation timeouts; three timeout cases passed on rerun, while the unrelated river-border sweep still exceeds its fixed 30-second timeout.
