### PR TITLE
Make early shrine visits harder and balance needs around five-minute days

### DIFF
--- a/lib/game/balance.test.ts
+++ b/lib/game/balance.test.ts
@@ -56,6 +56,8 @@ describe("balance presets", () => {
   it("migrates earlier version 1 presets without losing edits", () => {
     const old = JSON.parse(exportBalance(DEFAULT_BALANCE))
     delete old.balance.rules.visitRenown
+    for (const key of ["hospitalityBaseChance", "hungerDecay", "thirstDecay", "staminaDecay"])
+      delete old.balance.rules[key]
     delete old.balance.buildings.lumberCamp
     for (const id of ["monk-shelter", "shepherd-hut", "storehouse", "wood-shelter"]) delete old.balance.buildings[id]
     old.balance.rules.startingGold = 321
@@ -65,6 +67,8 @@ describe("balance presets", () => {
     expect(result.balance?.rules.startingGold).toBe(321)
     expect(result.balance?.buildings.shelter.goldCost).toBe(17)
     expect(result.balance?.rules.visitRenown).toBe(0.5)
+    for (const key of ["hospitalityBaseChance", "hungerDecay", "thirstDecay", "staminaDecay"] as const)
+      expect(result.balance?.rules[key]).toBe(DEFAULT_BALANCE.rules[key])
     expect(result.balance?.buildings.lumberCamp).toEqual(DEFAULT_BALANCE.buildings.lumberCamp)
     for (const id of ["monk-shelter", "shepherd-hut", "storehouse", "wood-shelter"] as const)
       expect(result.balance?.buildings[id]).toEqual(DEFAULT_BALANCE.buildings[id])
@@ -82,6 +86,19 @@ describe("balance presets", () => {
     expect(validateBalance({ rules: {}, buildings: {} }).balance).toBeNull()
     expect(importBalance('{"version":2}').error).toMatch(/version/)
     expect(importBalance("oops").error).toMatch(/JSON/)
+  })
+  it("preserves custom needs and hospitality settings and rejects invalid values", () => {
+    const balance = fresh()
+    balance.rules.hospitalityBaseChance = 0.35
+    balance.rules.hungerDecay = 0
+    balance.rules.thirstDecay = 2.5
+    balance.rules.staminaDecay = 7
+    expect(importBalance(exportBalance(balance)).balance).toEqual(balance)
+    balance.rules.hospitalityBaseChance = 1.1
+    expect(importBalance(exportBalance(balance)).balance).toBeNull()
+    balance.rules.hospitalityBaseChance = 0.35
+    balance.rules.thirstDecay = -1
+    expect(importBalance(exportBalance(balance)).balance).toBeNull()
   })
   it("rejects zero divisors, sub-second timers and unordered tiers", () => {
     for (const key of ["pietyDivisor", "relicDivisor", "drawCap", "incomeSeconds"] as const) {

--- a/lib/game/balance.ts
+++ b/lib/game/balance.ts
@@ -131,6 +131,7 @@ export const RULE_GROUPS = [
   "Relic renown",
   "Progression",
   "Traveler attraction",
+  "Traveler needs",
 ] as const
 export const RULE_FIELDS = [
   {
@@ -325,7 +326,7 @@ export const RULE_FIELDS = [
     group: "Traveler attraction",
     label: "Base draw multiplier",
     description: "Multiplier for a shrine with zero renown.",
-    default: 0.75,
+    default: 0.5,
     min: 0,
     max: 5,
     step: 0.01,
@@ -335,7 +336,7 @@ export const RULE_FIELDS = [
     group: "Traveler attraction",
     label: "Maximum renown draw bonus",
     description: "Added to the base multiplier once renown reaches the draw cap.",
-    default: 0.5,
+    default: 0.75,
     min: 0,
     max: 5,
     step: 0.01,
@@ -344,7 +345,7 @@ export const RULE_FIELDS = [
     key: "drawCap",
     group: "Traveler attraction",
     label: "Renown draw cap",
-    description: "Renown above this still counts for progression but adds no further attraction.",
+    description: "Renown at which relic attraction and hospitality reach their full strength. Higher renown still counts for progression.",
     default: 100,
     min: 1,
     max: 100000,
@@ -359,6 +360,26 @@ export const RULE_FIELDS = [
     min: 0,
     max: 1000,
     step: 1,
+  },
+  {
+    key: "hospitalityBaseChance", group: "Traveler attraction", label: "Hospitality chance at zero renown",
+    description: "Maximum chance of visiting for food, drink or rest at an unknown shrine. Scales up to 100% at the renown draw cap; needs below 60 increase the pull, reaching its maximum at 20.",
+    default: 0.1, min: 0, max: 1, step: 0.01,
+  },
+  {
+    key: "hungerDecay", group: "Traveler needs", label: "Hunger drain per game hour",
+    description: "Fullness lost per game hour. Default: hungry every 8 hours, or three full bars per day. Camping halves this rate; shrine hospitality restores it.",
+    default: 12.5, min: 0, max: 50, step: 0.1,
+  },
+  {
+    key: "thirstDecay", group: "Traveler needs", label: "Thirst drain per game hour",
+    description: "Hydration lost per game hour. Default: thirsty every 4 hours, or six full bars per day. Camping halves this rate; shrine hospitality restores it.",
+    default: 25, min: 0, max: 50, step: 0.1,
+  },
+  {
+    key: "staminaDecay", group: "Traveler needs", label: "Stamina drain per game hour",
+    description: "Energy lost per game hour. Default: exhausted after about 24 hours. Camping restores stamina and tending a parked stall holds it steady; drinking does not restore energy.",
+    default: 4.2, min: 0, max: 50, step: 0.1,
   },
 ] as const
 export type RuleKey = (typeof RULE_FIELDS)[number]["key"]
@@ -534,7 +555,14 @@ export function importBalance(json: string): ReturnType<typeof validateBalance> 
     const buildings = record(saved?.buildings)
     return validateBalance(saved && rules && buildings ? {
       ...saved,
-      rules: { visitRenown: DEFAULT_BALANCE.rules.visitRenown, ...rules },
+      rules: {
+        visitRenown: DEFAULT_BALANCE.rules.visitRenown,
+        hospitalityBaseChance: DEFAULT_BALANCE.rules.hospitalityBaseChance,
+        hungerDecay: DEFAULT_BALANCE.rules.hungerDecay,
+        thirstDecay: DEFAULT_BALANCE.rules.thirstDecay,
+        staminaDecay: DEFAULT_BALANCE.rules.staminaDecay,
+        ...rules,
+      },
       buildings: {
         lumberCamp: DEFAULT_BALANCE.buildings.lumberCamp,
         ...Object.fromEntries(EARLY_BUILDINGS.filter((preset) => preset.id !== "enclosure")

--- a/lib/game/hospitality.test.ts
+++ b/lib/game/hospitality.test.ts
@@ -10,7 +10,7 @@ import { generateMap } from "./map/generate-map"
 import { TILE_HEIGHT, type TerrainId } from "./map/terrain"
 import { tileToWorldX, tileToWorldZ, worldToTileX, worldToTileZ, type GameMap } from "./map/types"
 import { generateRelic, visitChance } from "./relic"
-import { createSim, stepSim, type SimState } from "./sim"
+import { createSim, stepSim, GAME_DAY_SECONDS, type SimState } from "./sim"
 import { DEFAULT_MOVEMENT, LINEAR_MOVEMENT } from "./motion"
 import { generateTravelers, TRAVELER_TYPES, type Traveler } from "./travelers"
 import { treeResource, treeStage, STUMP_LIFETIME_DAYS, TIMBER_LOAD, stackWood, type WoodPile } from "./trees/timber"
@@ -46,7 +46,36 @@ function run(sim: SimState, travelers: Traveler[], map: GameMap, seconds: number
 
 const obscure = { sanctity: 0, spectacle: 0, doubt: 100 }
 
+/** Established hospitality isolates the visit lifecycle from attraction rolls. */
+function createEstablishedShrine(travelers: Traveler[], map: GameMap) {
+  const sim = createSim(travelers, map, [], obscure)
+  sim.shrineRenown = sim.balance.rules.drawCap
+  return sim
+}
+
 describe("shrine hospitality", () => {
+  it("earns more junction visits through shrine renown and completed visits", () => {
+    const accepted = (renown: number, visits: number) => {
+      let count = 0
+      for (let id = 0; id < 40; id++) {
+        const { map, traveler } = fixture()
+        const t = traveler(id, id % 2 === 0 ? 1 : -1)
+        t.attributes.hunger = 20
+        const sim = createSim([t], map, [], obscure)
+        sim.shrineRenown = renown
+        sim.visits = visits
+        run(sim, [t], map, 1)
+        if (sim.travelers.get(id)!.activity === "toRelic") count++
+      }
+      return count
+    }
+    const early = accepted(0, 0)
+    expect(early).toBeGreaterThan(0)
+    expect(early).toBeLessThan(12)
+    expect(accepted(DEFAULT_BALANCE.rules.drawCap, 0)).toBe(40)
+    expect(accepted(0, DEFAULT_BALANCE.rules.drawCap / DEFAULT_BALANCE.rules.visitRenown)).toBe(40)
+  })
+
   it.each([0, 1, 2, 3])("enters gate %i, faces the relic, pays once and walks back out", (id) => {
     const { map, traveler } = fixture()
     const shrine = map.buildings[0]
@@ -54,7 +83,7 @@ describe("shrine hospitality", () => {
     const t = traveler(id)
     t.attributes.gold = 10
     t.attributes.hunger = 0
-    const sim = createSim([t], map, [], obscure)
+    const sim = createEstablishedShrine([t], map)
     const s = sim.travelers.get(id)!
     const route = shrineVisitRoute(map, id, 0)!
     expect(route.at(-1)).toEqual(shrineGates(shrine)[id].inside)
@@ -92,7 +121,7 @@ describe("shrine hospitality", () => {
     const t = traveler(0)
     t.attributes.gold = 2
     t.attributes.hunger = 30
-    const sim = createSim([t], map, [], obscure)
+    const sim = createEstablishedShrine([t], map)
     const s = sim.travelers.get(0)!
     run(sim, [t], map, 1)
     expect(s.activity).toBe("walking")
@@ -136,7 +165,7 @@ describe("shrine hospitality", () => {
     t.attributes.gold = 10
     t.attributes.hunger = 0
     map.buildings[0].admissionFee = 3
-    const sim = createSim([t], map, [], obscure), s = sim.travelers.get(0)!
+    const sim = createEstablishedShrine([t], map), s = sim.travelers.get(0)!
     run(sim, [t], map, 60, () => s.activity === "fromRelic")
     const paidPiety = s.piety
     expect(paidPiety).toBeGreaterThan(0)
@@ -155,7 +184,7 @@ describe("shrine hospitality", () => {
   it.each([LINEAR_MOVEMENT, DEFAULT_MOVEMENT])("keeps shrine visitors on opposite sides in both directions (%j)", (movement) => {
     const { map, traveler } = fixture()
     const travelers = [traveler(0), traveler(1)]
-    const sim = createSim(travelers, map, [], obscure)
+    const sim = createEstablishedShrine(travelers, map)
     for (const [index, s] of [...sim.travelers.values()].entries()) {
       s.activity = index === 0 ? "toRelic" : "fromRelic"
       s.branchProgress = 2
@@ -174,11 +203,11 @@ describe("shrine hospitality", () => {
     const { map, traveler } = fixture()
     const t = traveler(0, direction)
     t.attributes.hunger = 0
-    const sim = createSim([t], map, [], obscure)
+    const sim = createEstablishedShrine([t], map)
     const s = sim.travelers.get(0)!
     let returning = false
     let rejoined = false
-    for (let tick = 0; tick < 6000; tick++) {
+    for (let tick = 0; tick < GAME_DAY_SECONDS / 2 / 0.01; tick++) {
       const before = { x: s.x, z: s.z }
       stepSim(sim, [t], map, 1, 0.01, DEFAULT_MOVEMENT)
       expect(Math.hypot(s.x - before.x, s.z - before.z)).toBeLessThan(0.025)
@@ -201,7 +230,7 @@ describe("shrine hospitality", () => {
         const { map, traveler } = fixture()
         const t = traveler(0, direction)
         t.attributes[need] = 0
-        const sim = createSim([t], map, [], obscure)
+        const sim = createEstablishedShrine([t], map)
         const s = sim.travelers.get(t.id)!
         const identity = structuredClone(t)
         run(sim, [t], map, 1)
@@ -230,17 +259,18 @@ describe("shrine hospitality", () => {
     const t = traveler(0)
     t.offset = 8.5 / 29
     t.attributes.hunger = 0
-    const sim = createSim([t], map)
+    const sim = createEstablishedShrine([t], map)
     stepSim(sim, [t], map, 5, 1)
     expect(sim.travelers.get(0)!.activity).toBe("toRelic")
   })
 
-  it("keeps faith relevant for rested travelers and makes dire need certain", () => {
+  it("keeps faith relevant and reserves certain hospitality visits for established shrines", () => {
     const { traveler } = fixture()
     const a = traveler(0).attributes
     const holy = { sanctity: 95, spectacle: 40, doubt: 15 }
     expect(visitChance({ ...a, piety: 100 }, holy)).toBeGreaterThan(visitChance(a, holy))
-    expect(visitChance({ ...a, hunger: 0 }, obscure)).toBe(1)
+    expect(visitChance({ ...a, hunger: 0 }, obscure)).toBe(0.1)
+    expect(visitChance({ ...a, hunger: 0 }, obscure, DEFAULT_BALANCE.rules.drawCap)).toBe(1)
     expect(visitChance({ ...a, thirst: 35 }, obscure)).toBeGreaterThan(visitChance(a, obscure))
   })
 
@@ -293,7 +323,7 @@ describe("lumber camps", () => {
         expect(s.activity).toBe("toWork")
         expect(Math.min(s.hunger, s.thirst, s.stamina)).toBeGreaterThanOrEqual(80)
       }
-      run(sim, [t], map, 30, () => sim.wood > TIMBER_LOAD)
+      run(sim, [t], map, GAME_DAY_SECONDS / 4, () => sim.wood > TIMBER_LOAD)
       expect(sim.wood).toBe(2 * TIMBER_LOAD)
       expect(resource.remainingWood + s.carrying + sim.wood).toBe(resource.wood)
     },
@@ -416,7 +446,7 @@ describe("lumber camps", () => {
     let sawHauling = false
     const expectedWood = trees.reduce((sum, tree, index) => sum + treeResource(tree, index, map.seed).wood, 0)
     // Taller trunks need more hauling trips; wait for delivery within a bounded run.
-    for (let i = 0; i < 12000 && sim.wood < expectedWood; i++) {
+    for (let i = 0; i < 10 * GAME_DAY_SECONDS / 0.1 && sim.wood < expectedWood; i++) {
       stepSim(sim, travelers, map, 1.5, 0.1)
       const workers = Array.from(sim.travelers.values()).filter((s) => s.employer)
       maxWorkers = Math.max(maxWorkers, workers.length)
@@ -528,13 +558,13 @@ describe("tree resources and timber storage", () => {
     expect(resource.health).toBeLessThan(resource.maxHealth)
     expect(treeStage(resource, sim.time)).toBe("Being felled")
     expect(sim.felled.size).toBe(0)
-    run(sim, [t], map, 120, () => s.activity === "gathering")
+    run(sim, [t], map, GAME_DAY_SECONDS, () => s.activity === "gathering")
     expect(resource.health).toBe(0)
     expect(treeStage(resource, sim.time)).toBe("Fallen")
     expect(resource.stumpUntil! - resource.felledAt!).toBeCloseTo(STUMP_LIFETIME_DAYS)
     expect(resource.remainingWood).toBe(resource.wood)
     expect(sim.piles.size).toBe(0)
-    run(sim, [t], map, 10, () => s.carrying > 0)
+    run(sim, [t], map, GAME_DAY_SECONDS / 12, () => s.carrying > 0)
     expect(s.carrying).toBe(TIMBER_LOAD)
     const departure = { x: s.x, z: s.z }
     stepSim(sim, [t], map, 1.5, 0)
@@ -549,7 +579,7 @@ describe("tree resources and timber storage", () => {
     expect(s.x).toBeLessThan(tileToWorldX(map, camp.x + camp.w))
     expect(s.z).toBeGreaterThanOrEqual(tileToWorldZ(map, camp.z))
     expect(s.z).toBeLessThan(tileToWorldZ(map, camp.z + camp.d))
-    for (let i = 0; i < 2000; i++) {
+    for (let i = 0; i < 2 * GAME_DAY_SECONDS / 0.1 && sim.wood < resource.wood; i++) {
       stepSim(sim, [t], map, 1.5, 0.1)
       expect(resource.remainingWood + s.carrying + sim.wood).toBe(resource.wood)
     }

--- a/lib/game/relic.test.ts
+++ b/lib/game/relic.test.ts
@@ -8,7 +8,9 @@ import {
   relicTitle,
   TURN_ASIDE_DRAW,
   turnsAside,
+  visitChance,
 } from "./relic"
+import { DEFAULT_BALANCE } from "./balance"
 import { generateTravelers, TRAVELER_TYPES, type Traveler, type TravelerAttributes } from "./travelers"
 
 const who = (piety: number, status: number): TravelerAttributes => ({
@@ -26,6 +28,36 @@ const who = (piety: number, status: number): TravelerAttributes => ({
 describe("relic draw", () => {
   const holy = { sanctity: 95, spectacle: 40, doubt: 15 }
   const dubious = { sanctity: 30, spectacle: 95, doubt: 90 }
+
+  it.each(["hunger", "thirst", "stamina"] as const)("requires a reputation for reliable hospitality when %s is empty", (need) => {
+    const traveler = { ...who(0, 100), hunger: 100, thirst: 100, stamina: 100, [need]: 0 }
+    const obscure = { sanctity: 0, spectacle: 0, doubt: 100 }
+    expect(visitChance(traveler, obscure, 0)).toBeCloseTo(0.1)
+    expect(visitChance(traveler, obscure, 10)).toBeCloseTo(0.19)
+    expect(visitChance(traveler, obscure, 50)).toBeCloseTo(0.55)
+    expect(visitChance(traveler, obscure, 100)).toBe(1)
+    expect(visitChance(traveler, obscure, 200)).toBe(1)
+    expect(visitChance(traveler, obscure, -100)).toBeCloseTo(0.1)
+    const balance = structuredClone(DEFAULT_BALANCE)
+    balance.rules.hospitalityBaseChance = 0.2
+    balance.rules.drawCap = 200
+    expect(visitChance(traveler, obscure, 100, balance)).toBeCloseTo(0.6)
+  })
+
+  it("starts with a minority of visitors and attracts a wider crowd as renown grows", () => {
+    let early = 0, established = 0, count = 0
+    for (let seed = 1; seed <= 20; seed++) {
+      const relic = generateRelic(seed)
+      for (const traveler of generateTravelers(seed, 60)) {
+        early += visitChance(traveler.attributes, relic.stats, 10)
+        established += visitChance(traveler.attributes, relic.stats, 100)
+        count++
+      }
+    }
+    expect(early / count).toBeGreaterThan(0.05)
+    expect(early / count).toBeLessThan(0.25)
+    expect(established).toBeGreaterThan(early * 2)
+  })
 
   it("pulls the devout harder toward a holy relic than the worldly", () => {
     expect(relicDraw(who(100, 20), holy, 10)).toBeGreaterThan(relicDraw(who(20, 20), holy, 10))

--- a/lib/game/relic.ts
+++ b/lib/game/relic.ts
@@ -133,16 +133,19 @@ export const TURN_ASIDE_DRAW = (VISIT_DRAW_FLOOR + VISIT_DRAW_CEILING) / 2
 /**
  * The chance, 0–1, that this traveler turns down the branch when they reach
  * the junction. A chance rather than a threshold so the road's ordinary folk
- * still wander in now and then, while the devout all but always do. The sim
+ * still wander in now and then, while the devout favor a renowned shrine. The sim
  * rolls it (see sim.ts); the HUD's forecast rounds it.
  */
 export function visitChance(who: TravelerAttributes, stats: RelicStats, shrineRenown = 0, balance: GameBalance = DEFAULT_BALANCE): number {
   const draw = relicDraw(who, stats, shrineRenown, balance)
   const devotion = Math.max(0, Math.min(1, (draw - (balance.rules.turnAsideDraw - 25)) / 50))
-  // These are fullness/energy meters: low values mean greater need. Hospitality
-  // is known at the junction even when the relic itself is obscure.
+  // These are fullness/energy meters: low values mean greater need. Word of
+  // mouth must establish hospitality before it reliably pulls people in.
   const need = Math.min(who.hunger, who.thirst, who.stamina)
-  const hospitality = Math.max(0, Math.min(1, (60 - need) / 40))
+  const r = balance.rules
+  const reputation = Math.min(r.drawCap, Math.max(0, shrineRenown)) / r.drawCap
+  const hospitalityReach = r.hospitalityBaseChance + (1 - r.hospitalityBaseChance) * reputation
+  const hospitality = Math.max(0, Math.min(1, (60 - need) / 40)) * hospitalityReach
   return Math.max(devotion, hospitality)
 }
 

--- a/lib/game/sim.test.ts
+++ b/lib/game/sim.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest"
+import { DEFAULT_BALANCE } from "./balance"
+import { SIMULATION_SPEEDS } from "./simulation-store"
 
 import { DEFAULT_MOVEMENT, LINEAR_MOVEMENT } from "./motion"
 import { BRIDGE_RISE } from "./map/bridges"
@@ -12,7 +14,6 @@ import {
   formatGameTime,
   stepSim,
   WINE_PRICE,
-  WINE_STAMINA_BONUS,
   type SimState,
 } from "./sim"
 import {
@@ -124,6 +125,10 @@ function runUntil(
 }
 
 describe("game time", () => {
+  it("lasts five real minutes at the displayed normal speed", () => {
+    const normal = SIMULATION_SPEEDS.find(speed => speed.label === 1)!
+    expect(GAME_DAY_SECONDS / normal.rate).toBe(300)
+  })
   it("advances with real time at the configured day length", () => {
     const map = makeMap()
     const travelers = [makeTraveler(0, "knight")]
@@ -140,6 +145,45 @@ describe("game time", () => {
 })
 
 describe("stepSim", () => {
+  it("uses live needs tuning for walkers and keeps camping's reduced drain", () => {
+    const map = makeMap()
+    const travelers = [makeTraveler(0, "knight")]
+    const sim = createSim(travelers, map)
+    sim.balance = structuredClone(DEFAULT_BALANCE)
+    const s = sim.travelers.get(0)!
+    const hour = GAME_DAY_SECONDS / 24
+    stepSim(sim, travelers, map, 1, hour)
+    expect([s.hunger, s.thirst, s.stamina]).toEqual([67.5, 55, 75.8])
+
+    Object.assign(sim.balance.rules, { hungerDecay: 2, thirstDecay: 6, staminaDecay: 0 })
+    stepSim(sim, travelers, map, 1, hour)
+    expect([s.hunger, s.thirst, s.stamina]).toEqual([65.5, 49, 75.8])
+
+    s.activity = "camping"
+    s.stamina = 0
+    stepSim(sim, travelers, map, 1, hour)
+    expect([s.hunger, s.thirst, s.stamina]).toEqual([64.5, 46, 60])
+  })
+
+  it("uses three full hunger bars, six thirst bars and one stamina bar per active day", () => {
+    const map = makeMap()
+    const travelers = [makeTraveler(0, "knight", { hunger: 100, thirst: 100, stamina: 100 })]
+    const sim = createSim(travelers, map)
+    const s = sim.travelers.get(0)!
+    const depleted = { hunger: 0, thirst: 0, stamina: 0 }
+    for (let elapsed = 0; elapsed < GAME_DAY_SECONDS; elapsed += 0.25) {
+      stepSim(sim, travelers, map, 1, 0.25)
+      for (const need of ["hunger", "thirst", "stamina"] as const) {
+        if (s[need] > 0) continue
+        depleted[need]++
+        s[need] = 100 // Immediate replenishment measures the active-day baseline.
+        s.activity = "walking"
+      }
+    }
+    expect(depleted).toEqual({ hunger: 3, thirst: 6, stamina: 1 })
+    expect(sim.time).toBeCloseTo(1.25)
+  })
+
   it("wears travelers down as they walk", () => {
     const map = makeMap()
     const travelers = [makeTraveler(0, "knight")]
@@ -170,7 +214,7 @@ describe("stepSim", () => {
     stepSim(sim, travelers, map, 1, 0.5)
     expect(s.stamina).toBeGreaterThan(staminaAsleep)
 
-    expect(runUntil(sim, travelers, map, () => s.activity === "walking", 30)).toBe(true)
+    expect(runUntil(sim, travelers, map, () => s.activity === "walking", GAME_DAY_SECONDS / 4)).toBe(true)
     expect(s.stamina).toBeGreaterThan(90)
     expect(s.spot).toBeNull()
     expect(s.z).toBeCloseTo(tileToWorldZ(map, 4) - s.laneOffset)
@@ -244,10 +288,10 @@ describe("stepSim", () => {
     expect(buyer.activity).toBe("walking")
   })
 
-  it("wine refills thirst and restores some stamina", () => {
+  it("wine refills thirst without replacing sleep or buying a half-full meal", () => {
     const map = makeMap()
     const travelers = [
-      makeTraveler(0, "minstrel", { thirst: 0.1, hunger: 100, stamina: 50, gold: 10 }, 0.5),
+      makeTraveler(0, "minstrel", { thirst: 0.1, hunger: 50, stamina: 50, gold: 10 }, 0.5),
       makeTraveler(1, "vendor", { gold: 0 }, 0.5),
     ]
     const sim = createSim(travelers, map)
@@ -257,8 +301,31 @@ describe("stepSim", () => {
     expect(runUntil(sim, travelers, map, () => buyer.thirst > 50, 10)).toBe(true)
     expect(buyer.gold).toBe(10 - WINE_PRICE)
     expect(vendor.gold).toBe(WINE_PRICE)
-    // Roughly the bonus over where they were, less a moment of walking decay.
-    expect(buyer.stamina).toBeGreaterThan(50 + WINE_STAMINA_BONUS - 5)
+    expect(buyer.stamina).toBeLessThan(50)
+    expect(buyer.hunger).toBeLessThan(50)
+  })
+
+  it("buys three meals and six drinks over a day with a vendor immediately available", () => {
+    const map = makeMap()
+    const travelers = [
+      makeTraveler(0, "pilgrim", { hunger: 100, thirst: 100, gold: 100 }),
+      makeTraveler(1, "vendor", { gold: 0 }),
+    ]
+    const sim = createSim(travelers, map)
+    sim.balance = structuredClone(DEFAULT_BALANCE)
+    sim.balance.rules.staminaDecay = 0 // Isolate food and drink from sleep.
+    const buyer = sim.travelers.get(0)!, vendor = sim.travelers.get(1)!
+    vendor.timer = GAME_DAY_SECONDS + 1
+    let meals = 0, drinks = 0
+    for (let elapsed = 0; elapsed < GAME_DAY_SECONDS; elapsed += 0.25) {
+      const { hunger, thirst } = buyer
+      stepSim(sim, travelers, map, 0, 0.25)
+      if (buyer.hunger > hunger) meals++
+      if (buyer.thirst > thirst) drinks++
+    }
+    expect({ meals, drinks }).toEqual({ meals: 3, drinks: 6 })
+    expect(buyer.gold).toBe(100 - 3 * FOOD_PRICE - 6 * WINE_PRICE)
+    expect(vendor.gold).toBe(3 * FOOD_PRICE + 6 * WINE_PRICE)
   })
 
   it("chases down a vendor further along the road", () => {
@@ -280,7 +347,7 @@ describe("stepSim", () => {
     const sim = createSim(travelers, map)
     const s = sim.travelers.get(1)!
 
-    expect(runUntil(sim, travelers, map, () => s.activity === "vending", 60)).toBe(true)
+    expect(runUntil(sim, travelers, map, () => s.activity === "vending", GAME_DAY_SECONDS / 2)).toBe(true)
     // The stall stands on a clearing, off the road.
     const terrain = tileAt(map, worldToTileX(map, s.spot!.x), worldToTileZ(map, s.spot!.z))
     expect(["grass", "dirt", "clearing"]).toContain(terrain)
@@ -291,7 +358,7 @@ describe("stepSim", () => {
     expect(s.x).toBe(parkedX)
     expect(s.z).toBe(parkedZ)
 
-    expect(runUntil(sim, travelers, map, () => s.activity === "walking", 40)).toBe(true)
+    expect(runUntil(sim, travelers, map, () => s.activity === "walking", GAME_DAY_SECONDS / 3)).toBe(true)
     expect(s.spot).toBeNull()
     expect(
       runUntil(sim, travelers, map, () => Math.hypot(s.x - parkedX, s.z - parkedZ) > 1, 10),
@@ -557,7 +624,7 @@ describe("danger on the road", () => {
     expect(sawFleeing).toBe(true)
     expect(s.direction).toBe(-1)
     // The fright wears off and they walk on — in the new direction.
-    expect(runUntil(sim, travelers, map, () => s.activity === "walking", 30)).toBe(true)
+    expect(runUntil(sim, travelers, map, () => s.activity === "walking", GAME_DAY_SECONDS / 4)).toBe(true)
     expect(s.direction).toBe(-1)
   })
 

--- a/lib/game/sim.ts
+++ b/lib/game/sim.ts
@@ -53,7 +53,7 @@ import type { Traveler } from "./travelers"
  *    the favourite pitch for anyone; pilgrims will otherwise join an existing
  *    camp rather than camp alone.
  *  - Hunger or thirst at 0 → chase down a vendor and buy: food refills hunger,
- *    wine refills thirst and some stamina. Gold changes hands.
+ *    wine refills thirst. Energy returns through rest. Gold changes hands.
  *  - Vendors walk a stretch, then pull the cart off to the side of the path and
  *    keep shop for a few hours before moving on. They eat their own stock free.
  *  - Danger (see map/danger.ts) is met tile by tile: each new tile rolls for
@@ -116,8 +116,10 @@ export const ACTIVITY_LABELS: Record<Activity, string> = {
 
 // --- Game time ---------------------------------------------------------------
 
-/** Real seconds per game day; the one knob that scales the whole rhythm. */
-export const GAME_DAY_SECONDS = 120
+/** Simulation seconds per day: 5 real minutes at the HUD's 1× (2 sim seconds/real second).
+ * Roughly one uninterrupted walk along a generated 128×128 map's winding road.
+ */
+export const GAME_DAY_SECONDS = 600
 const GAME_HOUR_SECONDS = GAME_DAY_SECONDS / 24
 
 /** The sim opens at dawn on day one. */
@@ -133,21 +135,17 @@ export function formatGameTime(time: number): string {
 }
 
 // --- Tuning ------------------------------------------------------------------
-// Need rates are per game hour: a rested traveler walks dry in well under a
-// day, and a camp is a few hours' rest — watchable at the default day length.
+// Need rates are per game hour and read from the live balance below. A camp
+// is a few hours' rest — watchable at the default day length.
 
-export const STAMINA_DECAY = 6
-export const HUNGER_DECAY = 8
-export const THIRST_DECAY = 10
 export const CAMP_STAMINA_REGEN = 60
 /** Resting slows the need for food and drink but doesn't stop it. */
 const CAMP_NEED_FACTOR = 0.5
 
 export const FOOD_PRICE = 2
 export const WINE_PRICE = 3
-export const WINE_STAMINA_BONUS = 25
-/** At the vendor, top up any need at or below this — not just the empty one. */
-const BUY_THRESHOLD = 50
+/** Top up near-empty needs, so each drink doesn't also become a half-full meal. */
+const BUY_THRESHOLD = 10
 /** Close enough to trade, in tiles; a parked stall serves a wider reach. */
 const TRADE_RANGE = 1.2
 const STALL_TRADE_RANGE = 2.6
@@ -814,12 +812,12 @@ export function stepSim(
 
     // --- Needs march on ------------------------------------------------------
     const needFactor = camping ? CAMP_NEED_FACTOR : 1
-    s.hunger = Math.max(0, s.hunger - HUNGER_DECAY * needFactor * hours)
-    s.thirst = Math.max(0, s.thirst - THIRST_DECAY * needFactor * hours)
+    s.hunger = Math.max(0, s.hunger - sim.balance.rules.hungerDecay * needFactor * hours)
+    s.thirst = Math.max(0, s.thirst - sim.balance.rules.thirstDecay * needFactor * hours)
     if (camping) s.stamina = Math.min(100, s.stamina + CAMP_STAMINA_REGEN * hours)
     // Minding a parked stall neither drains nor restores the legs.
     else if (s.activity !== "vending") {
-      s.stamina = Math.max(0, s.stamina - STAMINA_DECAY * hours)
+      s.stamina = Math.max(0, s.stamina - sim.balance.rules.staminaDecay * hours)
     }
 
     if (sheltered) {
@@ -833,7 +831,6 @@ export function stepSim(
       if (s.hunger <= 0) s.hunger = 100
       if (s.thirst <= 0) {
         s.thirst = 100
-        s.stamina = Math.min(100, s.stamina + WINE_STAMINA_BONUS)
       }
     }
 
@@ -1015,7 +1012,6 @@ export function stepSim(
               if (s.thirst <= BUY_THRESHOLD) {
                 pay(s, vendor, WINE_PRICE)
                 s.thirst = 100
-                s.stamina = Math.min(100, s.stamina + WINE_STAMINA_BONUS)
               }
               s.activity = "walking"
               s.targetId = null
@@ -1124,7 +1120,7 @@ export function stepSim(
         if (s.timer === 0 || !vendor || vendor.activity !== "vending") {
           if (vendor?.activity === "vending") {
             if (s.hunger <= BUY_THRESHOLD) { pay(s, vendor, FOOD_PRICE); s.hunger = 100 }
-            if (s.thirst <= BUY_THRESHOLD) { pay(s, vendor, WINE_PRICE); s.thirst = 100; s.stamina = Math.min(100, s.stamina + WINE_STAMINA_BONUS) }
+            if (s.thirst <= BUY_THRESHOLD) { pay(s, vendor, WINE_PRICE); s.thirst = 100 }
           }
           startCustomerWalk(s, "fromStall")
         }

--- a/lib/game/travelers.ts
+++ b/lib/game/travelers.ts
@@ -194,7 +194,7 @@ export interface TravelerAttributes {
   gold: number
   /** Social standing, 0–100. */
   status: number
-  /** Needs, 0–100 — higher means more in need. */
+  /** Fullness and hydration, 0–100 — lower means more in need. */
   hunger: number
   thirst: number
   /** Devotion, 0–100. */


### PR DESCRIPTION
Reduce early relic attraction and scale hospitality from a 10% chance at zero renown to full strength at 100 renown, so unknown shrines must earn their visitors.

Set days to five real minutes at displayed 1×, approximately a 128×128 road crossing, with baseline hunger three times daily, thirst six times daily and exhaustion about once daily; drinking no longer restores stamina, purchases only top up nearly empty needs, and game-hour work and rest schedules follow the longer day.

Expose hospitality and drain rates in the existing tuning editor, preserve saved preset values while supplying new defaults, clarify meter semantics, and extend regression coverage for attraction, daily needs, trading and timed activities.

Validation: 137 targeted tests and TypeScript pass; an earlier full-suite run hit five map-generation timeouts, with the bridge and elevation tests passing isolated reruns.
