### PR TITLE
Double default game speed and expand playback options

### DIFF
--- a/components/game/game-hud.css
+++ b/components/game/game-hud.css
@@ -72,7 +72,7 @@
 .hud-time { margin-right: var(--hud-control-gap); font-size: 18px; font-variant-numeric: tabular-nums; line-height: 24px; }
 .hud-pause { width: 28px; height: 28px; display: flex; align-items: center; justify-content: center; cursor: pointer; }
 .hud-speeds { display: flex; gap: var(--hud-control-gap); }
-.hud-speeds button { width: 28px; height: 28px; font-size: 12px; cursor: pointer; }
+.hud-speeds button { min-width: 28px; height: 28px; padding: 0 4px; font-size: 12px; cursor: pointer; }
 .hud-bottom-center { position: absolute; left: var(--hud-left); right: var(--hud-right); bottom: var(--hud-space); display: flex; flex-direction: column; gap: var(--hud-space); z-index: 15; }
 .hud-bottom-actions { width: fit-content; max-width: 100%; background: #241f16ed; pointer-events: auto; display: flex; align-items: center; gap: var(--hud-control-gap); height: var(--hud-bar-height); border: 1px solid #8c784c; box-shadow: inset 0 0 0 2px #17140e; padding: 3px; }
 .hud-action { display: flex; gap: 7px; align-items: center; justify-content: center; padding: 4px var(--hud-space); height: 28px; font-family: var(--font-cinzel), serif; font-size: 11px; letter-spacing: .04em; white-space: nowrap; pointer-events: auto; cursor: pointer; text-shadow: 0 1px 2px #000; }
@@ -156,7 +156,7 @@
 .hud-resource-bar { min-width: 0; }
 .hud-resources { overflow-x: auto; }
 .hud-resources > :is(span, button) { flex-shrink: 0; }
-@media (max-width: 380px) {
+@media (max-width: 480px) {
   .hud-clock { grid-column: 1 / -1; grid-row: 3; }
   .game-hud { --hud-header-height: calc(var(--hud-bar-height) * 3 + var(--hud-space) * 2); }
 }

--- a/components/game/hud-controls.tsx
+++ b/components/game/hud-controls.tsx
@@ -12,7 +12,7 @@ import { influenceRadius } from "@/lib/game/build-influence"
 import { canAfford, placementError } from "@/lib/game/settlement"
 import { useCameraStore } from "@/lib/game/camera-store"
 import { formatGameTime, simRegistry } from "@/lib/game/sim"
-import { useSimulationStore } from "@/lib/game/simulation-store"
+import { SIMULATION_SPEEDS, useSimulationStore } from "@/lib/game/simulation-store"
 
 /** Hover and keyboard-focus help, positioned inside the viewport by Radix.
  * @see https://app.paper.design/file/01M1QTYBYHXP4H1BXFQ79N18AP/2-0/1N5-0
@@ -142,8 +142,8 @@ export function HudClock() {
       {paused ? <Play size={14} /> : <Pause size={14} />}
     </button>
     <div className="hud-speeds" aria-label="Simulation speed">
-      {([1, 2, 3] as const).map((value) => <button type="button" key={value} aria-label={`${value}× simulation speed`} aria-pressed={speed === value}
-        onClick={() => useSimulationStore.getState().setSpeed(value)}>{value}×</button>)}
+      {SIMULATION_SPEEDS.map(({ label, rate }) => <button type="button" key={rate} aria-label={`${label}× simulation speed`} aria-pressed={speed === rate}
+        onClick={() => useSimulationStore.getState().setSpeed(rate)}>{label}×</button>)}
     </div>
   </section>
 }

--- a/lib/game/simulation-store.ts
+++ b/lib/game/simulation-store.ts
@@ -1,14 +1,24 @@
 import { create } from "zustand"
 
+/** Display speeds use the former 2× pace as the new normal. Rates stay in simulation ticks. */
+export const SIMULATION_SPEEDS = [
+  { label: 0.5, rate: 1 },
+  { label: 1, rate: 2 },
+  { label: 2, rate: 4 },
+  { label: 3, rate: 6 },
+  { label: 5, rate: 10 },
+] as const
+type SimulationSpeed = typeof SIMULATION_SPEEDS[number]["rate"]
+
 /** Shared playback controls for the traveler simulation and ambient residents. */
 export const useSimulationStore = create<{
   paused: boolean
-  speed: 1 | 2 | 3
+  speed: SimulationSpeed
   togglePaused: () => void
-  setSpeed: (speed: 1 | 2 | 3) => void
+  setSpeed: (speed: SimulationSpeed) => void
 }>((set) => ({
   paused: false,
-  speed: 1,
+  speed: 2,
   togglePaused: () => set((s) => ({ paused: !s.paused })),
   setSpeed: (speed) => set({ speed }),
 }))


### PR DESCRIPTION
Make the former 2× pace the new default 1× and the former 1× pace the new 0.5×, with playback options of 0.5×, 1×, 2×, 3×, and 5×.
Widen the speed buttons and move the clock onto its own row at widths up to 480px to accommodate the expanded selector.

Validation: typecheck, 57 simulation/movement/monk tests, and diff checks passed.

Design reference: [existing HUD frame in Paper](https://app.paper.design/file/01M1QTYBYHXP4H1BXFQ79N18AP/2-0/1GB-0).
