### PR TITLE
Add 5% evangelism chance to completed crosses

### DIFF
--- a/app/docs/game-specs/page.tsx
+++ b/app/docs/game-specs/page.tsx
@@ -200,7 +200,10 @@ export default function GameSpecsPage() {
           of {r.hospitalityBaseChance} + {r.hospitalityRenownBonus} × q at an empty meter, capped at 100%.
           Tiredness and job vacancies alone do not attract visitors. Travelers roll the higher of faith
           and hospitality chances when crossing the junction; they do not turn back to seek the shrine.
-          The HUD forecasts that same chance, while actual visits require affordable admission and a clear route.
+          If that roll fails, a completed carved cross grants one independent 5% Evangelism roll.
+          Additional crosses do not stack this chance. For an ordinary visit chance p, the combined
+          chance is p + (1 − p) × 0.05. The HUD forecasts the combined chance, while actual visits
+          require affordable admission and a clear route.
           Higher renown does not increase the road’s traveler count or spawn new archetypes.
         </p>
         <p className="mt-3">

--- a/components/game/game-shell.tsx
+++ b/components/game/game-shell.tsx
@@ -16,6 +16,7 @@ import { loadSavedSeed } from "@/lib/game/seed-storage"
 import { generateMonks } from "@/lib/game/monks"
 import { tileToWorldX, tileToWorldZ } from "@/lib/game/map/types"
 import { generateRelic, visitChance } from "@/lib/game/relic"
+import { settlementEvangelism } from "@/lib/game/settlement"
 import { DEFAULT_TRAFFIC, generateTravelers, travelerCountForMap } from "@/lib/game/travelers"
 import {
   DEFAULT_CLEARING_COUNT,
@@ -266,9 +267,10 @@ export function GameShell({
   const economy = useSettlement(baseMap, monks, relic)
   const map = economy.map
   const renown = economy.renown
+  const evangelism = map ? settlementEvangelism(map) : 0
   const relicTraffic = useMemo(
-    () => (relic ? Math.round(travelers.reduce((sum, t) => sum + visitChance(t.attributes, relic.stats, renown?.total ?? 0, economy.balance), 0)) : 0),
-    [travelers, relic, renown, economy.balance],
+    () => (relic ? Math.round(travelers.reduce((sum, t) => sum + visitChance(t.attributes, relic.stats, renown?.total ?? 0, economy.balance, evangelism), 0)) : 0),
+    [travelers, relic, renown, economy.balance, evangelism],
   )
 
   // The camera's pan clamp follows the loaded map's extent, and a new world

--- a/lib/game/balance.ts
+++ b/lib/game/balance.ts
@@ -15,6 +15,8 @@ export interface BuildDefinition {
   description: string
   cost: Resources
   renown: number
+  /** Second-chance probability for passersby; only the strongest completed source applies. */
+  evangelism?: number
   requiredRenown: number
   income: Resources
   w: number
@@ -74,9 +76,10 @@ export const BUILD_CATALOG: readonly BuildDefinition[] = [
     id: "cross",
     label: "Carved cross",
     category: "scenery",
-    description: "A landmark of the brotherhood’s devotion.",
-    cost: { gold: 15, wood: 20 },
+    description: "Evangelism: 5%. Once complete, gives travelers who would otherwise pass one extra chance to visit the relic. Additional crosses do not stack this chance.",
+    cost: { gold: 60, wood: 45 },
     renown: 2,
+    evangelism: 0.05,
     requiredRenown: 0,
     income: { gold: 0, wood: 0 },
     w: 1,

--- a/lib/game/hospitality.test.ts
+++ b/lib/game/hospitality.test.ts
@@ -1,6 +1,6 @@
 import { shrineSeats } from "./shrine-layout"
 import { describe, expect, it } from "vitest"
-import { DEFAULT_BALANCE } from "./balance"
+import { BUILD_CATALOG, DEFAULT_BALANCE } from "./balance"
 import { createSettlement, purchaseStructure, woodcutterHuts, creditTimber, creditAdmission, syncTimberSpending, settlementRenown } from "./settlement"
 import { buildingStepAllowed, containsTile, shrineGates } from "./building-navigation"
 import { relicHeading, shrineVisitRoute, shrineVisitPlan } from "./shrine-visit"
@@ -47,6 +47,79 @@ function run(sim: SimState, travelers: Traveler[], map: GameMap, seconds: number
 }
 
 const obscure = { sanctity: 0, spectacle: 0, doubt: 100 }
+
+function addCross(map: GameMap) {
+  map.buildings.push({ ...BUILD_CATALOG.find(b => b.id === "cross")!, id: "cross-0", buildType: "cross", x: 13, z: 6 })
+}
+
+describe("cross evangelism", () => {
+  it("gives otherwise uninterested travelers one independent 5% roll at the junction", () => {
+    let persuaded = 0
+    for (let id = 0; id < 1000; id++) {
+      const { map, traveler } = fixture()
+      addCross(map)
+      const t = traveler(id, id % 2 === 0 ? 1 : -1)
+      const sim = createSim([t], map, [], obscure)
+      const s = sim.travelers.get(id)!
+      expect(visitChance(t.attributes, obscure)).toBe(0)
+      stepSim(sim, [t], map, 1.5, 0.2)
+      expect(s.rolls).toBe(2)
+      expect(s.piety).toBe(t.attributes.piety)
+      if (s.activity === "toRelic") persuaded++
+      else {
+        expect(s.activity).toBe("walking")
+        // No repeated chances while the same traveler is still at the junction.
+        s.progress = map.site!.junction
+        stepSim(sim, [t], map, 1.5, 0.01)
+        expect(s.rolls).toBe(2)
+      }
+    }
+    expect(persuaded).toBeGreaterThan(30)
+    expect(persuaded).toBeLessThan(70)
+  })
+
+  it("does not roll evangelism when the ordinary visit roll succeeds", () => {
+    const { map, traveler } = fixture()
+    addCross(map)
+    const t = traveler(0)
+    t.attributes.hunger = 0
+    const sim = createEstablishedShrine([t], map)
+    stepSim(sim, [t], map, 1.5, 0.2)
+    expect(sim.travelers.get(0)!.activity).toBe("toRelic")
+    expect(sim.travelers.get(0)!.rolls).toBe(1)
+  })
+
+  it.each(["open", "unaffordable", "blocked"])("respects shrine access after persuasion: %s", access => {
+    const { map, traveler } = fixture()
+    addCross(map)
+    // This traveler's second deterministic roll is about 2%, below Evangelism's 5%.
+    const t = traveler(15)
+    if (access === "unaffordable") map.buildings[0].admissionFee = 3
+    if (access === "blocked") {
+      const gate = shrineGates(map.buildings[0], map.site!.door)[0]
+      Object.assign(map.buildings.at(-1)!, gate.outside)
+    }
+    const sim = createSim([t], map, [], obscure)
+    stepSim(sim, [t], map, 1.5, 0.2)
+    const s = sim.travelers.get(t.id)!
+    expect(s.rolls).toBe(2)
+    expect(s.activity).toBe(access === "open" ? "toRelic" : "walking")
+    expect(s.admissionPaid).toBe(0)
+  })
+
+  it.each(["absent", "unfinished"])("does not give an extra roll for an %s cross", state => {
+    const { map, traveler } = fixture()
+    if (state === "unfinished") {
+      addCross(map)
+      map.buildings.at(-1)!.construction = { work: 0, required: 12 }
+    }
+    const t = traveler(0)
+    const sim = createSim([t], map, [], obscure)
+    stepSim(sim, [t], map, 1.5, 0.2)
+    expect(sim.travelers.get(0)!.activity).toBe("walking")
+    expect(sim.travelers.get(0)!.rolls).toBe(1)
+  })
+})
 
 /** Guaranteed hospitality isolates the visit lifecycle from attraction rolls. */
 function createEstablishedShrine(travelers: Traveler[], map: GameMap) {

--- a/lib/game/relic.test.ts
+++ b/lib/game/relic.test.ts
@@ -29,6 +29,17 @@ describe("relic draw", () => {
   const holy = { sanctity: 95, spectacle: 40, doubt: 15 }
   const dubious = { sanctity: 30, spectacle: 95, doubt: 90 }
 
+  it("forecasts an independent evangelism roll only for travelers who would decline", () => {
+    const traveler = { ...who(0, 100), hunger: 100, thirst: 100 }
+    const obscure = { sanctity: 0, spectacle: 0, doubt: 100 }
+    expect(visitChance(traveler, obscure, 0, DEFAULT_BALANCE, 0.05)).toBeCloseTo(0.05)
+    const balance = structuredClone(DEFAULT_BALANCE)
+    for (const [ordinary, expected] of [[0.2, 0.24], [0.5, 0.525], [1, 1]]) {
+      balance.rules.hospitalityBaseChance = ordinary
+      expect(visitChance({ ...traveler, hunger: 0 }, obscure, 0, balance, 0.05)).toBeCloseTo(expected)
+    }
+  })
+
   it.each(["hunger", "thirst"] as const)("requires a reputation for reliable hospitality when %s is empty", (need) => {
     const traveler = { ...who(0, 100), hunger: 100, thirst: 100, stamina: 100, [need]: 0 }
     const obscure = { sanctity: 0, spectacle: 0, doubt: 100 }

--- a/lib/game/relic.ts
+++ b/lib/game/relic.ts
@@ -144,9 +144,10 @@ export function hospitalityNeedThreshold(shrineRenown: number, balance: GameBala
  * The chance, 0–1, that this traveler turns down the branch when they reach
  * the junction. Early visitors are exceptionally pious or desperate for food
  * or water. Renown broadens those motives, but never creates a motive by itself.
- * The sim rolls it (see sim.ts); the HUD's forecast rounds it.
+ * Evangelism gives those who decline one independent second chance. The sim
+ * rolls each decision separately (see sim.ts); the HUD rounds their combined chance.
  */
-export function visitChance(who: TravelerAttributes, stats: RelicStats, shrineRenown = 0, balance: GameBalance = DEFAULT_BALANCE): number {
+export function visitChance(who: TravelerAttributes, stats: RelicStats, shrineRenown = 0, balance: GameBalance = DEFAULT_BALANCE, evangelism = 0): number {
   const draw = relicDraw(who, stats, shrineRenown, balance)
   const r = balance.rules
   const reputation = reputationModifier(shrineRenown, balance)
@@ -158,7 +159,8 @@ export function visitChance(who: TravelerAttributes, stats: RelicStats, shrineRe
   const threshold = hospitalityNeedThreshold(shrineRenown, balance)
   const hospitalityReach = Math.min(1, r.hospitalityBaseChance + r.hospitalityRenownBonus * reputation)
   const hospitality = Math.max(0, Math.min(1, (threshold - need) / threshold)) * hospitalityReach
-  return Math.max(devotion, hospitality)
+  const ordinary = Math.max(devotion, hospitality)
+  return ordinary + (1 - ordinary) * Math.max(0, Math.min(1, evangelism))
 }
 
 /** Would this traveler, more likely than not, leave the road for the relic? */

--- a/lib/game/settlement.test.ts
+++ b/lib/game/settlement.test.ts
@@ -18,6 +18,7 @@ import {
   purchaseStructure,
   relicRenown,
   settlementIncome,
+  settlementEvangelism,
   settlementRenown,
   STARTING_RESOURCES,
 } from "./settlement"
@@ -58,6 +59,22 @@ const shelter = BUILD_CATALOG.find((item) => item.id === "shelter")!
 const garden = BUILD_CATALOG.find((item) => item.id === "garden")!
 
 describe("build and buy", () => {
+  it("activates evangelism only after construction and never stacks extra crosses", () => {
+    const map = testMap()
+    expect(settlementEvangelism(map)).toBe(0)
+    const purchase = purchaseStructure(createSettlement(), map, monks, [relic], "cross", { x: 10, z: 14 })
+    expect(purchase.error).toBeNull()
+    expect(purchase.settlement.resources).toEqual({ gold: STARTING_RESOURCES.gold - 60, wood: STARTING_RESOURCES.wood - 45 })
+    const cross = purchase.settlement.structures[0]
+    map.buildings.push(cross)
+    expect(settlementEvangelism(map)).toBe(0)
+    cross.construction!.work = cross.construction!.required
+    expect(settlementEvangelism(map)).toBe(0.05)
+    map.buildings.push({ ...cross, id: "extra-cross", x: 12 })
+    expect(settlementEvangelism(map)).toBe(0.05)
+    map.buildings = map.buildings.filter(b => b.buildType !== "cross")
+    expect(settlementEvangelism(map)).toBe(0)
+  })
   it.each([0, 1, 2, 3] as BuildingRotation[])("buys and reserves a rectangular building at rotation %i", rotation => {
     const map = testMap(), at = { x: 10, z: 14 }
     const def = BUILD_CATALOG.find(item => item.id === "hall")!

--- a/lib/game/settlement.ts
+++ b/lib/game/settlement.ts
@@ -11,7 +11,7 @@ import { tileAt, type BuildingDef, type GameMap, type TilePos } from "./map/type
 import type { Monk } from "./monks"
 import type { Relic } from "./relic"
 
-import { DEFAULT_BALANCE, buildCatalog, type GameBalance } from "./balance"
+import { BUILD_CATALOG, DEFAULT_BALANCE, buildCatalog, type GameBalance } from "./balance"
 import type { BuildDefinition, Resources } from "./balance"
 export { BUILD_CATALOG, type BuildDefinition, type Resources } from "./balance"
 
@@ -76,6 +76,17 @@ export function individualRenown(monk: Monk, balance: GameBalance = DEFAULT_BALA
     Math.round(monk.attributes.piety / r.pietyDivisor) +
       monk.attributes.skills.length * r.skillRenown,
   )
+}
+
+/** One second chance per junction encounter, regardless of how many crosses are built. */
+export function settlementEvangelism(map: GameMap): number {
+  let chance = 0
+  for (const building of map.buildings) {
+    if (!isComplete(building)) continue
+    const def = BUILD_CATALOG.find(item => item.id === building.buildType)
+    chance = Math.max(chance, def?.evangelism ?? 0)
+  }
+  return chance
 }
 
 /** Renown belongs to the whole establishment; contributions remain inspectable. */

--- a/lib/game/sim.ts
+++ b/lib/game/sim.ts
@@ -14,7 +14,7 @@ import { cartOffset, SHOP_SECONDS, cartLoadout } from "./transport/assets"
 import { createPasture, stepPasture, type PastureAnimal } from "./transport/pasture"
 import { LINEAR_MOVEMENT, easeSpeed, paceVariation, type MovementTuning } from "./motion"
 import { DEFAULT_BALANCE, type GameBalance } from "./balance"
-import { buildingAt } from "./settlement"
+import { buildingAt, settlementEvangelism } from "./settlement"
 import { AXE_DAMAGE_PER_HOUR, STUMP_LIFETIME_DAYS, TIMBER_LOAD, stackWood, treeResource, type TreeResource, type WoodPile } from "./trees/timber"
 import { BUILDING_KINDS, buildingCentre, type PlacedBuilding } from "./buildings"
 import { generateRelic, hospitalityNeedThreshold, visitChance, type RelicStats } from "./relic"
@@ -45,7 +45,7 @@ import type { Traveler } from "./travelers"
  *
  * The loop per traveler:
  *  - Walking wears them down: stamina, hunger, and thirst all fall.
- *  - At the shrine junction, faith, hospitality and available work draw visitors
+ *  - At the shrine junction, faith, hospitality and evangelism draw visitors
  *    down the branch. The brothers restore their needs and bestow piety before
  *    they return to the road; each visit spreads the shrine's renown.
  *  - Jobless visitors may settle into a woodcutter hut slot, walk to a reserved
@@ -1107,7 +1107,10 @@ export function stepSim(
             const chance = visitChance({ ...t.attributes, piety: s.piety,
               hunger: s.hunger, thirst: s.thirst, stamina: s.stamina }, sim.relic, renown, sim.balance)
             s.visitCooldown = 5
-            const wantsVisit = nextRoll(s) < chance && s.gold >= admissionFee(map)
+            const ordinaryVisit = nextRoll(s) < chance
+            const evangelism = ordinaryVisit ? 0 : settlementEvangelism(map)
+            const persuaded = evangelism > 0 && nextRoll(s) < evangelism
+            const wantsVisit = (ordinaryVisit || persuaded) && s.gold >= admissionFee(map)
             const occupiedSeats = new Set([...sim.travelers.values()].flatMap(other =>
               other.shrineSeat && ["toRelic","visiting","fromRelic"].includes(other.activity) ? [other.shrineSeat] : []))
             const visit = wantsVisit ? shrineVisitPlan(map, s.id, s.visits, occupiedSeats) : null


### PR DESCRIPTION
A completed carved cross gives travelers who fail their normal visit roll one independent 5% Evangelism roll at the junction, while admission and route requirements still apply.
Additional crosses do not stack the chance, and the default cross cost increases to 60 gold and 45 wood.
Updates the cross description, HUD visit forecast, and game specifications to match, with regression coverage for construction completion, non-stacking, roll behavior, and shrine access.

Validation: 200 tests passed across the relic, settlement, hospitality, balance, simulation, and construction suites; `npm run typecheck` and `git diff --check` passed.
