### PR TITLE
Add playground buildings with matching build tiles and placement previews

### DIFF
--- a/components/building-lab/building-model.tsx
+++ b/components/building-lab/building-model.tsx
@@ -7,7 +7,7 @@ import { buildingParts, type BuildingPart } from "@/lib/game/building-art/geomet
 import { BUILDING_STYLE, type BuildingRecipe } from "@/lib/game/building-art/style"
 import { OUTLINE_ID_LAYER_MASK } from "@/lib/game/render/outline"
 
-function Part({ part, idColor, onClick }: { part: BuildingPart; idColor?: THREE.Color; onClick?: (event: ThreeEvent<MouseEvent>) => void }) {
+function Part({ part, idColor, onClick, ghostColor, ink = true }: { part: BuildingPart; idColor?: THREE.Color; onClick?: (event: ThreeEvent<MouseEvent>) => void; ghostColor?: string; ink?: boolean }) {
   const geometry = useMemo(() => {
     if (part.size) return new THREE.BoxGeometry(...part.size)
     const result = new THREE.BufferGeometry()
@@ -17,11 +17,19 @@ function Part({ part, idColor, onClick }: { part: BuildingPart; idColor?: THREE.
   }, [part])
   const edges = useMemo(() => new THREE.EdgesGeometry(geometry, 25), [geometry])
   useEffect(() => () => { geometry.dispose(); edges.dispose() }, [geometry, edges])
+  if (ghostColor) return <group position={part.position} rotation={part.rotation}>
+    <mesh geometry={geometry} renderOrder={4} raycast={() => {}}>
+      <meshBasicMaterial color={ghostColor} transparent opacity={0.12} depthWrite={false} side={THREE.DoubleSide} />
+    </mesh>
+    {part.outline !== false && <lineSegments geometry={edges} renderOrder={5} raycast={() => {}}>
+      <lineBasicMaterial color={ghostColor} transparent opacity={0.8} depthWrite={false} />
+    </lineSegments>}
+  </group>
   return <group position={part.position} rotation={part.rotation}>
     <mesh name={part.name} geometry={geometry} onClick={onClick}>
       <meshLambertMaterial color={part.color} side={THREE.DoubleSide} />
     </mesh>
-    {part.outline !== false && !part.name.startsWith("reed-") && !part.name.startsWith("thatch-grain-") && !part.name.startsWith("thatch-highlight-") && <lineSegments geometry={edges} raycast={() => {}}>
+    {ink && part.outline !== false && !part.name.startsWith("reed-") && !part.name.startsWith("thatch-grain-") && !part.name.startsWith("thatch-highlight-") && <lineSegments geometry={edges} raycast={() => {}}>
       <lineBasicMaterial color={BUILDING_STYLE.palette.ink} transparent opacity={0.65} />
     </lineSegments>}
     {idColor && <mesh geometry={geometry} layers-mask={OUTLINE_ID_LAYER_MASK}>
@@ -31,7 +39,7 @@ function Part({ part, idColor, onClick }: { part: BuildingPart; idColor?: THREE.
 }
 
 /** Material details share meshes, keeping four-view previews inexpensive. */
-function batchDetails(parts: BuildingPart[]): BuildingPart[] {
+export function batchDetails(parts: BuildingPart[]): BuildingPart[] {
   const visible: BuildingPart[] = [], groups = new Map<string, BuildingPart>()
   for (const part of parts) {
     if (part.outline !== false) { visible.push(part); continue }
@@ -53,4 +61,12 @@ export function BuildingModel({ recipe, cutaway = false, idColor, onClick }: {
 }) {
   const parts = useMemo(() => batchDetails(buildingParts(recipe)), [recipe])
   return <group name="ink-and-thatch-building">{parts.filter((p) => !cutaway || p.layer === "base").map((part) => <Part key={part.name} part={part} idColor={idColor} onClick={onClick} />)}</group>
+}
+
+/** Ghosts retain every surface, with frame lines only on structural parts. */
+export function StructureModel({ parts, idColor, ghostColor, ink = true }: {
+  parts: BuildingPart[]; idColor?: THREE.Color; ghostColor?: string; ink?: boolean
+}) {
+  const rendered = useMemo(() => batchDetails(parts), [parts])
+  return <group>{rendered.map((part) => <Part key={part.name} part={part} idColor={idColor} ghostColor={ghostColor} ink={ink} />)}</group>
 }

--- a/components/game/build-thumbnail.tsx
+++ b/components/game/build-thumbnail.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import Image from "next/image"
+import { useEffect, useState } from "react"
+import * as THREE from "three"
+import { BUILD_CATALOG, type BuildId } from "@/lib/game/balance"
+import { isProceduralStructure, structureParts } from "@/lib/game/building-art/structure"
+import { batchDetails } from "@/components/building-lab/building-model"
+import { BUILDING_STYLE } from "@/lib/game/building-art/style"
+import { cameraOffset, lightOffsetForYaw, yawForView } from "@/lib/game/render/iso"
+
+let thumbnails: Partial<Record<BuildId, string>> | undefined
+
+/** Bake the actual meshes once, with one short-lived WebGL context for the tray. */
+function buildThumbnails() {
+  if (thumbnails) return thumbnails
+  const images: Partial<Record<BuildId, string>> = {}
+  const renderer = new THREE.WebGLRenderer({ alpha: true, antialias: false })
+  renderer.setSize(54, 49)
+  renderer.setClearColor(0, 0)
+  const yaw = yawForView(0)
+  try {
+    for (const definition of BUILD_CATALOG) {
+      const scene = new THREE.Scene(), model = new THREE.Group()
+      const geometries: THREE.BufferGeometry[] = [], materials: THREE.Material[] = []
+      for (const part of batchDetails(structureParts({ ...definition, buildType: definition.id }))) {
+        const geometry = part.size ? new THREE.BoxGeometry(...part.size)
+          : new THREE.BufferGeometry().setAttribute("position", new THREE.Float32BufferAttribute(part.vertices!, 3))
+        geometry.computeVertexNormals()
+        const material = new THREE.MeshLambertMaterial({ color: part.color, side: THREE.DoubleSide })
+        const mesh = new THREE.Mesh(geometry, material)
+        mesh.position.set(...part.position)
+        if (part.rotation) mesh.rotation.set(...part.rotation)
+        model.add(mesh)
+        geometries.push(geometry); materials.push(material)
+        if (isProceduralStructure(definition.id)) {
+          if (part.outline !== false && !/^(reed-|thatch-grain-|thatch-highlight-)/.test(part.name)) {
+            const edges = new THREE.EdgesGeometry(geometry, 25)
+            const ink = new THREE.LineBasicMaterial({ color: BUILDING_STYLE.palette.ink, transparent: true, opacity: 0.65 })
+            mesh.add(new THREE.LineSegments(edges, ink))
+            geometries.push(edges); materials.push(ink)
+          }
+        }
+      }
+      const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.1, 400)
+      camera.position.set(...cameraOffset(yaw))
+      camera.lookAt(0, 0, 0)
+      camera.updateMatrixWorld()
+      model.updateMatrixWorld(true)
+      // Frame projected bounds, including thatch, raised legs and gable crosses.
+      const bounds = new THREE.Box3().setFromObject(model).applyMatrix4(camera.matrixWorldInverse)
+      const centre = bounds.getCenter(new THREE.Vector3())
+      const size = bounds.getSize(new THREE.Vector3())
+      const halfHeight = Math.max(size.y, size.x * 49 / 54) * 0.56
+      camera.left = centre.x - halfHeight * 54 / 49
+      camera.right = centre.x + halfHeight * 54 / 49
+      camera.top = centre.y + halfHeight
+      camera.bottom = centre.y - halfHeight
+      camera.updateProjectionMatrix()
+      const light = new THREE.DirectionalLight(0xffffff, 2)
+      light.position.set(...lightOffsetForYaw(yaw))
+      scene.add(model, new THREE.AmbientLight(0xffffff, 1.3), light)
+      try {
+        renderer.render(scene, camera)
+        images[definition.id] = renderer.domElement.toDataURL()
+      } finally {
+        geometries.forEach((geometry) => geometry.dispose())
+        materials.forEach((material) => material.dispose())
+      }
+    }
+    thumbnails = images
+    return images
+  } finally {
+    renderer.dispose()
+    renderer.forceContextLoss()
+  }
+}
+
+export function BuildThumbnail({ id }: { id: BuildId }) {
+  const [src, setSrc] = useState<string>()
+  useEffect(() => { setSrc(buildThumbnails()[id]) }, [id])
+  return src ? <Image src={src} unoptimized alt="" width={54} height={49} /> : null
+}

--- a/components/game/buildings.tsx
+++ b/components/game/buildings.tsx
@@ -1,5 +1,8 @@
 "use client"
 
+import { StructureModel } from "@/components/building-lab/building-model"
+import { isProceduralStructure, structureParts } from "@/lib/game/building-art/structure"
+
 import { groundHeight } from "@/lib/game/map/elevation"
 
 import { useMemo } from "react"
@@ -14,25 +17,13 @@ import {
   buildingObjectId,
   pileObjectId,
   encodeObjectId,
-  OUTLINE_ID_LAYER_MASK,
 } from "@/lib/game/render/outline"
 
-/** Shrink the body slightly so neighbouring footprints don't visually merge. */
-const BODY_INSET = 0.86
-const ROOF_INSET = 0.98
-const ROOF_THICKNESS = 0.18
-
-/**
- * Placeholder structures. A body box plus a thin contrasting cap — enough to
- * read as a building at this camera angle and to prove footprint placement.
- *
- * Each building also renders a flat ID-coloured copy of itself on the outline
- * layer. Body and roof share one ID, so the outline pass never draws a line
- * between a building and its own roof — only against *other* objects.
- */
+/** Built structures share their geometry with the menu and placement preview. */
 export function Buildings({ map }: { map: GameMap }) {
   const piles = useBuildStore((s) => s.piles)
   const buildings = map.buildings
+  const models = useMemo(() => buildings.map((building) => structureParts({ ...building, buildType: building.buildType ?? (building.id.startsWith("lumberCamp-") ? "lumberCamp" : undefined) })), [buildings])
   const idColors = useMemo(
     // Component tuples straight into the working colour space — an ID is data,
     // not a colour, so it must dodge sRGB conversion to survive readback.
@@ -50,28 +41,10 @@ export function Buildings({ map }: { map: GameMap }) {
         const centreZ = tileToWorldZ(map, building.z) + (building.d - 1) / 2
         const baseY = groundHeight(map, building.x + (building.w - 1) / 2, building.z + (building.d - 1) / 2)
 
-        const cross = building.buildType === "cross"
-        const capY = cross ? building.height * 0.72 : building.height + ROOF_THICKNESS / 2
-        if (building.id.startsWith("lumberCamp-")) {
+        if (building.buildType === "lumberCamp" || building.id.startsWith("lumberCamp-")) {
           return (
             <group key={building.id} name={`lumber-yard-${building.id}`} position={[centreX, baseY, centreZ]} onClick={(event) => selectElement({ kind: "building", id: building.id }, event)}>
-              <mesh position={[0, 0.022, 0]}>
-                <boxGeometry args={[building.w * 0.98, 0.044, building.d * 0.98]} />
-                <meshLambertMaterial color="#a18a60" />
-              </mesh>
-              <mesh position={[0, 0.022, 0]} layers-mask={OUTLINE_ID_LAYER_MASK}>
-                <boxGeometry args={[building.w * 0.98, 0.044, building.d * 0.98]} />
-                <meshBasicMaterial color={idColors[index]} toneMapped={false} />
-              </mesh>
-              {/* Low corner pegs mark the open yard without hiding its stacks. */}
-              {[-1, 1].flatMap((x) => [-1, 1].map((z) => (
-                <group key={`${x}:${z}`} position={[x * (building.w / 2 - 0.12), 0.13, z * (building.d / 2 - 0.12)]}>
-                  <mesh><boxGeometry args={[0.08, 0.26, 0.08]} /><meshLambertMaterial color="#705135" /></mesh>
-                  <mesh layers-mask={OUTLINE_ID_LAYER_MASK}>
-                    <boxGeometry args={[0.08, 0.26, 0.08]} /><meshBasicMaterial color={idColors[index]} toneMapped={false} />
-                  </mesh>
-                </group>
-              )))}
+              <StructureModel parts={models[index]} idColor={idColors[index]} ink={false} />
               {piles.filter((pile) => pile.campId === building.id).map((pile) => {
                 const [x, z] = pileOffset(pile.slot)
                 return <group key={pile.id} position={[x, 0.03, z]}><WoodPile pile={pile} objectId={pileObjectId(piles.indexOf(pile))} /></group>
@@ -79,40 +52,10 @@ export function Buildings({ map }: { map: GameMap }) {
             </group>
           )
         }
-        const bodyArgs: [number, number, number] = [
-          cross ? 0.14 : building.w * BODY_INSET,
-          building.height,
-          cross ? 0.14 : building.d * BODY_INSET,
-        ]
-        const roofArgs: [number, number, number] = [
-          cross ? 0.7 : building.w * ROOF_INSET,
-          ROOF_THICKNESS,
-          cross ? 0.14 : building.d * ROOF_INSET,
-        ]
 
         return (
           <group key={building.id} position={[centreX, baseY, centreZ]} onClick={(event) => selectElement({ kind: "building", id: building.id }, event)}>
-            <mesh position={[0, building.height / 2, 0]}>
-              <boxGeometry args={bodyArgs} />
-              <meshLambertMaterial color={building.color} />
-            </mesh>
-            <mesh position={[0, capY, 0]}>
-              <boxGeometry args={roofArgs} />
-              <meshLambertMaterial color={building.roofColor} />
-            </mesh>
-
-            {/* ID silhouette for the outline pass. */}
-            <mesh position={[0, building.height / 2, 0]} layers-mask={OUTLINE_ID_LAYER_MASK}>
-              <boxGeometry args={bodyArgs} />
-              <meshBasicMaterial color={idColors[index]} toneMapped={false} />
-            </mesh>
-            <mesh
-              position={[0, capY, 0]}
-              layers-mask={OUTLINE_ID_LAYER_MASK}
-            >
-              <boxGeometry args={roofArgs} />
-              <meshBasicMaterial color={idColors[index]} toneMapped={false} />
-            </mesh>
+            <StructureModel parts={models[index]} idColor={idColors[index]} ink={isProceduralStructure(building.buildType)} />
           </group>
         )
       })}

--- a/components/game/hud-controls.tsx
+++ b/components/game/hud-controls.tsx
@@ -6,7 +6,8 @@ import * as Tooltip from "@radix-ui/react-tooltip"
 import { Coins, Footprints, Hammer, House, Pause, Play, Sparkles, Users, X } from "lucide-react"
 
 import type { useSettlement } from "@/hooks/use-settlement"
-import { buildCatalog, buildingIncomeLabel, type BuildId } from "@/lib/game/balance"
+import { buildCatalog, buildingIncomeLabel } from "@/lib/game/balance"
+import { BuildThumbnail } from "./build-thumbnail"
 import { influenceRadius } from "@/lib/game/build-influence"
 import { canAfford, placementError } from "@/lib/game/settlement"
 import { useCameraStore } from "@/lib/game/camera-store"
@@ -49,10 +50,6 @@ export function HudResources({ economy, settlers, open, onToggle }: {
       </button>
     </HudHelp>
   </div>
-}
-
-const BUILD_ICONS: Record<BuildId, string> = {
-  lumberCamp: "camp", shelter: "inn", workshop: "tavern", hall: "inn", garden: "garden", cross: "cross",
 }
 
 /** Small illustrated commands use the live economy's catalogue and placement rules.
@@ -99,7 +96,7 @@ export function BuildControls({ economy, open, onToggle, onClose }: {
             <button type="button" className="hud-building-tile" aria-label={`Build ${item.label.toLowerCase()}`}
               aria-pressed={buildType === item.id} aria-disabled={unavailable}
               onClick={() => { if (!unavailable) chooseBuild(buildType === item.id ? null : item.id) }}>
-              <Image src={`/game-icons/${BUILD_ICONS[item.id]}.svg`} alt="" width={54} height={49} />
+              <BuildThumbnail id={item.id} />
               {item.id === "lumberCamp" && <kbd>L</kbd>}
             </button>
           </HudHelp>

--- a/components/game/tile-cursor.tsx
+++ b/components/game/tile-cursor.tsx
@@ -1,5 +1,8 @@
 "use client"
 
+import { StructureModel } from "@/components/building-lab/building-model"
+import { structureParts } from "@/lib/game/building-art/structure"
+
 import { useMemo } from "react"
 import { groundHeight } from "@/lib/game/map/elevation"
 
@@ -37,11 +40,12 @@ export function TileCursor({
     return new Float32Array([[-0.5, -0.5], [0.5, -0.5], [-0.5, 0.5], [0.5, 0.5]].flatMap(([x, z]) =>
       [x, onBridge ? (ropeHeightAt(map, hovered.x + x * 0.999, hovered.z + z * 0.999) ?? centre) - centre : groundHeight(map, hovered.x + x * 0.999, hovered.z + z * 0.999) - centre, z]))
   }, [map, hovered])
+  const build = useMemo(() => buildCatalog(balance).find((item) => item.id === buildType), [balance, buildType])
+  const parts = useMemo(() => build ? structureParts({ ...build, buildType: build.id }) : [], [build])
   if (!hovered) return null
 
   if (!tileAt(map, hovered.x, hovered.z)) return null
 
-  const build = buildCatalog(balance).find((item) => item.id === buildType)
   if (build) {
     const valid =
       shrineRenown >= build.requiredRenown &&
@@ -53,18 +57,15 @@ export function TileCursor({
       <group
         position={[
           tileToWorldX(map, hovered.x) + (build.w - 1) / 2,
-          surfaceHeight(map, hovered.x, hovered.z) + 0.04,
+          groundHeight(map, hovered.x + (build.w - 1) / 2, hovered.z + (build.d - 1) / 2),
           tileToWorldZ(map, hovered.z) + (build.d - 1) / 2,
         ]}
       >
-        <mesh renderOrder={4}>
+        <mesh position={[0, 0.04, 0]} renderOrder={4}>
           <boxGeometry args={[build.w, 0.04, build.d]} />
           <meshBasicMaterial color={color} transparent opacity={0.65} depthWrite={false} />
         </mesh>
-        <mesh position={[0, build.height / 2, 0]} renderOrder={4}>
-          <boxGeometry args={[build.w * 0.86, build.height, build.d * 0.86]} />
-          <meshBasicMaterial color={color} wireframe transparent opacity={0.8} depthWrite={false} />
-        </mesh>
+        <StructureModel parts={parts} ghostColor={color} />
       </group>
     )
   }

--- a/lib/game/balance.test.ts
+++ b/lib/game/balance.test.ts
@@ -57,6 +57,7 @@ describe("balance presets", () => {
     const old = JSON.parse(exportBalance(DEFAULT_BALANCE))
     delete old.balance.rules.visitRenown
     delete old.balance.buildings.lumberCamp
+    for (const id of ["monk-shelter", "shepherd-hut", "storehouse", "wood-shelter"]) delete old.balance.buildings[id]
     old.balance.rules.startingGold = 321
     old.balance.buildings.shelter.goldCost = 17
     const result = importBalance(JSON.stringify(old))
@@ -65,6 +66,8 @@ describe("balance presets", () => {
     expect(result.balance?.buildings.shelter.goldCost).toBe(17)
     expect(result.balance?.rules.visitRenown).toBe(0.5)
     expect(result.balance?.buildings.lumberCamp).toEqual(DEFAULT_BALANCE.buildings.lumberCamp)
+    for (const id of ["monk-shelter", "shepherd-hut", "storehouse", "wood-shelter"] as const)
+      expect(result.balance?.buildings[id]).toEqual(DEFAULT_BALANCE.buildings[id])
     old.balance.buildings.lumberCamp = { goldCost: -1 }
     expect(importBalance(JSON.stringify(old)).balance).toBeNull()
   })

--- a/lib/game/balance.ts
+++ b/lib/game/balance.ts
@@ -1,5 +1,7 @@
+import { EARLY_BUILDINGS, BUILDING_STYLE, type EarlyBuildingType } from "./building-art/style"
+
 /** Pure balance data, shared by gameplay, the tuning page and the specification. */
-export type BuildId = "shelter" | "workshop" | "garden" | "cross" | "hall" | "lumberCamp"
+export type BuildId = "shelter" | "workshop" | "garden" | "cross" | "hall" | "lumberCamp" | Exclude<EarlyBuildingType, "enclosure">
 
 export interface Resources {
   gold: number
@@ -105,6 +107,21 @@ export const BUILD_CATALOG: readonly BuildDefinition[] = [
     income: { gold: 0, wood: 0 }, w: 2, d: 2, height: 0.04,
     color: "#7a5a3a", roofColor: "#54402c",
   },
+  ...EARLY_BUILDINGS.filter((preset) => preset.id !== "enclosure").map((preset): BuildDefinition => ({
+    id: preset.id,
+    label: preset.name,
+    category: "buildings",
+    description: preset.description,
+    cost: { gold: preset.width * preset.depth * 10, wood: preset.width * preset.depth * 10 },
+    renown: 0,
+    requiredRenown: 0,
+    income: { gold: 0, wood: 0 },
+    w: preset.width,
+    d: preset.depth,
+    height: preset.wallHeight,
+    color: BUILDING_STYLE.palette.plaster,
+    roofColor: BUILDING_STYLE.palette.thatch,
+  })),
 ]
 
 export const RULE_GROUPS = [
@@ -511,14 +528,19 @@ export function importBalance(json: string): ReturnType<typeof validateBalance> 
     const preset = record(JSON.parse(json))
     if (preset?.version !== BALANCE_VERSION)
       return { balance: null, error: "Unsupported preset version. Expected version 1." }
-    // Version 1 presets made before lumber camps keep every existing setting.
+    // Add defaults for new structures while retaining all authored settings.
     const saved = record(preset.balance)
     const rules = record(saved?.rules)
     const buildings = record(saved?.buildings)
     return validateBalance(saved && rules && buildings ? {
       ...saved,
       rules: { visitRenown: DEFAULT_BALANCE.rules.visitRenown, ...rules },
-      buildings: { lumberCamp: DEFAULT_BALANCE.buildings.lumberCamp, ...buildings },
+      buildings: {
+        lumberCamp: DEFAULT_BALANCE.buildings.lumberCamp,
+        ...Object.fromEntries(EARLY_BUILDINGS.filter((preset) => preset.id !== "enclosure")
+          .map((preset) => [preset.id, DEFAULT_BALANCE.buildings[preset.id]])),
+        ...buildings,
+      },
     } : preset.balance)
   } catch {
     return { balance: null, error: "This file is not valid JSON." }

--- a/lib/game/building-art/structure.ts
+++ b/lib/game/building-art/structure.ts
@@ -1,0 +1,30 @@
+import type { BuildingDef } from "../map/types"
+import { buildingParts, type BuildingPart } from "./geometry"
+import { EARLY_BUILDINGS, earlyBuildingRecipe } from "./style"
+
+export type StructureAppearance = Pick<BuildingDef, "buildType" | "w" | "d" | "height" | "color" | "roofColor">
+
+export function isProceduralStructure(buildType: string | undefined): boolean {
+  return EARLY_BUILDINGS.some((preset) => preset.id === buildType)
+}
+
+/** One source for placed structures, construction ghosts and build-menu images. */
+export function structureParts(building: StructureAppearance): BuildingPart[] {
+  const preset = EARLY_BUILDINGS.find((item) => item.id === building.buildType)
+  if (preset) return buildingParts({ ...earlyBuildingRecipe(preset.id), width: building.w, depth: building.d, wallHeight: building.height })
+
+  const box = (name: string, layer: BuildingPart["layer"], position: BuildingPart["position"], size: BuildingPart["size"], color: string): BuildingPart =>
+    ({ name, layer, position, size, color })
+  if (building.buildType === "lumberCamp") return [
+    box("yard", "base", [0, 0.022, 0], [building.w * 0.98, 0.044, building.d * 0.98], "#a18a60"),
+    ...[-1, 1].flatMap((x) => [-1, 1].map((z) => box(`peg-${x}-${z}`, "wall",
+      [x * (building.w / 2 - 0.12), 0.13, z * (building.d / 2 - 0.12)], [0.08, 0.26, 0.08], "#705135"))),
+  ]
+  const cross = building.buildType === "cross"
+  return [
+    box("body", "wall", [0, building.height / 2, 0],
+      [cross ? 0.14 : building.w * 0.86, building.height, cross ? 0.14 : building.d * 0.86], building.color),
+    box("cap", "roof", [0, cross ? building.height * 0.72 : building.height + 0.09, 0],
+      [cross ? 0.7 : building.w * 0.98, 0.18, cross ? 0.14 : building.d * 0.98], building.roofColor),
+  ]
+}

--- a/lib/game/settlement.test.ts
+++ b/lib/game/settlement.test.ts
@@ -6,6 +6,9 @@ import type { GameMap } from "./map/types"
 import { generateMonks } from "./monks"
 import { generateRelic, relicDraw } from "./relic"
 import { generateTravelers } from "./travelers"
+import { EARLY_BUILDINGS, earlyBuildingRecipe } from "./building-art/style"
+import { buildingParts } from "./building-art/geometry"
+import { structureParts } from "./building-art/structure"
 import {
   BUILD_CATALOG,
   buildTileError,
@@ -56,6 +59,28 @@ const shelter = BUILD_CATALOG.find((item) => item.id === "shelter")!
 const garden = BUILD_CATALOG.find((item) => item.id === "garden")!
 
 describe("build and buy", () => {
+  it.each(EARLY_BUILDINGS.filter((preset) => preset.id !== "enclosure"))(
+    "buys $name with its playground geometry and reserves its full footprint", (preset) => {
+      const def = BUILD_CATALOG.find((item) => item.id === preset.id)!
+      const at = { x: 10, z: 14 }, map = testMap()
+      const before = { ...createSettlement(), resources: { ...def.cost } }
+      const result = purchaseStructure(before, map, monks, [relic], def.id, at)
+      expect(result.error).toBeNull()
+      expect(result.settlement.resources).toEqual({ gold: 0, wood: 0 })
+      const placed = result.settlement.structures[0]
+      expect([placed.w, placed.d]).toEqual([preset.width, preset.depth])
+      expect(structureParts(placed)).toEqual(buildingParts(earlyBuildingRecipe(preset.id)))
+      expect(structureParts({ ...def, buildType: def.id })).toEqual(structureParts(placed))
+      const farCorner = { x: at.x + def.w - 1, z: at.z + def.d - 1 }
+      const occupied = { ...map, buildings: [...map.buildings, placed] }
+      expect(placementError(occupied, def, farCorner)).toMatch(/occupies/)
+      map.tiles[farCorner.z * map.width + farCorner.x] = "water"
+      const rejected = purchaseStructure(before, map, monks, [relic], def.id, at)
+      expect(rejected.error).toBeTruthy()
+      expect(rejected.settlement).toBe(before)
+    },
+  )
+
   it("keeps influence feedback and footprint checks aware of cliffs and uneven ground", () => {
     const map = testMap(), i = 14 * map.width + 11
     map.elevation = { settings: DEFAULT_ELEVATION, height: Array(900).fill(0), corners: Array(3600).fill(0), cliffs: Array(900).fill(0), slope: Array(900).fill(0) }


### PR DESCRIPTION
Adds Monks’ shelter, Shepherd’s hut, Raised store, and Wood shelter from the playground to the build menu with their authored dimensions and construction costs.
Placed buildings, cached menu thumbnails, and placement ghosts now share geometry, including roofs, posts, raised floors, and selection silhouettes.
Existing saved tuning presets retain their settings and receive defaults for the new buildings.
Validated with TypeScript, 67 relevant tests (slow geometry/map tests rerun with a longer timeout), and browser checks of all four purchases, valid and blocked placement, rotation, and selection without runtime errors.

Design references: [Build controls](https://app.paper.design/file/01M1QTYBYHXP4H1BXFQ79N18AP/2-0/1GB-0), [HUD frame](https://app.paper.design/file/01M1QTYBYHXP4H1BXFQ79N18AP/2-0/1SK-0).
