### PR TITLE
Level soil automatically beneath placed buildings

### DIFF
--- a/hooks/use-settlement.ts
+++ b/hooks/use-settlement.ts
@@ -40,10 +40,10 @@ export function useSettlement(baseMap: GameMap | null, monks: Monk[], relic: Rel
   const map = useMemo(
     () =>
       world
-        ? { ...world, buildings: [...world.buildings.map(b => b.id === world.site?.hovelId
+        ? { ...world, elevation: session.settlement.elevation ?? world.elevation, buildings: [...world.buildings.map(b => b.id === world.site?.hovelId
           ? { ...b, admissionFee: session.settlement.shrineAdmission } : b), ...session.settlement.structures] }
         : null,
-    [world, session.settlement.structures, session.settlement.shrineAdmission],
+    [world, session.settlement.elevation, session.settlement.structures, session.settlement.shrineAdmission],
   )
 
   useEffect(() => {

--- a/lib/game/map/elevation.test.ts
+++ b/lib/game/map/elevation.test.ts
@@ -1,11 +1,68 @@
 import { describe, expect, it } from "vitest"
-import { DEFAULT_ELEVATION, elevationSettings, elevationStep, finishElevation, generateElevation, groundHeight } from "./elevation"
+import { DEFAULT_ELEVATION, elevationSettings, elevationStep, finishElevation, generateElevation, groundHeight, levelBuildingGround } from "./elevation"
 import { drainWater } from "./hydrology"
 import { generateMap } from "./generate-map"
 import { routeBlind } from "./route"
-import type { GameMap } from "./types"
+import { tileToWorldX, tileToWorldZ, type GameMap } from "./types"
+import { walkingSurface } from "./walking-surface"
 
 describe("topography", () => {
+  it.each([{ x: 2, z: 2, w: 2, d: 2 }, { x: 0, z: 0, w: 1, d: 1 }, { x: 5, z: 4, w: 3, d: 4 }])(
+    "levels the entire building pad and joins its dry perimeter at $x,$z", (building) => {
+      const width = 8, depth = 8, water = new Uint8Array(width * depth)
+      const elevation = generateElevation(1, width, depth, water)
+      elevation.height = elevation.height.map((_, i) => (i % width) * 0.04 + Math.floor(i / width) * 0.03)
+      finishElevation(elevation, width, depth, water, [])
+      const map: GameMap = { width, depth, tiles: Array(64).fill("grass"), buildings: [], elevation }
+      const before = structuredClone(map)
+      const foundation = groundHeight(map, building.x + (building.w - 1) / 2, building.z + (building.d - 1) / 2)
+      const graded = { ...map, elevation: levelBuildingGround(map, building)! }
+      expect(map).toEqual(before)
+      for (let z = building.z; z < building.z + building.d; z++) for (let x = building.x; x < building.x + building.w; x++) {
+        const i = z * width + x
+        for (const corner of graded.elevation.corners.slice(i * 4, i * 4 + 4)) expect(corner + 0.2).toBeCloseTo(foundation)
+        expect(graded.elevation.height[i] + 0.2).toBeCloseTo(foundation)
+        for (const dx of [-0.49, 0, 0.49]) for (const dz of [-0.49, 0, 0.49]) {
+          expect(walkingSurface(graded, tileToWorldX(map, x) + dx, tileToWorldZ(map, z) + dz)).toEqual({ height: foundation, dx: 0, dz: 0 })
+        }
+      }
+      // Every dry neighbour still shares its edge, including all four pad boundaries.
+      const c = graded.elevation.corners
+      for (let z = 0; z < depth; z++) for (let x = 0; x < width; x++) {
+        const i = z * width + x
+        if (x + 1 < width) { expect(c[i * 4 + 1]).toBe(c[(i + 1) * 4]); expect(c[i * 4 + 3]).toBe(c[(i + 1) * 4 + 2]) }
+        if (z + 1 < depth) { expect(c[i * 4 + 2]).toBe(c[(i + width) * 4]); expect(c[i * 4 + 3]).toBe(c[(i + width) * 4 + 1]) }
+      }
+      expect(graded.elevation.cliffs.every((mask) => mask === 0)).toBe(true)
+      expect(graded.elevation.slope[building.z * width + building.x]).not.toBe(elevation.slope[building.z * width + building.x])
+    },
+  )
+
+  it("preserves water, distant terrain, and an existing foundation beside a later purchase", () => {
+    const width = 8, depth = 8, water = new Uint8Array(64)
+    water[3 * width + 4] = 1
+    const elevation = generateElevation(1, width, depth, water)
+    elevation.height = elevation.height.map((_, i) => i % width * 0.04)
+    elevation.height[3 * width + 4] = -0.5
+    const surface = Array(64).fill(-0.1)
+    finishElevation(elevation, width, depth, water, surface)
+    const map: GameMap = { width, depth, tiles: Array(64).fill("grass"), buildings: [], elevation, water: { depth: Array.from(water), surface, flow: {} } }
+    map.tiles[3 * width + 4] = "water"
+    // A bridge can extend over dry banks; its land footings must stay dry.
+    map.tiles[63] = "bridge"
+    surface[63] = -2
+    const first = { x: 1, z: 2, w: 2, d: 2, id: "first", label: "First", height: 1, color: "", roofColor: "" }
+    const firstMap = { ...map, elevation: levelBuildingGround(map, first)!, buildings: [first] }
+    const next = levelBuildingGround(firstMap, { x: 3, z: 2, w: 1, d: 2 })!
+    for (const i of [0, 18, 17, 25, 26, 28, 63]) {
+      expect(next.corners.slice(i * 4, i * 4 + 4)).toEqual(firstMap.elevation.corners.slice(i * 4, i * 4 + 4))
+      expect(next.height[i]).toBe(firstMap.elevation.height[i])
+    }
+    expect(next.cliffs[63]).toBe(elevation.cliffs[63])
+    expect(map.water!.surface).toEqual(surface)
+    expect(levelBuildingGround({ ...map, elevation: undefined }, first)).toBeUndefined()
+  })
+
   it("clamps invalid settings and enforces the +4 ceiling", () => {
     expect(elevationSettings({ maxHeight: 99, scale: NaN, slopeCost: -9 })).toMatchObject({ maxHeight: 4, scale: DEFAULT_ELEVATION.scale, slopeCost: 0 })
   })

--- a/lib/game/map/elevation.ts
+++ b/lib/game/map/elevation.ts
@@ -1,6 +1,6 @@
 import { makeRng } from "../rng"
 import { TILE_HEIGHT } from "./terrain"
-import type { GameMap } from "./types"
+import type { BuildingDef, GameMap } from "./types"
 import { ROUTE_DIRS } from "./route"
 
 /** Independent generation and display controls; heights are in tile units. */
@@ -129,10 +129,8 @@ export function generateElevation(seed: number, width: number, depth: number, wa
   return { settings, height, corners: [], slope: [], cliffs: [] }
 }
 
-/** Rebuild after grading a founding footprint. Water corners retain their channel levels. */
-export function finishElevation(e: ElevationInfo, width: number, depth: number, water: Uint8Array, surface: number[]): void {
+function updateElevationEdges(e: ElevationInfo, width: number, depth: number, water: Uint8Array, surface: number[]): void {
   e.slope = e.height.map(() => 0); e.cliffs = e.height.map(() => 0)
-  e.corners = new Array(e.height.length * 4)
   for (let z = 0; z < depth; z++) for (let x = 0; x < width; x++) {
     const i = z * width + x, h = water[i] ? surface[i] : e.height[i]
     ROUTE_DIRS.forEach(([dx, dz], side) => {
@@ -143,6 +141,12 @@ export function finishElevation(e: ElevationInfo, width: number, depth: number, 
       if (delta >= e.settings.cliffThreshold) e.cliffs[i] |= 1 << side
     })
   }
+}
+
+/** Rebuild after grading a founding footprint. Water corners retain their channel levels. */
+export function finishElevation(e: ElevationInfo, width: number, depth: number, water: Uint8Array, surface: number[]): void {
+  updateElevationEdges(e, width, depth, water, surface)
+  e.corners = new Array(e.height.length * 4)
   // At each lattice vertex, connected dry tiles share one corner height.
   // Group by walkable edges, so a slope never develops a crack beside a cliff.
   for (let vz = 0; vz <= depth; vz++) for (let vx = 0; vx <= width; vx++) {
@@ -171,6 +175,46 @@ export function finishElevation(e: ElevationInfo, width: number, depth: number, 
       for (const p of group) e.corners[p.i * 4 + p.corner] = h
     }
   }
+}
+
+/**
+ * Cut and fill a purchased footprint at the height shown by its placement ghost.
+ * Pin every corner, including the perimeter: averaging tile heights alone would
+ * let the surrounding slope poke back through the floor. Unoccupied dry tiles
+ * sharing those corners meet the pad; existing foundations and water stay put.
+ * Adjacent buildings at different heights retain a small terrace between them.
+ */
+export function levelBuildingGround(map: GameMap, building: Pick<BuildingDef, "x" | "z" | "w" | "d">): ElevationInfo | undefined {
+  const original = map.elevation
+  if (!original) return undefined
+  const { x, z, w, d } = building
+  const foundation = groundHeight(map, x + (w - 1) / 2, z + (d - 1) / 2) - TILE_HEIGHT
+  const elevation = { ...original, height: [...original.height], corners: [...original.corners] }
+  const inside = (tx: number, tz: number) => tx >= x && tx < x + w && tz >= z && tz < z + d
+  const water = Uint8Array.from(map.tiles, (terrain, i) =>
+    (map.water ? map.water.depth[i] > 0 : terrain === "water" || terrain === "bridge") ? 1 : 0)
+  for (let tz = z; tz < z + d; tz++) for (let tx = x; tx < x + w; tx++) {
+    elevation.height[tz * map.width + tx] = foundation
+  }
+  for (let vz = z; vz <= z + d; vz++) for (let vx = x; vx <= x + w; vx++) {
+    const touching: Array<{ x: number; z: number; i: number; corner: number }> = []
+    for (let dz = -1; dz <= 0; dz++) for (let dx = -1; dx <= 0; dx++) {
+      const tx = vx + dx, tz = vz + dz
+      if (tx < 0 || tz < 0 || tx >= map.width || tz >= map.depth) continue
+      touching.push({ x: tx, z: tz, i: tz * map.width + tx, corner: (dx === -1 ? 1 : 0) + (dz === -1 ? 2 : 0) })
+    }
+    const sharedHeights = touching.filter((t) => inside(t.x, t.z)).map((t) => original.corners[t.i * 4 + t.corner])
+    for (const t of touching) {
+      if (water[t.i]) continue
+      if (!inside(t.x, t.z)) {
+        if (!sharedHeights.includes(original.corners[t.i * 4 + t.corner])) continue
+        if (map.buildings.some((b) => t.x >= b.x && t.x < b.x + b.w && t.z >= b.z && t.z < b.z + b.d)) continue
+      }
+      elevation.corners[t.i * 4 + t.corner] = foundation
+    }
+  }
+  updateElevationEdges(elevation, map.width, map.depth, water, map.water?.surface ?? original.height)
+  return elevation
 }
 
 export function elevationStep(e: ElevationInfo | undefined, a: number, b: number): number {

--- a/lib/game/settlement.test.ts
+++ b/lib/game/settlement.test.ts
@@ -1,5 +1,5 @@
 import { getBuildInfluence } from "./build-influence"
-import { DEFAULT_ELEVATION } from "./map/elevation"
+import { DEFAULT_ELEVATION, finishElevation, generateElevation, groundHeight } from "./map/elevation"
 import { describe, expect, it } from "vitest"
 import { generateMap } from "./map/generate-map"
 import type { GameMap } from "./map/types"
@@ -59,6 +59,37 @@ const shelter = BUILD_CATALOG.find((item) => item.id === "shelter")!
 const garden = BUILD_CATALOG.find((item) => item.id === "garden")!
 
 describe("build and buy", () => {
+  it("grades successful purchases cumulatively without editing terrain on rejected purchases", () => {
+    const map = testMap(), water = new Uint8Array(map.tiles.length)
+    map.elevation = generateElevation(1, map.width, map.depth, water)
+    map.elevation.height = map.elevation.height.map((_, i) => (i % map.width) * 0.025)
+    finishElevation(map.elevation, map.width, map.depth, water, [])
+    const original = structuredClone(map.elevation)
+    const before = { ...createSettlement(), resources: { gold: 1000, wood: 1000 } }
+    const at = { x: 11, z: 14 }
+    const previewHeight = groundHeight(map, at.x + (shelter.w - 1) / 2, at.z + (shelter.d - 1) / 2)
+    const first = purchaseStructure(before, map, monks, [relic], shelter.id, at)
+    expect(first.error).toBeNull()
+    const firstElevation = structuredClone(first.settlement.elevation!)
+    const second = purchaseStructure(first.settlement, map, monks, [relic], shelter.id, { x: 9, z: 14 })
+    expect(second.error).toBeNull()
+    expect(second.settlement.elevation).not.toBe(first.settlement.elevation)
+    for (const settlement of [first.settlement, second.settlement]) {
+      const placedMap = { ...map, elevation: settlement.elevation }
+      for (let z = at.z; z < at.z + shelter.d; z++) for (let x = at.x; x < at.x + shelter.w; x++) {
+        for (const dx of [-0.49, 0.49]) for (const dz of [-0.49, 0.49]) {
+          expect(groundHeight(placedMap, x + dx, z + dz)).toBeCloseTo(previewHeight)
+        }
+      }
+    }
+    const rejected = purchaseStructure(second.settlement, map, monks, [relic], shelter.id, at)
+    expect(rejected.error).toMatch(/occupies/)
+    expect(rejected.settlement).toBe(second.settlement)
+    expect(map.elevation).toEqual(original)
+    expect(first.settlement.elevation).toEqual(firstElevation)
+    expect(before.elevation).toBeUndefined()
+  })
+
   it.each(EARLY_BUILDINGS.filter((preset) => preset.id !== "enclosure"))(
     "buys $name with its playground geometry and reserves its full footprint", (preset) => {
       const def = BUILD_CATALOG.find((item) => item.id === preset.id)!

--- a/lib/game/settlement.ts
+++ b/lib/game/settlement.ts
@@ -1,4 +1,4 @@
-import { groundHeight } from "./map/elevation"
+import { groundHeight, levelBuildingGround } from "./map/elevation"
 import { placementProblem, PLACEMENT_PROBLEM_LABELS, type PlacedBuilding } from "./buildings"
 import { settlementRoute } from "./settlement-route"
 import { getBuildInfluence, type BuildInfluence } from "./build-influence"
@@ -22,6 +22,8 @@ export const STARTING_RESOURCES = {
 export const SETTLEMENT_RADIUS = DEFAULT_BALANCE.rules.buildRadius
 
 export interface Settlement {
+  /** Terrain after successful purchases; the generated base map stays immutable. */
+  elevation?: GameMap["elevation"]
   resources: Resources
   /** Cumulative harvest already credited; spending never credits it again. */
   deliveredWood: number
@@ -244,7 +246,7 @@ export function purchaseStructure(
 ): { settlement: Settlement; error: string | null } {
   const def = buildCatalog(balance).find((item) => item.id === type)
   if (!def) return { settlement, error: "Unknown structure." }
-  const map = { ...baseMap, buildings: [...baseMap.buildings, ...settlement.structures] }
+  const map = { ...baseMap, elevation: settlement.elevation ?? baseMap.elevation, buildings: [...baseMap.buildings, ...settlement.structures] }
   if (settlementRenown(map, residents, relics, balance, completedVisits).total < def.requiredRenown)
     return { settlement, error: `Requires ${def.requiredRenown} shrine renown.` }
   if (!canAfford(settlement.resources, def.cost))
@@ -266,6 +268,7 @@ export function purchaseStructure(
   return {
     settlement: {
       ...settlement,
+      elevation: levelBuildingGround(map, building),
       spentWood: settlement.spentWood + def.cost.wood,
       resources: {
         gold: settlement.resources.gold - def.cost.gold,


### PR DESCRIPTION
Placing a building now levels the soil across its full footprint, including perimeter corners, so sloping ground no longer intersects its floor.
Successful purchases retain the graded elevation for rendering, movement, and subsequent placement checks while preserving existing foundations, water, dry bridge footings, and the original map.
Type checking and new regression tests for level ground contacts, adjacent foundations, map edges, and rejected purchases passed; shelters and lumber yards were also verified in-game in rotated and selected views beside monks.
The full suite recorded 630 passes and 10 timeouts: character and geometry cases passed on isolated reruns, but some generated-map tests still time out.
