### PR TITLE
Fix character outline alignment and building occlusion

### DIFF
--- a/components/building-lab/building-model.tsx
+++ b/components/building-lab/building-model.tsx
@@ -56,11 +56,11 @@ export function batchDetails(parts: BuildingPart[]): BuildingPart[] {
 }
 
 /** Shared procedural building; cutting away the shell exposes the relic inside. */
-export function BuildingModel({ recipe, cutaway = false, idColor, onClick }: {
-  recipe: BuildingRecipe; cutaway?: boolean; idColor?: THREE.Color; onClick?: (event: ThreeEvent<MouseEvent>) => void
+export function BuildingModel({ recipe, cutaway = false, idColor, onClick, ink = true }: {
+  recipe: BuildingRecipe; cutaway?: boolean; idColor?: THREE.Color; onClick?: (event: ThreeEvent<MouseEvent>) => void; ink?: boolean
 }) {
   const parts = useMemo(() => batchDetails(buildingParts(recipe)), [recipe])
-  return <group name="ink-and-thatch-building">{parts.filter((p) => !cutaway || p.layer === "base").map((part) => <Part key={part.name} part={part} idColor={idColor} onClick={onClick} />)}</group>
+  return <group name="ink-and-thatch-building">{parts.filter((p) => !cutaway || p.layer === "base").map((part) => <Part key={part.name} part={part} idColor={idColor} onClick={onClick} ink={ink} />)}</group>
 }
 
 /** Ghosts retain every surface, with frame lines only on structural parts. */

--- a/components/game/buildings.tsx
+++ b/components/game/buildings.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { StructureModel } from "@/components/building-lab/building-model"
-import { isProceduralStructure, structureParts } from "@/lib/game/building-art/structure"
+import { structureParts } from "@/lib/game/building-art/structure"
 
 import { groundHeight } from "@/lib/game/map/elevation"
 
@@ -55,7 +55,7 @@ export function Buildings({ map }: { map: GameMap }) {
 
         return (
           <group key={building.id} position={[centreX, baseY, centreZ]} onClick={(event) => selectElement({ kind: "building", id: building.id }, event)}>
-            <StructureModel parts={models[index]} idColor={idColors[index]} ink={isProceduralStructure(building.buildType)} />
+            <StructureModel parts={models[index]} idColor={idColors[index]} ink={false} />
           </group>
         )
       })}

