### PR TITLE
Reduce early shrine detours and slow traveler needs

### DIFF
--- a/app/docs/game-specs/page.tsx
+++ b/app/docs/game-specs/page.tsx
@@ -188,13 +188,24 @@ export default function GameSpecsPage() {
         </p>
         <p className="mt-3">
           Defaults range from ×{r.drawBase} at zero renown to ×{r.drawBase + r.drawBonus} at{" "}
-          {r.drawCap} renown. A rested traveler has a 50% visit chance at a draw of {r.turnAsideDraw};
-          the chance rises linearly from 0 to 100% across scores {r.turnAsideDraw - 25}–{r.turnAsideDraw + 25}.
-          Hunger, thirst or exhaustion can increase that chance, and available work gives eligible
-          jobless travelers at least an 80% chance. The simulation rolls at the junction and routes
-          visitors to the shrine for food, rest and blessings. The HUD rounds the sum of faith and
-          hospitality chances as its forecast; actual visits also depend on changing needs and jobs.
+          {r.drawCap} renown. The faith chance rises linearly from 0 to 100% across draw scores{" "}
+          {r.turnAsideDraw - 25}–{r.turnAsideDraw + 25}, then scales by willingness to detour.
+          At zero renown, willingness starts above {r.earlyVisitPiety} piety and reaches full strength
+          at 100. Let q = (clamp(renown, 0, draw cap) ÷ draw cap)²: renown adds 100 × q to effective
+          piety before willingness is calculated.
+        </p>
+        <p className="mt-3">
+          Hospitality requires fullness or hydration below {r.hospitalityNeedThreshold} + (60 −{" "}
+          {r.hospitalityNeedThreshold}) × q. Its chance grows from zero at that threshold to a maximum
+          of {r.hospitalityBaseChance} + {r.hospitalityRenownBonus} × q at an empty meter, capped at 100%.
+          Tiredness and job vacancies alone do not attract visitors. Travelers roll the higher of faith
+          and hospitality chances when crossing the junction; they do not turn back to seek the shrine.
+          The HUD forecasts that same chance, while actual visits require affordable admission and a clear route.
           Higher renown does not increase the road’s traveler count or spawn new archetypes.
+        </p>
+        <p className="mt-3">
+          Passing travelers start with 80–100 fullness and hydration. These lose {r.hungerDecay} and{" "}
+          {r.thirstDecay} points per game hour respectively; camping halves both rates.
         </p>
 
         <h2 className={heading}>Tuning while playing</h2>

--- a/lib/game/balance.test.ts
+++ b/lib/game/balance.test.ts
@@ -82,6 +82,20 @@ describe("balance presets", () => {
     expect(result.balance?.buildings.workshop.woodIncome).toBe(0)
     expect(result.balance?.buildings.workshop.goldCost).toBe(71)
   })
+  it.each([1, 2])("updates old default need rates and adds attraction controls in version %i", (version) => {
+    const old = JSON.parse(exportBalance(DEFAULT_BALANCE))
+    old.version = version
+    old.balance.rules.hungerDecay = 12.5
+    old.balance.rules.thirstDecay = 25
+    for (const key of ["earlyVisitPiety", "hospitalityNeedThreshold", "hospitalityRenownBonus"])
+      delete old.balance.rules[key]
+    const result = importBalance(JSON.stringify(old))
+    expect(result.error).toBeNull()
+    expect(result.balance?.rules).toEqual(DEFAULT_BALANCE.rules)
+    old.balance.rules.hungerDecay = 8
+    old.balance.rules.thirstDecay = 10
+    expect(importBalance(JSON.stringify(old)).balance?.rules).toMatchObject({ hungerDecay: 8, thirstDecay: 10 })
+  })
   it.each([NaN, Infinity, -1, 1.5, 100001, "200", null])(
     "rejects invalid starting supplies: %s",
     (value) => {
@@ -91,7 +105,7 @@ describe("balance presets", () => {
   )
   it("rejects missing fields, unknown versions and malformed JSON", () => {
     expect(validateBalance({ rules: {}, buildings: {} }).balance).toBeNull()
-    expect(importBalance('{"version":3}').error).toMatch(/version/)
+    expect(importBalance('{"version":99}').error).toMatch(/version/)
     expect(importBalance("oops").error).toMatch(/JSON/)
   })
   it("preserves custom needs and hospitality settings and rejects invalid values", () => {

--- a/lib/game/balance.ts
+++ b/lib/game/balance.ts
@@ -340,26 +340,41 @@ export const RULE_FIELDS = [
     key: "turnAsideDraw",
     group: "Traveler attraction",
     label: "Turn-aside draw threshold",
-    description: "Attraction score giving a rested traveler a 50% visit chance. Need for hospitality can increase it.",
+    description: "Attraction score giving a fully willing traveler a 50% faith visit chance. Early visits also require exceptional piety.",
     default: 40,
     min: 0,
     max: 1000,
     step: 1,
   },
   {
+    key: "earlyVisitPiety", group: "Traveler attraction", label: "Piety needed at zero renown",
+    description: "Faith visits begin above this piety and reach full willingness at 100. Renown adds up to 100 to effective piety, scaled by the square of renown / draw cap.",
+    default: 90, min: 0, max: 99, step: 1,
+  },
+  {
+    key: "hospitalityNeedThreshold", group: "Traveler attraction", label: "Food or water threshold at zero renown",
+    description: "Only fullness or hydration below this level draws a hospitality visit. Renown raises the threshold toward 60, scaled by the square of renown / draw cap. Tiredness alone does not attract visitors.",
+    default: 20, min: 1, max: 60, step: 1,
+  },
+  {
     key: "hospitalityBaseChance", group: "Traveler attraction", label: "Hospitality chance at zero renown",
-    description: "Maximum chance of visiting for food, drink or rest at an unknown shrine. Scales up to 100% at the renown draw cap; needs below 60 increase the pull, reaching its maximum at 20.",
+    description: "Maximum chance of visiting an unknown shrine for food or water, reached only with an empty meter. Scales down to zero at the food or water threshold.",
     default: 0.1, min: 0, max: 1, step: 0.01,
   },
   {
+    key: "hospitalityRenownBonus", group: "Traveler attraction", label: "Maximum renown hospitality bonus",
+    description: "Added to the maximum hospitality chance at the draw cap, scaled by the square of renown / draw cap. The resulting chance is capped at 100% and still requires food or water need.",
+    default: 0.5, min: 0, max: 1, step: 0.01,
+  },
+  {
     key: "hungerDecay", group: "Traveler needs", label: "Hunger drain per game hour",
-    description: "Fullness lost per game hour. Default: hungry every 8 hours, or three full bars per day. Camping halves this rate; shrine hospitality restores it.",
-    default: 12.5, min: 0, max: 50, step: 0.1,
+    description: "Fullness lost per game hour. Default: 72 points per day, with a full bar lasting about 33 hours. Camping halves this rate; shrine hospitality restores it.",
+    default: 3, min: 0, max: 50, step: 0.1,
   },
   {
     key: "thirstDecay", group: "Traveler needs", label: "Thirst drain per game hour",
-    description: "Hydration lost per game hour. Default: thirsty every 4 hours, or six full bars per day. Camping halves this rate; shrine hospitality restores it.",
-    default: 25, min: 0, max: 50, step: 0.1,
+    description: "Hydration lost per game hour. Default: 144 points per day, with a full bar lasting about 17 hours. Camping halves this rate; shrine hospitality restores it.",
+    default: 6, min: 0, max: 50, step: 0.1,
   },
   {
     key: "staminaDecay", group: "Traveler needs", label: "Stamina drain per game hour",
@@ -525,15 +540,15 @@ export function validateBalance(
   }
   return { balance: clean, error: null }
 }
-export const BALANCE_VERSION = 2
+export const BALANCE_VERSION = 3
 export function exportBalance(balance: GameBalance): string {
   return JSON.stringify({ version: BALANCE_VERSION, balance }, null, 2)
 }
 export function importBalance(json: string): ReturnType<typeof validateBalance> {
   try {
     const preset = record(JSON.parse(json))
-    if (preset?.version !== 1 && preset?.version !== BALANCE_VERSION)
-      return { balance: null, error: "Unsupported preset version. Expected version 1 or 2." }
+    if (preset?.version !== 1 && preset?.version !== 2 && preset?.version !== BALANCE_VERSION)
+      return { balance: null, error: "Unsupported preset version. Expected version 1, 2 or 3." }
     // Add defaults for new structures while retaining all authored settings.
     const saved = record(preset.balance)
     const rules = record(saved?.rules)
@@ -546,7 +561,13 @@ export function importBalance(json: string): ReturnType<typeof validateBalance> 
         hungerDecay: DEFAULT_BALANCE.rules.hungerDecay,
         thirstDecay: DEFAULT_BALANCE.rules.thirstDecay,
         staminaDecay: DEFAULT_BALANCE.rules.staminaDecay,
+        earlyVisitPiety: DEFAULT_BALANCE.rules.earlyVisitPiety,
+        hospitalityNeedThreshold: DEFAULT_BALANCE.rules.hospitalityNeedThreshold,
+        hospitalityRenownBonus: DEFAULT_BALANCE.rules.hospitalityRenownBonus,
         ...rules,
+        // Adopt slower defaults in old saves without overwriting custom rates.
+        ...(preset.version !== BALANCE_VERSION && rules.hungerDecay === 12.5 ? { hungerDecay: DEFAULT_BALANCE.rules.hungerDecay } : {}),
+        ...(preset.version !== BALANCE_VERSION && rules.thirstDecay === 25 ? { thirstDecay: DEFAULT_BALANCE.rules.thirstDecay } : {}),
       },
       buildings: {
         storehouse: DEFAULT_BALANCE.buildings.storehouse,

--- a/lib/game/hospitality.test.ts
+++ b/lib/game/hospitality.test.ts
@@ -12,6 +12,7 @@ import { tileToWorldX, tileToWorldZ, worldToTileX, worldToTileZ, type GameMap } 
 import { generateRelic, visitChance } from "./relic"
 import { createSim, stepSim, GAME_DAY_SECONDS, type SimState } from "./sim"
 import { DEFAULT_MOVEMENT, LINEAR_MOVEMENT } from "./motion"
+import { generateMonks } from "./monks"
 import { generateTravelers, TRAVELER_TYPES, type Traveler } from "./travelers"
 import { treeResource, treeStage, STUMP_LIFETIME_DAYS, TIMBER_LOAD, stackWood, type WoodPile } from "./trees/timber"
 import type { TreePlacement } from "./trees/placement"
@@ -46,9 +47,11 @@ function run(sim: SimState, travelers: Traveler[], map: GameMap, seconds: number
 
 const obscure = { sanctity: 0, spectacle: 0, doubt: 100 }
 
-/** Established hospitality isolates the visit lifecycle from attraction rolls. */
+/** Guaranteed hospitality isolates the visit lifecycle from attraction rolls. */
 function createEstablishedShrine(travelers: Traveler[], map: GameMap) {
   const sim = createSim(travelers, map, [], obscure)
+  sim.balance = structuredClone(DEFAULT_BALANCE)
+  sim.balance.rules.hospitalityBaseChance = 1
   sim.shrineRenown = sim.balance.rules.drawCap
   return sim
 }
@@ -60,7 +63,7 @@ describe("shrine hospitality", () => {
       for (let id = 0; id < 40; id++) {
         const { map, traveler } = fixture()
         const t = traveler(id, id % 2 === 0 ? 1 : -1)
-        t.attributes.hunger = 20
+        t.attributes.hunger = 0
         const sim = createSim([t], map, [], obscure)
         sim.shrineRenown = renown
         sim.visits = visits
@@ -72,8 +75,10 @@ describe("shrine hospitality", () => {
     const early = accepted(0, 0)
     expect(early).toBeGreaterThan(0)
     expect(early).toBeLessThan(12)
-    expect(accepted(DEFAULT_BALANCE.rules.drawCap, 0)).toBe(40)
-    expect(accepted(0, DEFAULT_BALANCE.rules.drawCap / DEFAULT_BALANCE.rules.visitRenown)).toBe(40)
+    const established = accepted(DEFAULT_BALANCE.rules.drawCap, 0)
+    expect(established).toBeGreaterThan(early * 2)
+    expect(established).toBeLessThan(40)
+    expect(accepted(0, DEFAULT_BALANCE.rules.drawCap / DEFAULT_BALANCE.rules.visitRenown)).toBe(established)
   })
 
   it.each([0, 1, 2, 3])("enters gate %i, faces the relic, pays once and walks back out", (id) => {
@@ -224,7 +229,7 @@ describe("shrine hospitality", () => {
     expect(rejoined).toBe(true)
   })
 
-  for (const need of ["hunger", "thirst", "stamina"] as const) {
+  for (const need of ["hunger", "thirst"] as const) {
     for (const direction of [1, -1] as const) {
       it(`draws a traveler with empty ${need} from direction ${direction}, restores needs and returns them`, () => {
         const { map, traveler } = fixture()
@@ -264,24 +269,62 @@ describe("shrine hospitality", () => {
     expect(sim.travelers.get(0)!.activity).toBe("toRelic")
   })
 
-  it("keeps faith relevant and reserves certain hospitality visits for established shrines", () => {
+  it("keeps faith relevant and limits early hospitality to desperate needs", () => {
     const { traveler } = fixture()
     const a = traveler(0).attributes
     const holy = { sanctity: 95, spectacle: 40, doubt: 15 }
     expect(visitChance({ ...a, piety: 100 }, holy)).toBeGreaterThan(visitChance(a, holy))
     expect(visitChance({ ...a, hunger: 0 }, obscure)).toBe(0.1)
-    expect(visitChance({ ...a, hunger: 0 }, obscure, DEFAULT_BALANCE.rules.drawCap)).toBe(1)
-    expect(visitChance({ ...a, thirst: 35 }, obscure)).toBeGreaterThan(visitChance(a, obscure))
+    expect(visitChance({ ...a, hunger: 0 }, obscure, DEFAULT_BALANCE.rules.drawCap)).toBeCloseTo(0.6)
+    expect(visitChance({ ...a, thirst: 35 }, obscure)).toBe(0)
   })
 
-  it("produces actual visits on generated worlds", () => {
+  it.each([1, -1] as const)("does not turn desperate travelers back toward the shrine (direction %i)", (direction) => {
+    const { map, traveler } = fixture()
+    const t = traveler(0, direction)
+    t.offset = (map.site!.junction + direction * 2) / (map.road!.length - 1)
+    t.attributes.thirst = 10
+    const sim = createEstablishedShrine([t], map)
+    const s = sim.travelers.get(t.id)!
+    const before = s.progress
+    run(sim, [t], map, 1)
+    expect((s.progress - before) * direction).toBeGreaterThan(0)
+    expect(s.activity).toBe("walking")
+    expect(s.direction).toBe(direction)
+  })
+
+  it("does not lure ordinary passersby with a job vacancy or moderate needs", () => {
+    for (let id = 0; id < 40; id++) {
+      const { map, camp, trees, traveler } = fixture()
+      const t = traveler(id, id % 2 === 0 ? 1 : -1)
+      Object.assign(t.attributes, { jobless: true, hunger: 35, thirst: 35 })
+      const sim = createSim([t], map, [], obscure)
+      sim.buildings = [camp]
+      sim.trees = trees
+      sim.shrineRenown = 20
+      run(sim, [t], map, 1)
+      const s = sim.travelers.get(id)!
+      expect(s.activity).toBe("walking")
+      expect((s.progress - map.site!.junction) * t.direction).toBeGreaterThan(0)
+    }
+  })
+
+  it("earns more actual visits on generated worlds as the shrine becomes known", () => {
+    let early = 0, established = 0
     for (const seed of [1, 42, 12345]) {
       const map = generateMap({ seed })
       const travelers = generateTravelers(seed, 30)
-      const sim = createSim(travelers, map, [], generateRelic(seed).stats)
-      run(sim, travelers, map, 240)
-      expect(sim.visits, `seed ${seed}`).toBeGreaterThan(0)
+      const relic = generateRelic(seed)
+      for (const known of [false, true]) {
+        const sim = createSim(travelers, map, [], relic.stats)
+        sim.shrineRenown = known ? DEFAULT_BALANCE.rules.drawCap : settlementRenown(map, generateMonks(seed), [relic]).total
+        run(sim, travelers, map, 240)
+        if (known) established += sim.visits
+        else early += sim.visits
+      }
     }
+    expect(established).toBeGreaterThan(early)
+    expect(early).toBeLessThan(9) // Under one visit per ten initial passersby across these worlds.
   })
 })
 
@@ -384,7 +427,7 @@ describe("woodcutter huts", () => {
     const t = traveler(0)
     t.attributes.hunger = 0
     t.attributes.jobless = true
-    const sim = createSim([t], builtMap, [], obscure)
+    const sim = createEstablishedShrine([t], builtMap)
     sim.buildings = woodcutterHuts(builtMap)
     sim.trees = trees
     syncTimberSpending(sim, bought.settlement.spentWood)
@@ -438,7 +481,7 @@ describe("woodcutter huts", () => {
       t.attributes.jobless = true
       return t
     })
-    const sim = createSim(travelers, map, [], obscure)
+    const sim = createEstablishedShrine(travelers, map)
     sim.buildings = [camp]
     sim.trees = trees
     let maxWorkers = 0
@@ -493,7 +536,7 @@ describe("woodcutter huts", () => {
     const { map, trees, camp, traveler } = fixture()
     const t = traveler(0)
     t.attributes.hunger = 0
-    const sim = createSim([t], map)
+    const sim = createEstablishedShrine([t], map)
     sim.buildings = [camp]
     sim.trees = trees
     run(sim, [t], map, 120)

--- a/lib/game/relic.test.ts
+++ b/lib/game/relic.test.ts
@@ -29,22 +29,22 @@ describe("relic draw", () => {
   const holy = { sanctity: 95, spectacle: 40, doubt: 15 }
   const dubious = { sanctity: 30, spectacle: 95, doubt: 90 }
 
-  it.each(["hunger", "thirst", "stamina"] as const)("requires a reputation for reliable hospitality when %s is empty", (need) => {
+  it.each(["hunger", "thirst"] as const)("requires a reputation for reliable hospitality when %s is empty", (need) => {
     const traveler = { ...who(0, 100), hunger: 100, thirst: 100, stamina: 100, [need]: 0 }
     const obscure = { sanctity: 0, spectacle: 0, doubt: 100 }
     expect(visitChance(traveler, obscure, 0)).toBeCloseTo(0.1)
-    expect(visitChance(traveler, obscure, 10)).toBeCloseTo(0.19)
-    expect(visitChance(traveler, obscure, 50)).toBeCloseTo(0.55)
-    expect(visitChance(traveler, obscure, 100)).toBe(1)
-    expect(visitChance(traveler, obscure, 200)).toBe(1)
+    expect(visitChance(traveler, obscure, 10)).toBeCloseTo(0.105)
+    expect(visitChance(traveler, obscure, 50)).toBeCloseTo(0.225)
+    expect(visitChance(traveler, obscure, 100)).toBeCloseTo(0.6)
+    expect(visitChance(traveler, obscure, 200)).toBeCloseTo(0.6)
     expect(visitChance(traveler, obscure, -100)).toBeCloseTo(0.1)
     const balance = structuredClone(DEFAULT_BALANCE)
     balance.rules.hospitalityBaseChance = 0.2
     balance.rules.drawCap = 200
-    expect(visitChance(traveler, obscure, 100, balance)).toBeCloseTo(0.6)
+    expect(visitChance(traveler, obscure, 100, balance)).toBeCloseTo(0.325)
   })
 
-  it("starts with a minority of visitors and attracts a wider crowd as renown grows", () => {
+  it("starts with rare visitors and attracts a wider crowd as renown grows", () => {
     let early = 0, established = 0, count = 0
     for (let seed = 1; seed <= 20; seed++) {
       const relic = generateRelic(seed)
@@ -54,9 +54,42 @@ describe("relic draw", () => {
         count++
       }
     }
-    expect(early / count).toBeGreaterThan(0.05)
-    expect(early / count).toBeLessThan(0.25)
+    expect(early / count).toBeGreaterThan(0)
+    expect(early / count).toBeLessThan(0.03)
     expect(established).toBeGreaterThan(early * 2)
+  })
+
+  it("keeps ordinary and moderately needy passersby on their way at founding renown", () => {
+    for (const renown of [0, 10, 20, 30]) {
+      for (const piety of [0, 30, 60, 80]) {
+        expect(visitChance({ ...who(piety, 0), hunger: 30, thirst: 30 }, holy, renown)).toBe(0)
+        expect(visitChance({ ...who(piety, 0), hunger: 30, thirst: 30 }, dubious, renown)).toBe(0)
+      }
+    }
+    expect(visitChance(who(95, 20), holy, 0)).toBeGreaterThan(0)
+  })
+
+  it("only draws food and water need below the threshold, never tiredness alone", () => {
+    const obscure = { sanctity: 0, spectacle: 0, doubt: 100 }
+    const traveler = { ...who(0, 100), hunger: 100, thirst: 100, stamina: 0 }
+    for (const renown of [0, 30, 100]) expect(visitChance(traveler, obscure, renown)).toBe(0)
+    for (const need of ["hunger", "thirst"] as const) {
+      expect(visitChance({ ...traveler, [need]: 20 }, obscure, 0)).toBe(0)
+      expect(visitChance({ ...traveler, [need]: 10 }, obscure, 0)).toBeCloseTo(0.05)
+      expect(visitChance({ ...traveler, [need]: 30 }, obscure, 100)).toBeCloseTo(0.3)
+    }
+    expect(visitChance({ ...traveler, hunger: 60, thirst: 60 }, obscure, 100)).toBe(0)
+  })
+
+  it("applies live piety, need and hospitality strength settings", () => {
+    const balance = structuredClone(DEFAULT_BALANCE)
+    balance.rules.earlyVisitPiety = 70
+    expect(visitChance(who(80, 0), holy, 0, balance)).toBeGreaterThan(0)
+    balance.rules.hospitalityNeedThreshold = 40
+    balance.rules.hospitalityRenownBonus = 0.2
+    expect(visitChance(who(0, 100), holy, 0, balance)).toBe(0)
+    expect(visitChance({ ...who(0, 100), hunger: 20 }, holy, 0, balance)).toBeCloseTo(0.05)
+    expect(visitChance({ ...who(0, 100), thirst: 0 }, { sanctity: 0, spectacle: 0, doubt: 100 }, 100, balance)).toBeCloseTo(0.3)
   })
 
   it("pulls the devout harder toward a holy relic than the worldly", () => {

--- a/lib/game/relic.ts
+++ b/lib/game/relic.ts
@@ -130,22 +130,34 @@ export const VISIT_DRAW_FLOOR = DEFAULT_BALANCE.rules.turnAsideDraw - 25
 export const VISIT_DRAW_CEILING = DEFAULT_BALANCE.rules.turnAsideDraw + 25
 export const TURN_ASIDE_DRAW = (VISIT_DRAW_FLOOR + VISIT_DRAW_CEILING) / 2
 
+/** Word of mouth grows slowly while the shrine is still barely known. */
+function reputationModifier(shrineRenown: number, balance: GameBalance): number {
+  return Math.min(1, Math.max(0, shrineRenown) / balance.rules.drawCap) ** 2
+}
+
+/** Renown makes less urgent food and water needs worth a detour. */
+export function hospitalityNeedThreshold(shrineRenown: number, balance: GameBalance = DEFAULT_BALANCE): number {
+  return balance.rules.hospitalityNeedThreshold + (60 - balance.rules.hospitalityNeedThreshold) * reputationModifier(shrineRenown, balance)
+}
+
 /**
  * The chance, 0–1, that this traveler turns down the branch when they reach
- * the junction. A chance rather than a threshold so the road's ordinary folk
- * still wander in now and then, while the devout favor a renowned shrine. The sim
- * rolls it (see sim.ts); the HUD's forecast rounds it.
+ * the junction. Early visitors are exceptionally pious or desperate for food
+ * or water. Renown broadens those motives, but never creates a motive by itself.
+ * The sim rolls it (see sim.ts); the HUD's forecast rounds it.
  */
 export function visitChance(who: TravelerAttributes, stats: RelicStats, shrineRenown = 0, balance: GameBalance = DEFAULT_BALANCE): number {
   const draw = relicDraw(who, stats, shrineRenown, balance)
-  const devotion = Math.max(0, Math.min(1, (draw - (balance.rules.turnAsideDraw - 25)) / 50))
-  // These are fullness/energy meters: low values mean greater need. Word of
-  // mouth must establish hospitality before it reliably pulls people in.
-  const need = Math.min(who.hunger, who.thirst, who.stamina)
   const r = balance.rules
-  const reputation = Math.min(r.drawCap, Math.max(0, shrineRenown)) / r.drawCap
-  const hospitalityReach = r.hospitalityBaseChance + (1 - r.hospitalityBaseChance) * reputation
-  const hospitality = Math.max(0, Math.min(1, (60 - need) / 40)) * hospitalityReach
+  const reputation = reputationModifier(shrineRenown, balance)
+  const willingness = Math.max(0, Math.min(1, (who.piety + 100 * reputation - r.earlyVisitPiety) / (100 - r.earlyVisitPiety)))
+  const devotion = Math.max(0, Math.min(1, (draw - (r.turnAsideDraw - 25)) / 50)) * willingness
+  // Tired travelers can camp along their own route. Only food and water create
+  // hospitality draw; neither a job vacancy nor renown alone is a destination.
+  const need = Math.min(who.hunger, who.thirst)
+  const threshold = hospitalityNeedThreshold(shrineRenown, balance)
+  const hospitalityReach = Math.min(1, r.hospitalityBaseChance + r.hospitalityRenownBonus * reputation)
+  const hospitality = Math.max(0, Math.min(1, (threshold - need) / threshold)) * hospitalityReach
   return Math.max(devotion, hospitality)
 }
 

--- a/lib/game/sim.test.ts
+++ b/lib/game/sim.test.ts
@@ -153,19 +153,19 @@ describe("stepSim", () => {
     const s = sim.travelers.get(0)!
     const hour = GAME_DAY_SECONDS / 24
     stepSim(sim, travelers, map, 1, hour)
-    expect([s.hunger, s.thirst, s.stamina]).toEqual([67.5, 55, 75.8])
+    expect([s.hunger, s.thirst, s.stamina]).toEqual([77, 74, 75.8])
 
     Object.assign(sim.balance.rules, { hungerDecay: 2, thirstDecay: 6, staminaDecay: 0 })
     stepSim(sim, travelers, map, 1, hour)
-    expect([s.hunger, s.thirst, s.stamina]).toEqual([65.5, 49, 75.8])
+    expect([s.hunger, s.thirst, s.stamina]).toEqual([75, 68, 75.8])
 
     s.activity = "camping"
     s.stamina = 0
     stepSim(sim, travelers, map, 1, hour)
-    expect([s.hunger, s.thirst, s.stamina]).toEqual([64.5, 46, 60])
+    expect([s.hunger, s.thirst, s.stamina]).toEqual([74, 65, 60])
   })
 
-  it("uses three full hunger bars, six thirst bars and one stamina bar per active day", () => {
+  it("keeps food and water supplied longer over an active day", () => {
     const map = makeMap()
     const travelers = [makeTraveler(0, "knight", { hunger: 100, thirst: 100, stamina: 100 })]
     const sim = createSim(travelers, map)
@@ -180,7 +180,7 @@ describe("stepSim", () => {
         s.activity = "walking"
       }
     }
-    expect(depleted).toEqual({ hunger: 3, thirst: 6, stamina: 1 })
+    expect(depleted).toEqual({ hunger: 0, thirst: 1, stamina: 1 })
     expect(sim.time).toBeCloseTo(1.25)
   })
 
@@ -305,7 +305,7 @@ describe("stepSim", () => {
     expect(buyer.hunger).toBeLessThan(50)
   })
 
-  it("buys three meals and six drinks over a day with a vendor immediately available", () => {
+  it("needs only one drink in the first day when starting fully supplied", () => {
     const map = makeMap()
     const travelers = [
       makeTraveler(0, "pilgrim", { hunger: 100, thirst: 100, gold: 100 }),
@@ -323,9 +323,9 @@ describe("stepSim", () => {
       if (buyer.hunger > hunger) meals++
       if (buyer.thirst > thirst) drinks++
     }
-    expect({ meals, drinks }).toEqual({ meals: 3, drinks: 6 })
-    expect(buyer.gold).toBe(100 - 3 * FOOD_PRICE - 6 * WINE_PRICE)
-    expect(vendor.gold).toBe(3 * FOOD_PRICE + 6 * WINE_PRICE)
+    expect({ meals, drinks }).toEqual({ meals: 0, drinks: 1 })
+    expect(buyer.gold).toBe(100 - WINE_PRICE)
+    expect(vendor.gold).toBe(WINE_PRICE)
   })
 
   it("chases down a vendor further along the road", () => {

--- a/lib/game/sim.ts
+++ b/lib/game/sim.ts
@@ -16,7 +16,7 @@ import { DEFAULT_BALANCE, type GameBalance } from "./balance"
 import { buildingAt } from "./settlement"
 import { AXE_DAMAGE_PER_HOUR, STUMP_LIFETIME_DAYS, TIMBER_LOAD, stackWood, treeResource, type TreeResource, type WoodPile } from "./trees/timber"
 import { BUILDING_KINDS, buildingCentre, type PlacedBuilding } from "./buildings"
-import { generateRelic, visitChance, type RelicStats } from "./relic"
+import { generateRelic, hospitalityNeedThreshold, visitChance, type RelicStats } from "./relic"
 import { settlementRoute } from "./settlement-route"
 import { admissionFee, shrineVisitRoute } from "./shrine-visit"
 import type { TreePlacement } from "./trees/placement"
@@ -952,9 +952,12 @@ export function stepSim(
       case "walking":
       case "seeking":
       case "fleeing": {
-        // Nearby travelers seek the brothers before collapsing or chasing a cart.
+        // A hungry traveler may consider a shrine ahead on their own route.
+        // Never turn them back toward a junction they have already passed.
+        const renown = sim.shrineRenown + sim.visits * sim.balance.rules.visitRenown
+        const ahead = map.site ? s.direction * (map.site.junction - s.progress) : -1
         const shelter = !!map.site && s.gold >= admissionFee(map) && !s.track && s.activity !== "fleeing" && s.visitCooldown <= 0 &&
-          Math.min(s.hunger, s.thirst, s.stamina) <= 40 && Math.abs(s.progress - map.site.junction) <= 12
+          Math.min(s.hunger, s.thirst) < hospitalityNeedThreshold(renown, sim.balance) && ahead >= 0 && ahead <= 12
         if (s.stamina <= 0 && !shelter) {
           startCamping(sim, s, t, map)
           break
@@ -1058,14 +1061,12 @@ export function stepSim(
           break
         }
 
-        if (shelter) direction = map.site!.junction >= s.progress ? 1 : -1
         const site = map.site
         if (site && site.branch.length >= 2 && s.activity !== "fleeing" && s.visitCooldown <= 0) {
           const distance = ((direction * (site.junction - s.progress)) % length + length) % length
           if (distance <= worldSpeed * haste * dt) {
-            const chance = Math.max(visitChance({ ...t.attributes, piety: s.piety,
-              hunger: s.hunger, thirst: s.thirst, stamina: s.stamina }, sim.relic, sim.shrineRenown + sim.visits * sim.balance.rules.visitRenown, sim.balance),
-              findJob(sim, s, map) ? 0.8 : 0)
+            const chance = visitChance({ ...t.attributes, piety: s.piety,
+              hunger: s.hunger, thirst: s.thirst, stamina: s.stamina }, sim.relic, renown, sim.balance)
             s.visitCooldown = 5
             const wantsVisit = nextRoll(s) < chance && s.gold >= admissionFee(map)
             const visitRoute = wantsVisit ? shrineVisitRoute(map, s.id, s.visits) : null

--- a/lib/game/travelers.test.ts
+++ b/lib/game/travelers.test.ts
@@ -29,6 +29,14 @@ describe("travelerCountForMap", () => {
 })
 
 describe("generateTravelers", () => {
+  it("starts passing travelers supplied for their own journey", () => {
+    for (const seed of [1, 42, 12345]) {
+      for (const { attributes } of generateTravelers(seed, 100)) {
+        expect(attributes.hunger).toBeGreaterThanOrEqual(80)
+        expect(attributes.thirst).toBeGreaterThanOrEqual(80)
+      }
+    }
+  })
   it("matches first names to the rendered population profile across seeds and callings", () => {
     const women = new Set([
       "Berta", "Dilys", "Frida", "Hawise", "Isolde", "Maude", "Osanna",

--- a/lib/game/travelers.ts
+++ b/lib/game/travelers.ts
@@ -161,9 +161,9 @@ export const TRAVELER_TYPES: Record<TravelerTypeId, TravelerTypeDef> = {
   },
 }
 
-/** Needs everyone shares regardless of calling; refill/decay comes later. */
-const HUNGER: StatRange = { min: 20, max: 80 }
-const THIRST: StatRange = { min: 20, max: 80 }
+/** Passing travelers start supplied for their own journey. */
+const HUNGER: StatRange = { min: 80, max: 100 }
+const THIRST: StatRange = { min: 80, max: 100 }
 const STAMINA: StatRange = { min: 40, max: 100 }
 
 const FIRST_NAMES = {


### PR DESCRIPTION
Travelers now start at 80–100% fullness and hydration, with hunger/thirst draining at 3/6 points per game hour; early shrine detours require desperate food/water needs or exceptional piety.
Renown gradually broadens attraction, while exhaustion, job vacancies, and backtracking no longer funnel passersby toward the shrine.
Adds tuning controls, migrates legacy default drain rates while preserving custom rates, and updates the game specs and regression tests.

Validation: the 675-test full suite and type checking passed during implementation; all 76 affected tests passed after the final starting-supplies adjustment.
