### PR TITLE
Add paid relic visits with gate access and payment effects

### DIFF
--- a/components/game/admission-effects.tsx
+++ b/components/game/admission-effects.tsx
@@ -1,0 +1,76 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import { useFrame } from "@react-three/fiber"
+import * as THREE from "three"
+import { createAdmissionAudio } from "@/lib/game/admission-audio"
+import { paymentLabel } from "@/lib/game/render/payment-label"
+import { CHARACTER_PIXEL_SIZE } from "@/lib/game/render/pixel-scale"
+import { useSimulationStore } from "@/lib/game/simulation-store"
+import type { SimState } from "@/lib/game/sim"
+
+const LIFETIME = 2
+const POOL_SIZE = 32
+type Floater = { sprite: THREE.Sprite; age: number; baseY: number }
+
+/** A receipt appears at its payer, rises and fades; historical receipts stay silent. */
+export function AdmissionEffects({ sim, characterScale }: { sim: SimState; characterScale: number }) {
+  const group = useRef<THREE.Group>(null)
+  const state = useRef<{ seen: number; floaters: Floater[]; audio: ReturnType<typeof createAdmissionAudio> } | null>(null)
+
+  useEffect(() => {
+    const root = group.current!
+    const audio = createAdmissionAudio()
+    const floaters = Array.from({ length: POOL_SIZE }, () => {
+      const sprite = new THREE.Sprite(new THREE.SpriteMaterial({ transparent: true, depthTest: false, depthWrite: false, toneMapped: false }))
+      sprite.name = "admission-payment"
+      sprite.visible = false
+      sprite.renderOrder = 1000
+      sprite.raycast = () => {}
+      root.add(sprite)
+      return { sprite, age: LIFETIME, baseY: 0 }
+    })
+    state.current = { seen: sim.admissionSequence, floaters, audio }
+    window.addEventListener("pointerdown", audio.unlock)
+    window.addEventListener("keydown", audio.unlock)
+    return () => {
+      window.removeEventListener("pointerdown", audio.unlock)
+      window.removeEventListener("keydown", audio.unlock)
+      audio.dispose()
+      for (const { sprite } of floaters) { root.remove(sprite); sprite.material.map?.dispose(); sprite.material.dispose() }
+      state.current = null
+    }
+  }, [sim])
+
+  useFrame((_, delta) => {
+    const live = state.current
+    if (!live) return
+    const playback = useSimulationStore.getState()
+    const dt = playback.paused ? 0 : Math.min(delta, 0.1) * playback.speed
+    for (const floater of live.floaters) {
+      floater.age += dt
+      floater.sprite.visible = floater.age < LIFETIME
+      floater.sprite.position.y = floater.baseY + floater.age * 0.55
+      floater.sprite.material.opacity = Math.min(1, Math.max(0, (LIFETIME - floater.age) / 0.65))
+    }
+    for (const payment of sim.admissionPayments) {
+      if (payment.id <= live.seen) continue
+      live.seen = payment.id
+      const floater = live.floaters.find(f => f.age >= LIFETIME) ?? live.floaters.reduce((a, b) => a.age > b.age ? a : b)
+      floater.age = 0
+      floater.baseY = payment.y + 0.9 * characterScale
+      const texture = paymentLabel(payment.amount)
+      floater.sprite.material.map?.dispose()
+      floater.sprite.material.map = texture
+      floater.sprite.material.needsUpdate = true
+      floater.sprite.material.opacity = 1
+      floater.sprite.scale.set(texture.image.width * CHARACTER_PIXEL_SIZE * characterScale, texture.image.height * CHARACTER_PIXEL_SIZE * characterScale, 1)
+      floater.sprite.position.set(payment.x, floater.baseY, payment.z)
+      floater.sprite.visible = true
+      floater.sprite.userData.amount = payment.amount
+      live.audio.play()
+    }
+  }, -2)
+
+  return <group ref={group} name="admission-effects" />
+}