--- a/components/game/outline-pass.tsx
+++ b/components/game/outline-pass.tsx
@@ -51,7 +51,6 @@ const FRAGMENT_SHADER = /* glsl */ `
   uniform bool uCharacterPass;
   uniform float uCharacterIdMin;
   uniform vec2 uTexel;
-  uniform vec2 uPixelOffset;
   uniform int uMode; // 1 = overlap only, 2 = full silhouette
   uniform vec3 uColor;
   uniform float uSelectedId;
@@ -90,9 +89,12 @@ const FRAGMENT_SHADER = /* glsl */ `
   }
 
   void main() {
-    // Sample selection and overlap edges on the scenery pixel grid even when
-    // character IDs are drawn at display resolution. This changes only edges.
-    vec2 pixelUv = (floor(vUv / uTexel + uPixelOffset) + 0.5 - uPixelOffset) * uTexel;
+    // IDs and depth already match the visible raster in each pass. Snapping
+    // display-resolution characters to scenery texel centres moves their edges
+    // away from the sprite and can paint ink across an occluding wall.
+    // Keep the sample on the visible pixel; uTexel still sets one world-pixel
+    // border width, just as it does for trees and buildings.
+    vec2 pixelUv = vUv;
     float idC = idAt(pixelUv);
     float dC = texture2D(tDepth, pixelUv).x;
     if (uCharacterSelected) {
@@ -228,7 +230,6 @@ export function OutlinePass({ objects }: { objects?: Omit<Parameters<typeof sele
       uCharacterPass: { value: false },
       uCharacterIdMin: { value: MAX_OBJECT_ID - 0x2000 + 1 },
       uTexel: { value: new THREE.Vector2() },
-      uPixelOffset: { value: new THREE.Vector2() },
       uMode: { value: 0 },
       uColor: { value: new THREE.Color(OUTLINE_COLOR) },
       uSelectedId: { value: 0 },
@@ -328,12 +329,8 @@ export function OutlinePass({ objects }: { objects?: Omit<Parameters<typeof sele
         // selections and overlap halos equally thick through zoom and DPR changes.
         if (characterPass) {
           pass.uniforms.uTexel.value.set(1 / (target.width * stage.scale.x), 1 / (target.height * stage.scale.y))
-          pass.uniforms.uPixelOffset.value.set(
-            ((1 - stage.scale.x) * 0.5 + stage.offset.x) * target.width,
-            ((1 - stage.scale.y) * 0.5 + stage.offset.y) * target.height)
         } else {
           pass.uniforms.uTexel.value.set(1 / ids.width, 1 / ids.height)
-          pass.uniforms.uPixelOffset.value.set(0, 0)
         }
         pass.uniforms.uMode.value = MODE_INT[mode]
         pass.uniforms.uSelectedId.value = selectedId

--- a/components/game/shrine.tsx
+++ b/components/game/shrine.tsx
@@ -55,7 +55,7 @@ export function Shrine({ map, relic }: { map: GameMap; relic: Relic }) {
   return (
     <group position={[layout.centreX, layout.baseY, layout.centreZ]}>
       <group rotation={[0, layout.rotation, 0]}>
-        <BuildingModel recipe={layout.recipe} idColor={shrineId} onClick={event => selectElement({ kind: "building", id: hovel.id }, event)} />
+        <BuildingModel recipe={layout.recipe} idColor={shrineId} ink={false} onClick={event => selectElement({ kind: "building", id: hovel.id }, event)} />
       </group>
       <RelicDisplay color={relic.color} idColor={relicId} onClick={select} />
 

--- a/scripts/test-sprite-depth.mjs
+++ b/scripts/test-sprite-depth.mjs
@@ -6,10 +6,12 @@ import { chromium } from "playwright"
 import ts from "typescript"
 
 // Real GPU depth testing: unit tests cannot catch interpolation/quantization seams.
-test("sprites preserve overlaps, terrain contact, and scenery occlusion", async () => {
+test("sprites preserve overlaps, terrain contact, scenery occlusion, and aligned outlines", async () => {
   const shader = ts.transpileModule(await readFile(new URL("../lib/game/render/sprite-depth.ts", import.meta.url), "utf8"), {
     compilerOptions: { module: ts.ModuleKind.ESNext },
   }).outputText
+  const outlineSource = await readFile(new URL("../components/game/outline-pass.tsx", import.meta.url), "utf8")
+  const outlineFragment = outlineSource.match(/const FRAGMENT_SHADER = \/\* glsl \*\/ `([\s\S]*?)`/)[1]
   const server = createServer(async (request, response) => {
     const name = request.url.slice(1)
     if (name === "shader.js") {
@@ -29,7 +31,7 @@ test("sprites preserve overlaps, terrain contact, and scenery occlusion", async 
     page.on("pageerror", error => errors.push(error.message))
     page.on("console", message => { if (message.type() === "error") errors.push(message.text()) })
     await page.goto(`http://127.0.0.1:${server.address().port}`)
-    const result = await page.evaluate(async () => {
+    const result = await page.evaluate(async (outlineFragment) => {
       const THREE = await import("/three.module.js")
       const { applySpriteDepth } = await import("/shader.js")
       const gl = new THREE.WebGLRenderer({ canvas: document.querySelector("canvas"), antialias: false })
@@ -163,17 +165,99 @@ test("sprites preserve overlaps, terrain contact, and scenery occlusion", async 
       output.dispose()
       floor.geometry.dispose()
       floor.material.dispose()
+      // Exercise the actual outline compositor with display-resolution IDs.
+      // A figure crosses a wall (or tree) in front of it; its right half is
+      // hidden. The edge must touch the visible figure and stay off the wall.
+      const size = 96, characterId = 0xffffff
+      const idPixels = new Uint8Array(size * size * 4)
+      const depthPixels = new Float32Array(size * size * 4)
+      const characterPixels = new Uint8Array(size * size * 4)
+      const characterDepthPixels = new Float32Array(size * size * 4)
+      const makeTexture = (pixels, type) => {
+        const texture = new THREE.DataTexture(pixels, size, size, THREE.RGBAFormat, type)
+        texture.needsUpdate = true
+        return texture
+      }
+      const ids = makeTexture(idPixels, THREE.UnsignedByteType)
+      const depths = makeTexture(depthPixels, THREE.FloatType)
+      const character = makeTexture(characterPixels, THREE.UnsignedByteType)
+      const characterDepth = makeTexture(characterDepthPixels, THREE.FloatType)
+      const outlineTarget = new THREE.WebGLRenderTarget(size, size)
+      const outlineMaterial = new THREE.ShaderMaterial({
+        vertexShader: copyMaterial.vertexShader, fragmentShader: outlineFragment,
+        depthTest: false, depthWrite: false,
+        uniforms: {
+          tId: { value: ids }, tDepth: { value: depths },
+          tCharacter: { value: character }, tCharacterDepth: { value: characterDepth },
+          uCharacterPass: { value: true }, uCharacterSelected: { value: false },
+          uCharacterIdMin: { value: 0xffe000 }, uTexel: { value: new THREE.Vector2() },
+          uMode: { value: 1 }, uColor: { value: new THREE.Color(1, 0, 0) },
+          uSelectedId: { value: 0 }, uSelectionFill: { value: new THREE.Color(0, 1, 0) },
+          uSelectionOpacity: { value: 0.06 }, uSelectionColor: { value: new THREE.Color(0, 0, 1) },
+          uSelectionOutlineOpacity: { value: 0.65 },
+        },
+      })
+      copyMesh.material = outlineMaterial
+      gl.autoClear = true
+      gl.setClearColor(0, 0)
+      let outlineCompared = 0, outlineMismatches = 0, selectionMismatches = 0
+      // Fractional texel widths represent zoom and DPR; shifts cover the phase
+      // difference between scenery pixels and moving display-resolution sprites.
+      for (const width of [1, 2.25, 4, 5.75]) for (const shift of [0, 1, 3]) {
+        const left = 25 + shift, bottom = 23 + shift, top = 70 + shift, wall = 49
+        const figureAt = (x, y) => x >= left && x < 65 + shift && y >= bottom && y < top
+        const idAt = (x, y) => x >= wall ? 2 : figureAt(x, y) ? characterId : 1
+        const depthAt = (x, y) => x >= wall ? 0.2 : figureAt(x, y) ? 0.4 : 0.8
+        for (let y = 0; y < size; y++) for (let x = 0; x < size; x++) {
+          const i = (y * size + x) * 4, id = idAt(x, y)
+          idPixels.set([id & 255, (id >> 8) & 255, (id >> 16) & 255, 255], i)
+          depthPixels[i] = depthAt(x, y)
+          characterPixels.set([255, 255, 255, figureAt(x, y) ? 255 : 0], i)
+          characterDepthPixels[i] = 0.4
+        }
+        for (const texture of [ids, depths, character, characterDepth]) texture.needsUpdate = true
+        outlineMaterial.uniforms.uTexel.value.set(width / size, width / size)
+        const pixels = new Uint8Array(size * size * 4)
+        for (const selected of [false, true]) {
+          outlineMaterial.uniforms.uCharacterSelected.value = selected
+          outlineMaterial.uniforms.uSelectedId.value = selected ? characterId : 0
+          gl.setRenderTarget(outlineTarget)
+          gl.render(copyScene, copyCamera)
+          gl.readRenderTargetPixels(outlineTarget, 0, 0, size, size, pixels)
+          for (let y = 8; y < size - 8; y++) for (let x = 8; x < size - 8; x++) {
+            const neighbors = [[x + width, y], [x - width, y], [x, y + width], [x, y - width]]
+              .map(([nx, ny]) => [Math.floor(nx + 0.5), Math.floor(ny + 0.5)])
+            const edge = neighbors.some(([nx, ny]) => idAt(nx, ny) !== idAt(x, y)
+              && (idAt(x, y) === characterId || idAt(nx, ny) === characterId)
+              && depthAt(nx, ny) < depthAt(x, y))
+            const selection = selected && (figureAt(x, y) || neighbors.some(([nx, ny]) => figureAt(nx, ny)))
+            const drawn = pixels[(y * size + x) * 4 + 3] > 0
+            if (drawn !== (edge || selection)) {
+              if (selected) selectionMismatches++
+              else outlineMismatches++
+            }
+            outlineCompared++
+          }
+        }
+      }
+      for (const texture of [ids, depths, character, characterDepth]) texture.dispose()
+      outlineTarget.dispose()
+      outlineMaterial.dispose()
       copyMesh.geometry.dispose()
       copyMaterial.dispose()
       gl.dispose()
-      return { cases, compared, mismatches, occlusionFailures, floorCompared, floorClipped }
-    })
+      return { cases, compared, mismatches, occlusionFailures, floorCompared, floorClipped,
+        outlineCompared, outlineMismatches, selectionMismatches }
+    }, outlineFragment)
     assert.deepEqual(errors, [], "WebGL shaders should compile without errors")
     assert.ok(result.compared > 10000, "must compare visible overlapping pixels")
     assert.equal(result.mismatches, 0, JSON.stringify(result))
     assert.equal(result.occlusionFailures, 0, "scenery must retain depth occlusion")
     assert.ok(result.floorCompared > 10000, "must compare feet against enlarged terrain depth")
     assert.equal(result.floorClipped, 0, "the enlarged floor must not erase sprite pixels")
+    assert.ok(result.outlineCompared > 10000, "must compare outlines at multiple zooms and sprite offsets")
+    assert.equal(result.outlineMismatches, 0, "overlap outlines must touch the visible sprite and respect foreground occlusion")
+    assert.equal(result.selectionMismatches, 0, "selected silhouettes and borders must track the actual character pixels")
   } finally {
     await browser?.close()
     await new Promise(resolve => server.close(resolve))


### PR DESCRIPTION
Character outlines now sample the visible character pixels, closing offset gaps and respecting foreground building occlusion while preserving the existing border width.
Buildings and the shrine use the same occlusion outlines as trees, with extra wireframe ink disabled in the game.
Validation passed: typecheck, 16 rendering/selection unit tests, and expanded GPU regression coverage for occlusion, selection, sprite offsets, and fractional zoom; the GPU regression also fails against the original shader.
The broader test suite hit timeouts in simulation and geometry tests, and additional browser checks stalled.