--- a/components/game/debug-handle.tsx
+++ b/components/game/debug-handle.tsx
@@ -42,6 +42,13 @@ export function DebugHandle({ map, travelers, speed, movement, speedScales, char
       /** Live traveler sim state (stats, activities), for e2e assertions. */
       sim: () => (simRegistry.current ? [...simRegistry.current.travelers.values()] : []),
       time: () => simRegistry.current?.time ?? null,
+      /** Admission receipts and their live floating amounts for payment smoke tests. */
+      payments: () => ({
+        receipts: simRegistry.current?.admissionPayments ?? [],
+        effects: scene.getObjectByName("admission-effects")?.children.flatMap(object =>
+          object instanceof THREE.Sprite && object.visible
+            ? [{ amount: object.userData.amount, position: object.position.toArray(), opacity: object.material.opacity }] : []) ?? [],
+      }),
       setTerrainVisible: (visible: boolean) => { const terrain = scene.getObjectByName("terrain"); if (terrain) terrain.visible = visible },
       renderInfo: () => ({
         programs: gl.info.programs?.length ?? 0,

--- a/components/game/game-hud.tsx
+++ b/components/game/game-hud.tsx
@@ -974,6 +974,17 @@ export function GameHud({
             <Panel>
             <div className="flex items-center justify-between gap-4"><Label>{selectedDefinition?.category === "scenery" ? "Scenery" : "Building"}</Label><button type="button" aria-label="Dismiss building" onClick={() => useCameraStore.getState().select(null)} className="pointer-events-auto text-xs text-ink-light">✕</button></div>
             <p className="mt-1 font-display text-xs text-ink">{selectedBuilding.label}</p>
+            {selectedBuilding.id === map?.site?.hovelId && (
+              <div className="mt-3 flex flex-col gap-1.5">
+                <label htmlFor="shrine-admission" className="text-[11px] text-ink-light">Admission · gold per visitor</label>
+                <input id="shrine-admission" type="number" min={0} step={1}
+                  value={economy.settlement.shrineAdmission}
+                  onChange={event => economy.setShrineAdmission(event.target.valueAsNumber)}
+                  className="pointer-events-auto w-24 border border-rule bg-parchment px-2 py-1 text-[13px] text-ink outline-none focus:border-gold" />
+                <p className="max-w-56 text-[11px] text-ink-light">Paid on entry. Only paying visitors gain piety. Set 0 for free entry without a piety reward.</p>
+                <p className="text-[11px] text-ink-light">Collected · {economy.settlement.collectedAdmission} gold</p>
+              </div>
+            )}
             {selectedBuilding.buildType === "lumberCamp" && (
               <p className="mt-2 text-[11px] text-ink"><span className="text-ink-light">Stored wood</span> · {storedWood} wood</p>
             )}

--- a/components/game/travelers.tsx
+++ b/components/game/travelers.tsx
@@ -18,6 +18,7 @@ import type { Relic } from "@/lib/game/relic"
 import type { TreePlacement } from "@/lib/game/trees/placement"
 import { tileAt, worldToTileX, worldToTileZ, type GameMap } from "@/lib/game/map/types"
 import { createSim, simRegistry, stepSim } from "@/lib/game/sim"
+import { relicHeading } from "@/lib/game/shrine-visit"
 import type { Traveler } from "@/lib/game/travelers"
 import { LINEAR_MOVEMENT, type MovementTuning, type WalkTuning } from "@/lib/game/motion"
 import type { CharacterModel } from "@/lib/game/character-assets"
@@ -29,6 +30,7 @@ import {
 } from "@/lib/game/render/outline"
 
 import { TravelerFigure } from "./traveler-figure"
+import { AdmissionEffects } from "./admission-effects"
 import { cartLoadout, SHOP_SECONDS } from "@/lib/game/transport/assets"
 
 /**
@@ -147,6 +149,9 @@ export function Travelers({
         group.rotation.y += turn * blend
       }
       const workTree = s.tree === null ? undefined : trees[s.tree]
+      if (s.activity === "visiting") {
+        group.rotation.y = relicHeading(map, s) ?? group.rotation.y
+      }
       group.userData.workTree = workTree
       if (!playback.paused && !moving && workTree && (s.activity === "working" || s.activity === "gathering")) {
         group.rotation.y = Math.atan2(workTree.x - s.x, workTree.z - s.z)
@@ -187,6 +192,7 @@ export function Travelers({
 
   return (
     <group>
+      <AdmissionEffects sim={sim} characterScale={characterScale} />
       {travelers.map((traveler, index) => {
         const selected = isSelected(selection, { kind: "traveler", id: traveler.id })
         const idColor = new THREE.Color(...encodeObjectId(travelerObjectId(index)))

--- a/hooks/use-settlement.ts
+++ b/hooks/use-settlement.ts
@@ -5,7 +5,7 @@ import type { GameMap, TilePos } from "@/lib/game/map/types"
 import type { Monk } from "@/lib/game/monks"
 import type { Relic } from "@/lib/game/relic"
 import { useBuildStore } from "@/lib/game/build-store"
-import { collectIncome, createSettlement, purchaseStructure, creditTimber, syncTimberSpending, settlementRenown } from "@/lib/game/settlement"
+import { collectIncome, createSettlement, purchaseStructure, creditTimber, creditAdmission, syncTimberSpending, settlementRenown } from "@/lib/game/settlement"
 
 import { useSimulationStore } from "@/lib/game/simulation-store"
 import { useBalanceStore } from "@/lib/game/balance-store"
@@ -19,6 +19,7 @@ export function useSettlement(baseMap: GameMap | null, monks: Monk[], relic: Rel
   const world = ready ? baseMap : null
   const simulation = useBuildStore((s) => s.simulation)
   const wood = useBuildStore((s) => s.wood)
+  const shrineGold = useBuildStore((s) => s.shrineGold)
   const visitCount = useBuildStore((s) => s.visits)
   const settlers = useBuildStore((s) => s.settlers)
   const sameWorld = !!world && simulation?.world.road === world.road
@@ -39,9 +40,10 @@ export function useSettlement(baseMap: GameMap | null, monks: Monk[], relic: Rel
   const map = useMemo(
     () =>
       world
-        ? { ...world, buildings: [...world.buildings, ...session.settlement.structures] }
+        ? { ...world, buildings: [...world.buildings.map(b => b.id === world.site?.hovelId
+          ? { ...b, admissionFee: session.settlement.shrineAdmission } : b), ...session.settlement.structures] }
         : null,
-    [world, session.settlement.structures],
+    [world, session.settlement.structures, session.settlement.shrineAdmission],
   )
 
   useEffect(() => {
@@ -52,10 +54,10 @@ export function useSettlement(baseMap: GameMap | null, monks: Monk[], relic: Rel
     if (!sameWorld) return
     setSession((current) => {
       if (current.world !== world) return current
-      const settlement = creditTimber(current.settlement, wood)
+      const settlement = creditAdmission(creditTimber(current.settlement, wood), shrineGold)
       return settlement === current.settlement ? current : { ...current, settlement }
     })
-  }, [sameWorld, wood, world])
+  }, [sameWorld, wood, shrineGold, world])
 
   useEffect(() => {
     if (sameWorld && simulation) syncTimberSpending(simulation, session.settlement.spentWood)
@@ -92,6 +94,10 @@ export function useSettlement(baseMap: GameMap | null, monks: Monk[], relic: Rel
 
   const chooseBuild = useCallback((buildType: string | null) =>
     setSession((current) => ({ ...current, buildType, message: "" })), [])
+  const setShrineAdmission = useCallback((fee: number) => {
+    if (!Number.isSafeInteger(fee) || fee < 0) return
+    setSession(current => ({ ...current, settlement: { ...current.settlement, shrineAdmission: fee } }))
+  }, [])
   const place = (at: TilePos) => {
     setSession((current) => {
       if (!baseMap || !relic || current.world !== baseMap || !current.buildType) return current
@@ -124,6 +130,7 @@ export function useSettlement(baseMap: GameMap | null, monks: Monk[], relic: Rel
     buildType: session.buildType,
     message: session.message,
     chooseBuild,
+    setShrineAdmission,
     place,
   }
 }

--- a/lib/game/admission-audio.test.ts
+++ b/lib/game/admission-audio.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { createAdmissionAudio } from "./admission-audio"
+
+const sound = vi.hoisted(() => ({ muted: false, listener: undefined as undefined | ((state: { muted: boolean }) => void) }))
+vi.mock("./character-asset-store", () => ({ useCharacterAssetStore: {
+  getState: () => sound,
+  subscribe: (listener: typeof sound.listener) => { sound.listener = listener; return () => { sound.listener = undefined } },
+} }))
+
+afterEach(() => { vi.unstubAllGlobals(); sound.muted = false; sound.listener = undefined })
+
+describe("admission clinks", () => {
+  it("unlocks once, plays the existing coin sound, respects mute and releases audio on cleanup", async () => {
+    const sources: Array<{ start: ReturnType<typeof vi.fn>; stop: ReturnType<typeof vi.fn> }> = []
+    const context = {
+      state: "suspended", destination: {},
+      resume: vi.fn(async () => { context.state = "running" }),
+      decodeAudioData: vi.fn(async () => ({})), close: vi.fn(async () => {}),
+      createGain: () => ({ gain: { value: 0 }, connect: vi.fn(), disconnect: vi.fn() }),
+      createBufferSource: () => {
+        const source = { start: vi.fn(), stop: vi.fn(), connect: (gain: unknown) => gain, disconnect: vi.fn() }
+        sources.push(source)
+        return source
+      },
+    }
+    vi.stubGlobal("AudioContext", class { constructor() { return context } })
+    const fetchAudio = vi.fn(async () => ({ ok: true, arrayBuffer: async () => new ArrayBuffer(8) }))
+    vi.stubGlobal("fetch", fetchAudio)
+    const audio = createAdmissionAudio()
+    expect(audio.play()).toBe(false)
+    audio.unlock()
+    await vi.waitFor(() => expect(context.decodeAudioData).toHaveBeenCalledOnce())
+    audio.unlock()
+    expect(fetchAudio).toHaveBeenCalledExactlyOnceWith("/sounds/characters/merchant-select-v1.wav")
+    expect(audio.play()).toBe(true)
+    expect(sources[0].start).toHaveBeenCalledOnce()
+    sound.muted = true
+    sound.listener?.(sound)
+    expect(sources[0].stop).toHaveBeenCalledOnce()
+    expect(audio.play()).toBe(false)
+    sound.muted = false
+    expect(audio.play()).toBe(true)
+    audio.dispose()
+    expect(sources[1].stop).toHaveBeenCalledOnce()
+    expect(context.close).toHaveBeenCalledOnce()
+    expect(sound.listener).toBeUndefined()
+    expect(audio.play()).toBe(false)
+  })
+})

--- a/lib/game/admission-audio.ts
+++ b/lib/game/admission-audio.ts
@@ -1,0 +1,45 @@
+"use client"
+
+import { CHARACTER_ASSETS } from "./character-assets"
+import { useCharacterAssetStore } from "./character-asset-store"
+
+/** The existing merchant coin-purse recording, unlocked by a game gesture. */
+export function createAdmissionAudio() {
+  let context: AudioContext | undefined
+  let buffer: AudioBuffer | undefined
+  let loading: Promise<void> | undefined
+  let disposed = false
+  const active = new Set<AudioBufferSourceNode>()
+  const stop = () => { for (const source of active) source.stop(); active.clear() }
+  const unsubscribe = useCharacterAssetStore.subscribe(state => { if (state.muted) stop() })
+  return {
+    unlock() {
+      if (disposed || typeof AudioContext === "undefined") return
+      context ??= new AudioContext()
+      void context.resume().catch(() => {})
+      const audio = context
+      loading ??= fetch(CHARACTER_ASSETS.merchant.sound)
+        .then(response => { if (!response.ok) throw new Error("Coin audio unavailable"); return response.arrayBuffer() })
+        .then(data => audio.decodeAudioData(data))
+        .then(decoded => { if (!disposed) buffer = decoded })
+        .catch(() => { loading = undefined })
+    },
+    play(): boolean {
+      if (disposed || useCharacterAssetStore.getState().muted || context?.state !== "running" || !buffer || active.size >= 4) return false
+      const source = context.createBufferSource(), gain = context.createGain()
+      source.buffer = buffer
+      gain.gain.value = 0.4
+      source.connect(gain).connect(context.destination)
+      active.add(source)
+      source.onended = () => { active.delete(source); source.disconnect(); gain.disconnect() }
+      source.start()
+      return true
+    },
+    dispose() {
+      disposed = true
+      unsubscribe()
+      stop()
+      if (context) void context.close().catch(() => {})
+    },
+  }
+}

--- a/lib/game/build-store.ts
+++ b/lib/game/build-store.ts
@@ -19,6 +19,7 @@ interface BuildState {
   resourceRevision: number
   simulation: SimState | null
   wood: number
+  shrineGold: number
   visits: number
   settlers: Monk[]
   syncResources: (sim: SimState, travelers?: readonly Traveler[]) => void
@@ -36,6 +37,7 @@ const emptyState = () => ({
   resourceRevision: -1,
   simulation: null,
   wood: 0,
+  shrineGold: 0,
   visits: 0,
   settlers: [] as Monk[],
 })
@@ -55,6 +57,7 @@ export const useBuildStore = create<BuildState>((set) => ({
     return {
       simulation: sim,
       wood: sim.wood,
+      shrineGold: sim.shrineGold,
       visits: sim.visits,
       settlers: JSON.stringify(s.settlers) === JSON.stringify(settlers) ? s.settlers : settlers,
       time: sim.time,

--- a/lib/game/hospitality.test.ts
+++ b/lib/game/hospitality.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest"
 import { DEFAULT_BALANCE } from "./balance"
-import { createSettlement, purchaseStructure, lumberCamps, creditTimber, syncTimberSpending, settlementRenown } from "./settlement"
+import { createSettlement, purchaseStructure, lumberCamps, creditTimber, creditAdmission, syncTimberSpending, settlementRenown } from "./settlement"
+import { buildingStepAllowed, containsTile, shrineGates } from "./building-navigation"
+import { relicHeading, shrineVisitRoute } from "./shrine-visit"
 import { BUILDING_KINDS, placementProblem, planBuilding } from "./buildings"
 import { useBuildStore } from "./build-store"
 import { BRIDGE_RISE } from "./map/bridges"
@@ -22,7 +24,7 @@ function fixture() {
       door: { x: 10, z: 8 }, hovelId: "hovel" } }
   for (const p of map.road!) map.tiles[p.z * width + p.x] = "path"
   for (const p of map.site!.branch.slice(1)) map.tiles[p.z * width + p.x] = "track"
-  map.buildings.push({ id: "hovel", label: "Shrine", x: 9, z: 9, w: 2, d: 2, height: 1, color: "tan", roofColor: "brown" })
+  map.buildings.push({ id: "hovel", admissionFee: 0, label: "Shrine", x: 9, z: 9, w: 3, d: 3, height: 1, color: "tan", roofColor: "brown" })
   const trees: TreePlacement[] = Array.from({ length: 6 }, (_, i) => {
     const x = 16 + i % 3, z = 10 + Math.floor(i / 3)
     map.tiles[z * width + x] = "forest"
@@ -45,6 +47,111 @@ function run(sim: SimState, travelers: Traveler[], map: GameMap, seconds: number
 const obscure = { sanctity: 0, spectacle: 0, doubt: 100 }
 
 describe("shrine hospitality", () => {
+  it.each([0, 1, 2, 3])("enters gate %i, faces the relic, pays once and walks back out", (id) => {
+    const { map, traveler } = fixture()
+    const shrine = map.buildings[0]
+    shrine.admissionFee = 3
+    const t = traveler(id)
+    t.attributes.gold = 10
+    t.attributes.hunger = 0
+    const sim = createSim([t], map, [], obscure)
+    const s = sim.travelers.get(id)!
+    const route = shrineVisitRoute(map, id, 0)!
+    expect(route.at(-1)).toEqual(shrineGates(shrine)[id].inside)
+    for (let i = 1; i < route.length; i++) {
+      expect(Math.abs(route[i].x - route[i - 1].x) + Math.abs(route[i].z - route[i - 1].z)).toBe(1)
+      expect(buildingStepAllowed(map, map.buildings, route[i - 1], route[i], true)).toBe(true)
+    }
+    run(sim, [t], map, 60, () => s.activity === "visiting")
+    expect(s.activity).toBe("visiting")
+    expect(containsTile(shrine, { x: worldToTileX(map, s.x), z: worldToTileZ(map, s.z) })).toBe(true)
+    expect(s.gold).toBe(7)
+    expect(sim.shrineGold).toBe(3)
+    expect(sim.admissionPayments).toEqual([{ id: 1, travelerId: id, amount: 3, x: s.x, y: s.y, z: s.z }])
+    expect(s.admissionPaid).toBe(3)
+    const heading = relicHeading(map, s)!
+    expect(s.x + Math.sin(heading)).toBeCloseTo(tileToWorldX(map, shrine.x + 1))
+    expect(s.z + Math.cos(heading)).toBeCloseTo(tileToWorldZ(map, shrine.z + 1))
+    shrine.admissionFee = 0 // A paid visit keeps its reward even if the price changes.
+    run(sim, [t], map, 60, () => s.activity === "fromRelic")
+    expect(s.visits).toBe(1)
+    expect(s.piety).toBeGreaterThan(t.attributes.piety)
+    expect(s.admissionPaid).toBe(0)
+    run(sim, [t], map, 30, () => s.activity === "walking")
+    expect(s.activity).toBe("walking")
+    expect(s.gold).toBe(7)
+    expect(sim.shrineGold).toBe(3)
+    expect(s.shrineRoute).toBeNull()
+    expect(t.attributes.gold).toBe(10)
+    expect(sim.admissionPayments).toHaveLength(1)
+  })
+
+  it("passes an unaffordable shrine and returns unpaid if the fee rises during the approach", () => {
+    const { map, traveler } = fixture()
+    map.buildings[0].admissionFee = 3
+    const t = traveler(0)
+    t.attributes.gold = 2
+    t.attributes.hunger = 30
+    const sim = createSim([t], map, [], obscure)
+    const s = sim.travelers.get(0)!
+    run(sim, [t], map, 1)
+    expect(s.activity).toBe("walking")
+    expect(s.progress).toBeGreaterThan(map.site!.junction)
+    s.gold = 3
+    s.progress = map.site!.junction - 0.1
+    s.visitCooldown = 0
+    s.hunger = 0
+    run(sim, [t], map, 1, () => s.activity === "toRelic")
+    expect(s.activity).toBe("toRelic")
+    map.buildings[0].admissionFee = 4
+    run(sim, [t], map, 60, () => s.activity === "fromRelic")
+    expect(s.activity).toBe("fromRelic")
+    expect(s.gold).toBe(3)
+    expect(sim.shrineGold).toBe(0)
+    expect(sim.visits).toBe(0)
+    expect(sim.admissionPayments).toHaveLength(0)
+  })
+
+  it("credits admission receipts once across spending and clears them for a new world", () => {
+    const initial = createSettlement()
+    expect(initial.shrineAdmission).toBe(2)
+    const paid = creditAdmission(initial, 6)
+    expect(paid.resources.gold).toBe(initial.resources.gold + 6)
+    const spent = { ...paid, resources: { ...paid.resources, gold: 0 } }
+    expect(creditAdmission(spent, 6)).toBe(spent)
+    expect(creditAdmission(spent, 8).resources.gold).toBe(2)
+    const { map } = fixture()
+    const sim = createSim([], map)
+    sim.shrineGold = 6
+    useBuildStore.getState().syncResources(sim)
+    expect(useBuildStore.getState().shrineGold).toBe(6)
+    useBuildStore.getState().reset()
+    expect(useBuildStore.getState().shrineGold).toBe(0)
+    expect(createSettlement().collectedAdmission).toBe(0)
+  })
+
+  it("never carries a paid visit's piety entitlement into a later free visit", () => {
+    const { map, traveler } = fixture()
+    const t = traveler(0)
+    t.attributes.gold = 10
+    t.attributes.hunger = 0
+    map.buildings[0].admissionFee = 3
+    const sim = createSim([t], map, [], obscure), s = sim.travelers.get(0)!
+    run(sim, [t], map, 60, () => s.activity === "fromRelic")
+    const paidPiety = s.piety
+    expect(paidPiety).toBeGreaterThan(0)
+    map.buildings[0].admissionFee = 0
+    s.activity = "toRelic"
+    run(sim, [t], map, 1, () => s.activity === "visiting")
+    expect(s.admissionPaid).toBe(0)
+    map.buildings[0].admissionFee = 5 // Changing the current price cannot create a payment.
+    run(sim, [t], map, 60, () => s.activity === "fromRelic")
+    expect(s.visits).toBe(2)
+    expect(s.piety).toBe(paidPiety)
+    expect(s.gold).toBe(7)
+    expect(sim.admissionPayments).toHaveLength(1)
+  })
+
   it.each([LINEAR_MOVEMENT, DEFAULT_MOVEMENT])("keeps shrine visitors on opposite sides in both directions (%j)", (movement) => {
     const { map, traveler } = fixture()
     const travelers = [traveler(0), traveler(1)]
@@ -102,7 +209,8 @@ describe("shrine hospitality", () => {
         run(sim, [t], map, 60, () => s.activity === "fromRelic")
         expect(s.visits).toBe(1)
         expect(Math.min(s.hunger, s.thirst, s.stamina)).toBeGreaterThanOrEqual(95)
-        expect(s.piety).toBeGreaterThan(t.attributes.piety)
+        expect(s.piety).toBe(t.attributes.piety)
+        expect(sim.admissionPayments).toHaveLength(0)
         expect(s.gold).toBe(0)
         expect(sim.visits * sim.balance.rules.visitRenown).toBe(0.5)
         expect(sim.relic).toEqual(obscure)

--- a/lib/game/map/generate-map.test.ts
+++ b/lib/game/map/generate-map.test.ts
@@ -144,8 +144,7 @@ describe("generateMap", () => {
           if (inFootprint) {
             expect(terrain, `seed ${seed} hovel stands on grass`).toBe("grass")
           } else {
-            // The ring is grass except where the track arrives at the door.
-            expect(["grass", "track"], `seed ${seed} hovel has breathing room`).toContain(terrain)
+            expect(["path", "track"], `seed ${seed} path encircles every side and corner`).toContain(terrain)
           }
         }
       }

--- a/lib/game/map/generate-map.ts
+++ b/lib/game/map/generate-map.ts
@@ -1028,7 +1028,7 @@ function foundSite(
   }
 
   const foundation = elevation.height[best.z * width + best.x]
-  // --- Guarantee footing: footprint plus ring become grass ---------------------
+  // Level the enclosure and its continuous walking path, serving all four gates.
   for (let dz = -1; dz <= HOVEL_SIZE; dz++) {
     for (let dx = -1; dx <= HOVEL_SIZE; dx++) {
       const i = (best.z + dz) * width + (best.x + dx)
@@ -1040,6 +1040,9 @@ function foundSite(
         tiles[i] === "sand"
       ) {
         tiles[i] = "grass"
+      }
+      if ((dx === -1 || dz === -1 || dx === HOVEL_SIZE || dz === HOVEL_SIZE) && tiles[i] !== "path") {
+        tiles[i] = "track"
       }
     }
   }

--- a/lib/game/map/types.ts
+++ b/lib/game/map/types.ts
@@ -4,6 +4,8 @@ export interface BuildingDef {
   id: string
   /** Player-built catalogue entry; absent on the founding hovel. */
   buildType?: string
+  /** Gold paid by each visitor entering the relic enclosure. */
+  admissionFee?: number
   label: string
   /** Origin tile — the minimum corner of the footprint. */
   x: number

--- a/lib/game/render/payment-label.ts
+++ b/lib/game/render/payment-label.ts
@@ -1,0 +1,36 @@
+import * as THREE from "three"
+
+// Native bitmap lettering keeps these small amounts crisp beside the characters.
+const GLYPHS: Record<string, string[]> = {
+  "+": ["00000", "00100", "00100", "11111", "00100", "00100", "00000"],
+  "$": ["00100", "01111", "10100", "01110", "00101", "11110", "00100"],
+  "0": ["01110", "10001", "10011", "10101", "11001", "10001", "01110"],
+  "1": ["00100", "01100", "00100", "00100", "00100", "00100", "01110"],
+  "2": ["01110", "10001", "00001", "00010", "00100", "01000", "11111"],
+  "3": ["11110", "00001", "00001", "01110", "00001", "00001", "11110"],
+  "4": ["00010", "00110", "01010", "10010", "11111", "00010", "00010"],
+  "5": ["11111", "10000", "10000", "11110", "00001", "00001", "11110"],
+  "6": ["01110", "10000", "10000", "11110", "10001", "10001", "01110"],
+  "7": ["11111", "00001", "00010", "00100", "01000", "01000", "01000"],
+  "8": ["01110", "10001", "10001", "01110", "10001", "10001", "01110"],
+  "9": ["01110", "10001", "10001", "01111", "00001", "00001", "01110"],
+}
+
+/** Gold income with a one-native-pixel dark border, using the scene's pixel size. */
+export function paymentLabel(amount: number): THREE.DataTexture {
+  const text = `+$${amount}`, width = text.length * 6 + 1, height = 9
+  const data = new Uint8Array(width * height * 4)
+  const points: Array<[number, number]> = []
+  for (let i = 0; i < text.length; i++) GLYPHS[text[i]].forEach((row, y) => {
+    for (let x = 0; x < row.length; x++) if (row[x] === "1") points.push([i * 6 + x + 1, 7 - y])
+  })
+  const paint = (x: number, y: number, color: number[]) => data.set(color, (y * width + x) * 4)
+  for (const [x, y] of points) for (let dy = -1; dy <= 1; dy++) for (let dx = -1; dx <= 1; dx++) paint(x + dx, y + dy, [48, 33, 12, 255])
+  for (const [x, y] of points) paint(x, y, [255, 216, 106, 255])
+  const texture = new THREE.DataTexture(data, width, height)
+  texture.colorSpace = THREE.SRGBColorSpace
+  texture.magFilter = texture.minFilter = THREE.NearestFilter
+  texture.generateMipmaps = false
+  texture.needsUpdate = true
+  return texture
+}

--- a/lib/game/settlement.ts
+++ b/lib/game/settlement.ts
@@ -3,6 +3,7 @@ import { placementProblem, PLACEMENT_PROBLEM_LABELS, type PlacedBuilding } from 
 import { settlementRoute } from "./settlement-route"
 import { getBuildInfluence, type BuildInfluence } from "./build-influence"
 import type { SimState } from "./sim"
+import { DEFAULT_ADMISSION_FEE } from "./shrine-visit"
 import { TERRAIN } from "./map/terrain"
 import { tileAt, type BuildingDef, type GameMap, type TilePos } from "./map/types"
 import type { Monk } from "./monks"
@@ -25,6 +26,8 @@ export interface Settlement {
   /** Cumulative harvest already credited; spending never credits it again. */
   deliveredWood: number
   spentWood: number
+  shrineAdmission: number
+  collectedAdmission: number
   /** Only player-built additions. The founding hovel stays on the base map. */
   structures: BuildingDef[]
 }
@@ -35,6 +38,18 @@ export function createSettlement(balance: GameBalance = DEFAULT_BALANCE): Settle
     structures: [],
     deliveredWood: 0,
     spentWood: 0,
+    shrineAdmission: DEFAULT_ADMISSION_FEE,
+    collectedAdmission: 0,
+  }
+}
+
+/** Admission is earned in the simulation and credited once, even after spending. */
+export function creditAdmission(settlement: Settlement, receipts: number): Settlement {
+  if (receipts <= settlement.collectedAdmission) return settlement
+  return {
+    ...settlement,
+    collectedAdmission: receipts,
+    resources: { ...settlement.resources, gold: settlement.resources.gold + receipts - settlement.collectedAdmission },
   }
 }
 

--- a/lib/game/shrine-visit.ts
+++ b/lib/game/shrine-visit.ts
@@ -1,0 +1,33 @@
+import { buildingStepAllowed, shrineGates } from "./building-navigation"
+import { tileToWorldX, tileToWorldZ, type GameMap, type TilePos } from "./map/types"
+import { settlementRoute } from "./settlement-route"
+
+export const DEFAULT_ADMISSION_FEE = 2
+
+export function admissionFee(map: GameMap): number {
+  return map.buildings.find(b => b.id === map.site?.hovelId)?.admissionFee ?? DEFAULT_ADMISSION_FEE
+}
+
+/** Join the approach to a gate via the grounds, then step inside to pray.
+ * Rotate preferred gates between visitors and repeat visits. */
+export function shrineVisitRoute(map: GameMap, visitor: number, visits: number): TilePos[] | null {
+  const site = map.site
+  const shrine = map.buildings.find(b => b.id === site?.hovelId)
+  if (!site || !shrine) return null
+  const gates = shrineGates(shrine)
+  for (let i = 0; i < gates.length; i++) {
+    const gate = gates[(visitor + visits + i) % gates.length]
+    if (!buildingStepAllowed(map, map.buildings, gate.outside, gate.inside, true)) continue
+    const approach = settlementRoute(map, map.buildings, site.door, gate.outside)
+    if (approach) return [...site.branch, ...approach.slice(1), gate.inside]
+  }
+  return null
+}
+
+/** Match the displayed relic at the centre of the enclosure. */
+export function relicHeading(map: GameMap, visitor: { x: number; z: number }): number | null {
+  const shrine = map.buildings.find(b => b.id === map.site?.hovelId)
+  if (!shrine) return null
+  return Math.atan2(tileToWorldX(map, shrine.x) + (shrine.w - 1) / 2 - visitor.x,
+    tileToWorldZ(map, shrine.z) + (shrine.d - 1) / 2 - visitor.z)
+}

--- a/lib/game/sim.ts
+++ b/lib/game/sim.ts
@@ -13,6 +13,7 @@ import { AXE_DAMAGE_PER_HOUR, STUMP_LIFETIME_DAYS, TIMBER_LOAD, stackWood, treeR
 import { BUILDING_KINDS, buildingCentre, type PlacedBuilding } from "./buildings"
 import { generateRelic, visitChance, type RelicStats } from "./relic"
 import { settlementRoute } from "./settlement-route"
+import { admissionFee, shrineVisitRoute } from "./shrine-visit"
 import type { TreePlacement } from "./trees/placement"
 import { TREE_SPECIES } from "./trees/species"
 import type { TilePos } from "./map/types"
@@ -87,7 +88,7 @@ export type Activity =
 
 export const ACTIVITY_LABELS: Record<Activity, string> = {
   toRelic: "Following the path to the shrine",
-  visiting: "Food, lodging & blessings",
+  visiting: "Praying before the relic",
   fromRelic: "Returning from the shrine",
   toWork: "Walking to work",
   working: "Felling a tree",
@@ -185,6 +186,8 @@ function roll(id: number, n: number): number {
 }
 
 export interface SimTraveler {
+  /** Actual gold paid for this visit, captured on admission. */
+  admissionPaid: number
   keeperTime?: number
   customerVisit?: { vendorId: number; road: { x: number; y: number; z: number }; frontage: { x: number; y: number; z: number } }
   stallRoute?: StallRoute
@@ -197,6 +200,7 @@ export interface SimTraveler {
   jobless: boolean
   employer: string | null
   branchProgress: number
+  shrineRoute: TilePos[] | null
   /** Road lane used when entering the shrine, including a reversed approach for shelter. */
   branchEntryLane: number
   visitCooldown: number
@@ -254,6 +258,8 @@ export interface SimTraveler {
 }
 
 export interface SimState {
+  admissionSequence: number
+  admissionPayments: AdmissionPayment[]
   seed: number
   travelers: Map<number, SimTraveler>
   /** Game time in days since the sim began (fractional). */
@@ -267,6 +273,8 @@ export interface SimState {
   balance: GameBalance
   visits: number
   wood: number
+  /** Cumulative admission receipts; the economy credits each payment once. */
+  shrineGold: number
   constructionWood: number
   felled: Set<number>
   treeResources: Map<number, TreeResource>
@@ -274,6 +282,15 @@ export interface SimState {
   resourceRevision: number
   buildings: readonly PlacedBuilding[]
   trees: readonly TreePlacement[]
+}
+
+export interface AdmissionPayment {
+  id: number
+  travelerId: number
+  amount: number
+  x: number
+  y: number
+  z: number
 }
 
 /**
@@ -369,7 +386,10 @@ function currentRoutePoint(map: GameMap, s: SimTraveler): WorldPoint {
 /** Join the shrine's walking lanes to the traveler's road lane over the first tile. */
 function shrineWorldPoint(map: GameMap, s: SimTraveler): WorldPoint {
   const site = map.site!
-  const point = routeWorldPoint(map, site.branch, s.branchProgress, s.lane)
+  const route = s.shrineRoute ?? site.branch
+  // Leave the walking lane before reaching the grounds; cross gates centrally.
+  const laneBlend = s.shrineRoute ? Math.max(0, Math.min(1, site.branch.length - 1 - s.branchProgress)) : 1
+  const point = routeWorldPoint(map, route, s.branchProgress, s.lane * laneBlend)
   if (s.branchProgress < 1) {
     const start = routeWorldPoint(map, site.branch, 0, s.lane)
     const roadLane = s.activity === "toRelic" ? s.branchEntryLane : s.direction * s.laneOffset
@@ -396,6 +416,8 @@ export function createSim(
   relic: RelicStats = generateRelic(map.seed ?? 0).stats,
 ): SimState {
   const sim: SimState = {
+    admissionSequence: 0,
+    admissionPayments: [],
     seed: map.seed ?? 0,
     travelers: new Map(),
     time: START_TIME,
@@ -406,6 +428,7 @@ export function createSim(
     balance: DEFAULT_BALANCE,
     visits: 0,
     wood: 0,
+    shrineGold: 0,
     constructionWood: 0,
     felled: new Set(),
     treeResources: new Map(),
@@ -424,6 +447,7 @@ export function createSim(
     const lane = t.direction * laneOffset
     const at = roadWorldPoint(map, progress, lane)
     sim.travelers.set(t.id, {
+      admissionPaid: 0,
       id: t.id,
       activity: "walking",
       gold: t.attributes.gold,
@@ -431,6 +455,7 @@ export function createSim(
       jobless: t.attributes.jobless,
       employer: null,
       branchProgress: 0,
+      shrineRoute: null,
       branchEntryLane: lane,
       visitCooldown: 0,
       visits: 0,
@@ -716,11 +741,13 @@ function chooseTree(sim: SimState, s: SimTraveler, map: GameMap): boolean {
 function finishVisit(sim: SimState, s: SimTraveler, t: Traveler, map: GameMap): void {
   s.visits++
   sim.visits++
-  s.piety = Math.min(100, s.piety + 4 + sim.relic.sanctity / 25)
+  if (s.admissionPaid > 0) s.piety = Math.min(100, s.piety + 4 + sim.relic.sanctity / 25)
+  s.admissionPaid = 0
   const job = findJob(sim, s, map)
   if (job && nextRoll(s) < (t.attributes.skills.some((skill) => BUILDING_KINDS[job.kind].trades.includes(skill)) ? 0.9 : 0.65)) {
-    const route = settlementRoute(map, [...map.buildings, ...sim.buildings], map.site!.door,
-      { x: job.x, z: job.z + job.d - 1 })
+    const route = settlementRoute(map, [...map.buildings, ...sim.buildings],
+      { x: worldToTileX(map, s.x), z: worldToTileZ(map, s.z) },
+      { x: job.x, z: job.z + job.d - 1 }, false, true)
     if (route) {
       s.employer = job.id
       s.jobless = false
@@ -793,7 +820,7 @@ export function stepSim(
     switch (s.activity) {
       case "toRelic":
       case "fromRelic": {
-        const branch = map.site!.branch
+        const branch = s.shrineRoute ?? map.site!.branch
         const inbound = s.activity === "toRelic"
         s.branchProgress = Math.max(0, Math.min(branch.length - 1,
           s.branchProgress + (inbound ? 1 : -1) * worldSpeed * dt))
@@ -803,11 +830,25 @@ export function stepSim(
         s.y = at.y
         s.z = at.z
         if (inbound && s.branchProgress >= branch.length - 1) {
-          s.activity = "visiting"
-          s.timer = 2 * GAME_HOUR_SECONDS
+          const fee = admissionFee(map)
+          if (s.gold >= fee) {
+            s.gold -= fee
+            sim.shrineGold += fee
+            s.admissionPaid = fee
+            if (fee > 0) {
+              sim.admissionPayments.push({ id: ++sim.admissionSequence, travelerId: s.id, amount: fee, x: s.x, y: s.y, z: s.z })
+              // Presentation reads these receipts by sequence; long games stay bounded.
+              if (sim.admissionPayments.length > 64) sim.admissionPayments.shift()
+            }
+            s.activity = "visiting"
+            s.timer = 2 * GAME_HOUR_SECONDS
+          } else {
+            s.activity = "fromRelic"
+          }
         } else if (!inbound && s.branchProgress <= 0) {
           s.lane = s.direction * s.laneOffset
           s.activity = "walking"
+          s.shrineRoute = null
           s.visitCooldown = 30
         }
         break
@@ -875,7 +916,7 @@ export function stepSim(
       case "seeking":
       case "fleeing": {
         // Nearby travelers seek the brothers before collapsing or chasing a cart.
-        const shelter = !!map.site && !s.track && s.activity !== "fleeing" && s.visitCooldown <= 0 &&
+        const shelter = !!map.site && s.gold >= admissionFee(map) && !s.track && s.activity !== "fleeing" && s.visitCooldown <= 0 &&
           Math.min(s.hunger, s.thirst, s.stamina) <= 40 && Math.abs(s.progress - map.site.junction) <= 12
         if (s.stamina <= 0 && !shelter) {
           startCamping(sim, s, t, map)
@@ -990,9 +1031,13 @@ export function stepSim(
               hunger: s.hunger, thirst: s.thirst, stamina: s.stamina }, sim.relic, sim.shrineRenown + sim.visits * sim.balance.rules.visitRenown, sim.balance),
               findJob(sim, s, map) ? 0.8 : 0)
             s.visitCooldown = 5
-            if (nextRoll(s) < chance) {
+            const wantsVisit = nextRoll(s) < chance && s.gold >= admissionFee(map)
+            const visitRoute = wantsVisit ? shrineVisitRoute(map, s.id, s.visits) : null
+            if (visitRoute) {
               s.progress = site.junction
               s.branchProgress = 0
+              s.shrineRoute = visitRoute
+              s.admissionPaid = 0
               s.activity = "toRelic"
               s.targetId = null
               s.branchEntryLane = s.lane


### PR DESCRIPTION
Visitors now follow a continuous path around the shrine, enter through its four gates, and pray inside while facing the relic.
Selecting the building lets players set admission (2 gold by default, with 0 for free entry), and each payment credits the settlement treasury once.
Paid entry plays the existing coin clink and displays a floating gold amount; only visitors who actually paid gain piety, even if the price changes during their visit.

Validated with TypeScript checks, targeted simulation, hospitality, settlement, map, and audio tests (using a longer timeout for simulation tests), plus browser checks of gate entry, live pricing, payment accounting, clinks, and floating-label animation.
