### PR TITLE
Add monk roadside evangelism task

### DIFF
--- a/components/game/game-hud.tsx
+++ b/components/game/game-hud.tsx
@@ -28,6 +28,8 @@ import { CURRENT_VERSION } from "@/lib/changelog"
 import { SITE_MENU } from "@/lib/site-menu"
 import { ACTIVITY_LABELS, simRegistry, type SimTraveler } from "@/lib/game/sim"
 import { useRelicProcessionStore } from "@/lib/game/relic-procession-store"
+import { MONK_TIRED_AT } from "@/lib/game/monk-work"
+import { useMonkEvangelismStore } from "@/lib/game/monk-evangelism-store"
 import { MONK_ACTIVITY_LABELS, monkStaminaRegistry, monkRegistry, monkPositionRegistry, type Monk, type MonkActivity } from "@/lib/game/monks"
 import { relicTitle, type Relic } from "@/lib/game/relic"
 import { DEFAULT_TRAFFIC, type Traveler } from "@/lib/game/travelers"
@@ -528,6 +530,8 @@ function MonkPanel({ monk }: { monk: Monk }) {
   }, [monk.id])
   const procession = useRelicProcessionStore()
   const carryingRelic = procession.monkId === monk.id
+  const evangelism = useMonkEvangelismStore()
+  const evangelizing = evangelism.assigned.has(monk.id)
   return (
     <Panel>
       <div className="flex items-baseline justify-between gap-4">
@@ -553,12 +557,21 @@ function MonkPanel({ monk }: { monk: Monk }) {
 
       <div className="mt-2 flex flex-col gap-0.5 border-t border-rule pt-2">
         <StatBar label="Piety" value={piety ?? a.piety} />
-        <StatBar label="Stamina" value={stamina} />
+        <StatBar label="Stamina" value={Math.round(stamina)} />
         <div className="mt-1 text-[11px] text-ink-light">Contributes +{individualRenown(monk, balance)} shrine renown</div>
       </div>
 
       <div className="mt-2 border-t border-rule pt-2">
-        <button type="button" className="hud-action" disabled={!procession.available || activity === "flying" ||
+        <button type="button" className="hud-action"
+          disabled={!evangelizing && (!evangelism.available || carryingRelic || activity === "flying" || stamina <= MONK_TIRED_AT)}
+          onClick={() => evangelizing ? evangelism.recall(monk.id) : evangelism.request(monk.id)}>
+          {evangelizing ? "Recall from preaching" : "Evangelize on the main road"}
+        </button>
+        <p className="mt-1 text-[11px] italic text-ink-light">Preach beside the junction until recalled or tired. Gives passing travelers a 5% extra chance to visit the relic, independent of a cross. Extra preachers do not stack.</p>
+      </div>
+
+      <div className="mt-2 border-t border-rule pt-2">
+        <button type="button" className="hud-action" disabled={!procession.available || evangelizing || activity === "toEvangelize" || activity === "preaching" || activity === "flying" ||
           (procession.monkId !== null && !carryingRelic) || (carryingRelic && (procession.returnRequested || procession.stage === "lowering" || procession.stage === "returning"))}
           onClick={() => carryingRelic ? procession.returnRelic() : procession.request(monk.id)}>
           {carryingRelic ? "Return relic" : "Carry relic in procession"}

--- a/components/game/game-shell.tsx
+++ b/components/game/game-shell.tsx
@@ -16,7 +16,7 @@ import { loadSavedSeed } from "@/lib/game/seed-storage"
 import { generateMonks } from "@/lib/game/monks"
 import { tileToWorldX, tileToWorldZ } from "@/lib/game/map/types"
 import { generateRelic, visitChance } from "@/lib/game/relic"
-import { settlementEvangelism } from "@/lib/game/settlement"
+import { roadsideEvangelism } from "@/lib/game/monk-evangelism"
 import { DEFAULT_TRAFFIC, generateTravelers, travelerCountForMap } from "@/lib/game/travelers"
 import {
   DEFAULT_CLEARING_COUNT,
@@ -267,7 +267,13 @@ export function GameShell({
   const economy = useSettlement(baseMap, monks, relic)
   const map = economy.map
   const renown = economy.renown
-  const evangelism = map ? settlementEvangelism(map) : 0
+  const [evangelism, setEvangelism] = useState(0)
+  useEffect(() => {
+    const read = () => setEvangelism(map ? roadsideEvangelism(map) : 0)
+    read()
+    const timer = setInterval(read, 250)
+    return () => clearInterval(timer)
+  }, [map])
   const relicTraffic = useMemo(
     () => (relic ? Math.round(travelers.reduce((sum, t) => sum + visitChance(t.attributes, relic.stats, renown?.total ?? 0, economy.balance, evangelism), 0)) : 0),
     [travelers, relic, renown, economy.balance, evangelism],

--- a/components/game/monks.tsx
+++ b/components/game/monks.tsx
@@ -3,6 +3,8 @@
 import { PietyEffects } from "./admission-effects"
 import { PixelCharacters } from "@/components/pixel-canvas"
 import { createMonkNeeds, stepMonkWork, type MonkNeeds } from "@/lib/game/monk-work"
+import { preachingRegistry, preachingSpots, stepMonkEvangelism, type PreachingTask } from "@/lib/game/monk-evangelism"
+import { useMonkEvangelismStore } from "@/lib/game/monk-evangelism-store"
 import { workerRoute } from "@/lib/game/construction"
 import { walkingSurface } from "@/lib/game/map/walking-surface"
 
@@ -39,6 +41,7 @@ import { rocketMonkVisual, rocketFlightClip } from "@/lib/game/rocket/assets"
  */
 
 interface MonkState extends MonkRoutine, MonkNeeds {
+  preachingTask?: PreachingTask
   workScale?: number
   flight?: MonkFlight
   piety: number
@@ -74,13 +77,20 @@ export function Monks({ map, monks, relic, flying = false, characterScale = 1 }:
   world.grounds = useMemo(() => processionGrounds(map, navigation), [map, navigation])
   useEffect(() => {
     for (const state of world.states) {
-      if (state.buildingTask || state.flight) continue
+      if (state.buildingTask || state.flight || state.preachingTask) continue
       if (map.site) { state.route = workerRoute(map, state, map.site.door) ?? []; state.destination = "home" }
     }
   }, [map, world])
 
+  useEffect(() => {
+    useMonkEvangelismStore.setState({ available: preachingSpots(map).length > 0 })
+  }, [map])
+
   // Publish activities so the HUD's monk panel can poll them.
   useEffect(() => {
+    const preachers = { road: map.road, monks: world.states }
+    preachingRegistry.current = preachers
+    useMonkEvangelismStore.setState({ assigned: new Set() })
     monkRegistry.current = world.activities
     monkStaminaRegistry.current = world.stamina
     const positions = new Map(monks.map((m, i) => [m.id, world.states[i]]))
@@ -88,6 +98,10 @@ export function Monks({ map, monks, relic, flying = false, characterScale = 1 }:
     processionRegistry.current = world.procession
     useRelicProcessionStore.setState({ available: !!world.grounds, monkId: null, stage: "idle", returnRequested: false })
     return () => {
+      if (preachingRegistry.current === preachers) {
+        preachingRegistry.current = null
+        useMonkEvangelismStore.setState({ available: false, assigned: new Set() })
+      }
       if (monkPositionRegistry.current === positions) monkPositionRegistry.current = null
       if (monkRegistry.current === world.activities) monkRegistry.current = null
       if (monkStaminaRegistry.current === world.stamina) monkStaminaRegistry.current = null
@@ -107,12 +121,13 @@ export function Monks({ map, monks, relic, flying = false, characterScale = 1 }:
       const index = monks.findIndex(m => m.id === controls.monkId)
       const actor = world.states[index]
       if (actor) actor.buildingTask = undefined
-      if (!actor || actor.flight || !startProcession(world.procession, controls.monkId, actor, world.grounds)) {
+      if (!actor || actor.flight || actor.preachingTask || useMonkEvangelismStore.getState().assigned.has(controls.monkId) || !startProcession(world.procession, controls.monkId, actor, world.grounds)) {
         useRelicProcessionStore.setState({ monkId: null, returnRequested: false })
       }
     }
     if (!playback.paused && world.procession.stage === "idle" && world.grounds) {
-      const index = world.states.findIndex(s => !s.flight && !s.processionConsidered &&
+      const index = world.states.findIndex((s, index) => !s.flight && !s.processionConsidered &&
+        !s.preachingTask && !useMonkEvangelismStore.getState().assigned.has(monks[index].id) &&
         s.activity === "praying" && s.destination === "prayer" &&
         Math.hypot(s.x - world.grounds!.altar.x, s.z - world.grounds!.altar.z) < .01)
       if (index >= 0 && startAltarProcession(world.procession, monks[index].id, world.states[index], world.grounds, world.rng)) {
@@ -165,7 +180,8 @@ export function Monks({ map, monks, relic, flying = false, characterScale = 1 }:
         group.position.set(s.x, s.y, s.z)
         continue
       }
-      const praying = !s.flight && s.buildingTask?.purpose !== "rest" && nearProcession(world.procession, s, group.userData.activity === "praying")
+      const evangelismRequested = useMonkEvangelismStore.getState().assigned.has(monks[i].id)
+      const praying = !evangelismRequested && !s.preachingTask && !s.flight && s.buildingTask?.purpose !== "rest" && nearProcession(world.procession, s, group.userData.activity === "praying")
       group.userData.moving = false
       if (praying && world.procession.position) {
         blessByProcession(world.procession, `monk:${monks[i].id}`, s)
@@ -178,7 +194,7 @@ export function Monks({ map, monks, relic, flying = false, characterScale = 1 }:
 
       if (flying) {
         s.flightWait -= dt
-        if (!s.flight && s.flightWait <= 0 && s.destination === "grounds" && s.activity === "resting" && !s.buildingTask && s.stamina > 25) {
+        if (!evangelismRequested && !s.preachingTask && !s.flight && s.flightWait <= 0 && s.destination === "grounds" && s.activity === "resting" && !s.buildingTask && s.stamina > 25) {
           s.flight = createMonkFlight(s, world.pick(), map, world.flightRng)
         }
       }
@@ -217,13 +233,18 @@ export function Monks({ map, monks, relic, flying = false, characterScale = 1 }:
       }
       group.rotation.x = 0
 
-      if (!stepMonkWork(s, map, monkWalkSpeed(characterScale), dt))
+      const evangelizing = stepMonkEvangelism(s, map, evangelismRequested, monkWalkSpeed(characterScale), dt,
+        world.states.filter(other => other !== s && other.preachingTask).map(other => other.preachingTask!.tile))
+      if (evangelismRequested && !evangelizing) useMonkEvangelismStore.getState().recall(monks[i].id)
+      if (!evangelizing && !stepMonkWork(s, map, monkWalkSpeed(characterScale), dt))
         stepMonkRoutine(s, world.wander, world.rng, monkWalkSpeed(characterScale), dt)
       world.stamina.set(monks[i].id, s.stamina)
       if (s.buildingTask && (s.activity === "building" || s.activity === "sleeping")) group.rotation.y = s.buildingTask.heading
       group.userData.activity = s.activity
       world.activities.set(monks[i].id, s.activity)
-      if (s.activity === "praying" && world.centre) {
+      if (s.activity === "preaching" && s.preachingTask) {
+        group.rotation.y = s.preachingTask.heading
+      } else if (s.activity === "praying" && world.centre) {
         group.rotation.y = Math.atan2(world.centre.x - s.x, world.centre.z - s.z)
       } else if (Math.hypot(s.x - previousX, s.z - previousZ) > 0) {
         group.rotation.y = Math.atan2(s.x - previousX, s.z - previousZ)

--- a/lib/game/base-person/activity.ts
+++ b/lib/game/base-person/activity.ts
@@ -12,6 +12,8 @@ export function activityClip(activity: Activity | MonkActivity | undefined, movi
   if (carrying > 0) return "carrying"
   if (moving) return "walk"
   switch (activity) {
+    // Roadside sermons keep the brother standing and facing passing travelers.
+    case "preaching": return "idle"
     case "building": return "building"
     case "sleeping":
     case "camping": return "sleeping"

--- a/lib/game/hospitality.test.ts
+++ b/lib/game/hospitality.test.ts
@@ -1,5 +1,5 @@
 import { shrineSeats } from "./shrine-layout"
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it } from "vitest"
 import { BUILD_CATALOG, DEFAULT_BALANCE } from "./balance"
 import { createSettlement, purchaseStructure, woodcutterHuts, creditTimber, creditAdmission, syncTimberSpending, settlementRenown } from "./settlement"
 import { buildingStepAllowed, containsTile, shrineGates } from "./building-navigation"
@@ -13,6 +13,10 @@ import { tileToWorldX, tileToWorldZ, worldToTileX, worldToTileZ, type GameMap } 
 import { generateRelic, visitChance } from "./relic"
 import { createSim, stepSim, GAME_DAY_SECONDS, type SimState } from "./sim"
 import { DEFAULT_MOVEMENT, LINEAR_MOVEMENT } from "./motion"
+import { preachingRegistry, stepMonkEvangelism, type EvangelizingMonk } from "./monk-evangelism"
+import { createMonkRoutine } from "./monk-routine"
+import { monkWander } from "./monk-wander"
+import { createMonkNeeds } from "./monk-work"
 import { generateMonks } from "./monks"
 import { generateTravelers, TRAVELER_TYPES, type Traveler } from "./travelers"
 import { treeResource, treeStage, STUMP_LIFETIME_DAYS, TIMBER_LOAD, stackWood, type WoodPile } from "./trees/timber"
@@ -118,6 +122,51 @@ describe("cross evangelism", () => {
     stepSim(sim, [t], map, 1.5, 0.2)
     expect(sim.travelers.get(0)!.activity).toBe("walking")
     expect(sim.travelers.get(0)!.rolls).toBe(1)
+  })
+})
+
+describe("monk evangelism at the junction", () => {
+  afterEach(() => { preachingRegistry.current = null })
+  function preacher(map: GameMap) {
+    const monk: EvangelizingMonk = { ...createMonkRoutine(monkWander(map), 0, () => .5), ...createMonkNeeds(0) }
+    for (let i = 0; i < 300 && monk.activity !== "preaching"; i++) stepMonkEvangelism(monk, map, true, 2, .1)
+    expect(monk.activity).toBe("preaching")
+    preachingRegistry.current = { road: map.road, monks: [monk] }
+    return monk
+  }
+
+  it("persuades about 5% of uninterested travelers in both directions, once per pass", () => {
+    const { map, traveler } = fixture()
+    preacher(map)
+    let persuaded = 0
+    for (let id = 0; id < 1000; id++) {
+      const t = traveler(id, id % 2 === 0 ? 1 : -1), sim = createSim([t], map, [], obscure)
+      stepSim(sim, [t], map, 1.5, .2)
+      const s = sim.travelers.get(id)!
+      expect(s.rolls).toBe(2)
+      if (s.activity === "toRelic") persuaded++
+      else {
+        s.progress = map.site!.junction
+        stepSim(sim, [t], map, 1.5, .01)
+        expect(s.rolls).toBe(2)
+      }
+    }
+    expect(persuaded).toBeGreaterThan(30)
+    expect(persuaded).toBeLessThan(70)
+  })
+
+  it.each(["open", "unaffordable", "blocked", "recalled"])("respects shrine access and recall: %s", access => {
+    const { map, traveler } = fixture(), monk = preacher(map), t = traveler(15)
+    if (access === "unaffordable") map.buildings[0].admissionFee = 3
+    if (access === "blocked") {
+      const gate = shrineGates(map.buildings[0], map.site!.door)[0]
+      map.buildings.push({ ...BUILD_CATALOG.find(b => b.id === "cross")!, id: "obstacle", ...gate.outside })
+    }
+    if (access === "recalled") stepMonkEvangelism(monk, map, false, 2, .1)
+    const sim = createSim([t], map, [], obscure)
+    stepSim(sim, [t], map, 1.5, .2)
+    expect(sim.travelers.get(t.id)!.activity).toBe(access === "open" ? "toRelic" : "walking")
+    expect(sim.travelers.get(t.id)!.rolls).toBe(access === "recalled" ? 1 : 2)
   })
 })
 

--- a/lib/game/monk-evangelism-store.ts
+++ b/lib/game/monk-evangelism-store.ts
@@ -1,0 +1,13 @@
+import { create } from "zustand"
+
+interface EvangelismControls {
+  available: boolean
+  assigned: ReadonlySet<number>
+  request: (id: number) => void
+  recall: (id: number) => void
+}
+export const useMonkEvangelismStore = create<EvangelismControls>((set, get) => ({
+  available: false, assigned: new Set(),
+  request: id => { if (get().available) set({ assigned: new Set([...get().assigned, id]) }) },
+  recall: id => { const assigned = new Set(get().assigned); assigned.delete(id); set({ assigned }) },
+}))

--- a/lib/game/monk-evangelism.test.ts
+++ b/lib/game/monk-evangelism.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it } from "vitest"
+import { BUILD_CATALOG } from "./balance"
+import { activityClip } from "./base-person/activity"
+import { generateMap } from "./map/generate-map"
+import { tileToWorldX, tileToWorldZ, worldToTileX, worldToTileZ, type GameMap } from "./map/types"
+import { createMonkRoutine } from "./monk-routine"
+import { monkWander } from "./monk-wander"
+import { createMonkNeeds, stepMonkWork } from "./monk-work"
+import { MONK_EVANGELISM, preachingRegistry, preachingSpots, roadsideEvangelism, stepMonkEvangelism, type EvangelizingMonk } from "./monk-evangelism"
+import { useMonkEvangelismStore } from "./monk-evangelism-store"
+
+function fixture() {
+  const map: GameMap = { width: 20, depth: 20, tiles: Array(400).fill("grass"),
+    buildings: [{ id: "shrine", x: 8, z: 10, w: 3, d: 3, height: 1, label: "Shrine", color: "", roofColor: "" }],
+    road: Array.from({ length: 20 }, (_, x) => ({ x, z: 4 })),
+    site: { hovelId: "shrine", junction: 9, door: { x: 9, z: 9 }, branch: Array.from({ length: 6 }, (_, i) => ({ x: 9, z: 4 + i })) } }
+  for (const p of map.road!) map.tiles[p.z * map.width + p.x] = "path"
+  for (const p of map.site!.branch.slice(1)) map.tiles[p.z * map.width + p.x] = "track"
+  const monk: EvangelizingMonk = { ...createMonkRoutine(monkWander(map), 0, () => .5), ...createMonkNeeds(0),
+    x: tileToWorldX(map, 9), z: tileToWorldZ(map, 9) }
+  preachingRegistry.current = { road: map.road, monks: [monk] }
+  return { map, monk }
+}
+function arrive(monk: EvangelizingMonk, map: GameMap) {
+  for (let tick = 0; tick < 1500 && monk.activity !== "preaching"; tick++) stepMonkEvangelism(monk, map, true, 2, .1)
+  expect(monk.activity).toBe("preaching")
+}
+afterEach(() => { preachingRegistry.current = null; useMonkEvangelismStore.setState({ available: false, assigned: new Set() }) })
+
+describe("roadside preaching", () => {
+  it("walks to a shoulder, faces the road and only persuades after arrival", () => {
+    const { map, monk } = fixture()
+    stepMonkEvangelism(monk, map, true, 2, .1)
+    expect(monk.activity).toBe("toEvangelize")
+    expect(roadsideEvangelism(map)).toBe(0)
+    arrive(monk, map)
+    const tile = { x: worldToTileX(map, monk.x), z: worldToTileZ(map, monk.z) }
+    expect(map.road).not.toContainEqual(tile)
+    expect(map.site!.branch).not.toContainEqual(tile)
+    expect(map.road!.some(p => Math.abs(p.x - tile.x) + Math.abs(p.z - tile.z) === 1)).toBe(true)
+    expect(monk.preachingTask!.heading).toBe(Math.atan2(0, 1))
+    expect(activityClip(monk.activity, false)).toBe("idle")
+    expect(roadsideEvangelism(map)).toBeCloseTo(MONK_EVANGELISM)
+    const before = { x: monk.x, z: monk.z }
+    stepMonkEvangelism(monk, map, true, 2, 1)
+    expect({ x: monk.x, z: monk.z }).toEqual(before)
+  })
+
+  it("combines with a cross, without stacking extra monks or affecting a different world", () => {
+    const { map, monk } = fixture()
+    arrive(monk, map)
+    preachingRegistry.current!.monks.push({ ...monk })
+    expect(roadsideEvangelism(map)).toBeCloseTo(.05)
+    map.buildings.push({ ...BUILD_CATALOG.find(b => b.id === "cross")!, id: "cross", buildType: "cross", x: 14, z: 10 })
+    expect(roadsideEvangelism(map)).toBeCloseTo(.0975)
+    expect(roadsideEvangelism({ ...map, road: [...map.road!] })).toBe(.05)
+  })
+
+  it.each(["recall", "tired"])("stops persuasion and walks home on %s", reason => {
+    const { map, monk } = fixture()
+    arrive(monk, map)
+    if (reason === "tired") monk.stamina = 25
+    expect(stepMonkEvangelism(monk, map, reason !== "recall", 2, .1)).toBe(false)
+    expect(roadsideEvangelism(map)).toBe(0)
+    expect(monk.preachingTask).toBeUndefined()
+    for (let i = 0; i < 300 && monk.destination === "home"; i++) stepMonkWork(monk, map, 2, .1)
+    expect(monk.x).toBeCloseTo(tileToWorldX(map, map.site!.door.x))
+    expect(monk.z).toBeCloseTo(tileToWorldZ(map, map.site!.door.z))
+  })
+
+  it("freezes an approach while paused and cancels before arrival", () => {
+    const { map, monk } = fixture()
+    stepMonkEvangelism(monk, map, true, 2, .1)
+    const before = structuredClone(monk)
+    stepMonkEvangelism(monk, map, false, 2, 0)
+    expect(monk).toEqual(before)
+    stepMonkEvangelism(monk, map, false, 2, .1)
+    expect(monk.preachingTask).toBeUndefined()
+    expect(monk.destination).toBe("home")
+  })
+
+  it("reserves different shoulders and replans when construction blocks a preacher", () => {
+    const { map, monk } = fixture()
+    arrive(monk, map)
+    const occupied = monk.preachingTask!.tile
+    const other: EvangelizingMonk = { ...monk, preachingTask: undefined, route: [] }
+    stepMonkEvangelism(other, map, true, 2, .1, [occupied])
+    expect(other.preachingTask!.tile).not.toEqual(occupied)
+    const changed = { ...map, buildings: [...map.buildings, { ...map.buildings[0], ...occupied, w: 1, d: 1, id: "new", construction: { work: 0, required: 12 } }] }
+    stepMonkEvangelism(monk, changed, true, 2, .1)
+    expect(monk.preachingTask!.tile).not.toEqual(occupied)
+    expect(monk.preachingTask!.map).toBe(changed)
+  })
+
+  it("declines orders when all shoulders are impassable", () => {
+    const { map, monk } = fixture()
+    for (const tile of preachingSpots(map)) map.tiles[tile.z * map.width + tile.x] = "water"
+    expect(stepMonkEvangelism(monk, map, true, 2, .1)).toBe(false)
+    expect(monk.preachingTask).toBeUndefined()
+    expect(roadsideEvangelism(map)).toBe(0)
+  })
+
+  it.each([1, 42, 12345])("finds a reachable roadside position in generated world %i", seed => {
+    const map = generateMap({ seed }), grounds = monkWander(map)
+    const monk = { ...createMonkRoutine(grounds, 0, () => .5), ...createMonkNeeds(0) }
+    expect(stepMonkEvangelism(monk, map, true, 2, .1)).toBe(true)
+    arrive(monk, map)
+  })
+
+  it("keeps individual orders independent and recalls them", () => {
+    const controls = useMonkEvangelismStore.getState()
+    controls.request(0)
+    expect(useMonkEvangelismStore.getState().assigned.size).toBe(0)
+    useMonkEvangelismStore.setState({ available: true })
+    controls.request(0); controls.request(1); controls.recall(0)
+    expect([...useMonkEvangelismStore.getState().assigned]).toEqual([1])
+  })
+})

--- a/lib/game/monk-evangelism.ts
+++ b/lib/game/monk-evangelism.ts
@@ -1,0 +1,77 @@
+import { walkWorker, workerRoute } from "./construction"
+import { ROUTE_DIRS } from "./map/route"
+import { tileAt, type GameMap, type TilePos } from "./map/types"
+import type { MonkRoutine } from "./monk-routine"
+import { MONK_TIRED_AT, type MonkNeeds } from "./monk-work"
+import { buildingAt, settlementEvangelism } from "./settlement"
+
+export const MONK_EVANGELISM = 0.05
+export interface PreachingTask { tile: TilePos; heading: number; map: GameMap }
+export type EvangelizingMonk = MonkRoutine & MonkNeeds & { preachingTask?: PreachingTask }
+
+/** The scene publishes live arrivals; an order alone never attracts travelers. */
+export const preachingRegistry: { current: { road: GameMap["road"]; monks: EvangelizingMonk[] } | null } = { current: null }
+
+/** Crosses and roadside preaching each offer an independent second chance. */
+export function roadsideEvangelism(map: GameMap): number {
+  const live = preachingRegistry.current
+  const preaching = live?.road === map.road && live?.monks.some(m => m.activity === "preaching" && m.preachingTask?.map === map)
+  const cross = settlementEvangelism(map)
+  return preaching ? 1 - (1 - cross) * (1 - MONK_EVANGELISM) : cross
+}
+
+/** Clear shoulders near the junction, never on the road or the relic branch. */
+export function preachingSpots(map: GameMap): TilePos[] {
+  if (!map.site || !map.road || map.site.branch.length < 2) return []
+  const junction = map.road[map.site.junction]
+  if (!junction) return []
+  const paths = new Set([...map.road, ...map.site.branch].map(p => `${p.x},${p.z}`))
+  const spots = new Map<string, TilePos>()
+  for (const road of map.road.slice(Math.max(0, map.site.junction - 2), map.site.junction + 3)) {
+    for (const [dx, dz] of ROUTE_DIRS) {
+      const tile = { x: road.x + dx, z: road.z + dz }, key = `${tile.x},${tile.z}`
+      const terrain = tileAt(map, tile.x, tile.z)
+      if (!terrain || !["grass", "dirt", "sand", "clearing", "hills"].includes(terrain) || paths.has(key) || buildingAt(map, tile.x, tile.z)) continue
+      spots.set(key, tile)
+    }
+  }
+  return [...spots.values()].sort((a, b) => Math.hypot(a.x - junction.x, a.z - junction.z) - Math.hypot(b.x - junction.x, b.z - junction.z))
+}
+
+export function stopEvangelizing(s: EvangelizingMonk): void {
+  s.preachingTask = undefined
+  s.route = []
+  s.pause = 0
+  s.destination = "home"
+  s.activity = "walking"
+}
+
+/** Explicit preaching interrupts ordinary work, then releases the monk when recalled or tired. */
+export function stepMonkEvangelism(s: EvangelizingMonk, map: GameMap, requested: boolean, speed: number, dt: number,
+  occupied: readonly TilePos[] = []): boolean {
+  if (dt <= 0) return !!s.preachingTask
+  if (!requested || s.stamina <= MONK_TIRED_AT) {
+    if (s.preachingTask) stopEvangelizing(s)
+    return false
+  }
+  if (!s.preachingTask || s.preachingTask.map !== map) {
+    let assigned = false
+    for (const tile of preachingSpots(map)) {
+      if (occupied.some(p => p.x === tile.x && p.z === tile.z)) continue
+      const route = workerRoute(map, s, tile)
+      if (!route) continue
+      const road = map.road!.reduce((best, p) => Math.hypot(p.x - tile.x, p.z - tile.z) < Math.hypot(best.x - tile.x, best.z - tile.z) ? p : best)
+      s.buildingTask = undefined
+      s.route = route
+      s.pause = 0
+      s.preachingTask = { tile, heading: Math.atan2(road.x - tile.x, road.z - tile.z), map }
+      s.activity = "toEvangelize"
+      assigned = true
+      break
+    }
+    if (!assigned) { stopEvangelizing(s); return false }
+  }
+  s.stamina = Math.max(0, s.stamina - dt * 0.25)
+  s.activity = walkWorker(s, s.route, speed, dt) ? "preaching" : "toEvangelize"
+  return true
+}

--- a/lib/game/monks.ts
+++ b/lib/game/monks.ts
@@ -32,9 +32,11 @@ const PIETY = { min: 75, max: 100 }
 const SKILL_COUNT = { min: 1, max: 3 }
 
 /** What a brother is up to, for the HUD; set by the scene's ambient loop. */
-export type MonkActivity = "toBuild" | "building" | "toShelter" | "sleeping" | "vigil" | "walking" | "resting" | "flying" | "collecting" | "procession" | "returningRelic" | "praying" | "hoisting"
+export type MonkActivity = "toEvangelize" | "preaching" | "toBuild" | "building" | "toShelter" | "sleeping" | "vigil" | "walking" | "resting" | "flying" | "collecting" | "procession" | "returningRelic" | "praying" | "hoisting"
 
 export const MONK_ACTIVITY_LABELS: Record<MonkActivity, string> = {
+  toEvangelize: "Going to preach beside the main road",
+  preaching: "Preaching to passing travelers",
   toBuild: "Going to a construction site",
   building: "Building a structure",
   toShelter: "Tired — going to the monk shelter",

--- a/lib/game/sim.ts
+++ b/lib/game/sim.ts
@@ -14,7 +14,8 @@ import { cartOffset, SHOP_SECONDS, cartLoadout } from "./transport/assets"
 import { createPasture, stepPasture, type PastureAnimal } from "./transport/pasture"
 import { LINEAR_MOVEMENT, easeSpeed, paceVariation, type MovementTuning } from "./motion"
 import { DEFAULT_BALANCE, type GameBalance } from "./balance"
-import { buildingAt, settlementEvangelism } from "./settlement"
+import { roadsideEvangelism } from "./monk-evangelism"
+import { buildingAt } from "./settlement"
 import { AXE_DAMAGE_PER_HOUR, STUMP_LIFETIME_DAYS, TIMBER_LOAD, stackWood, treeResource, type TreeResource, type WoodPile } from "./trees/timber"
 import { BUILDING_KINDS, buildingCentre, type PlacedBuilding } from "./buildings"
 import { generateRelic, hospitalityNeedThreshold, visitChance, type RelicStats } from "./relic"
@@ -1111,7 +1112,7 @@ export function stepSim(
               hunger: s.hunger, thirst: s.thirst, stamina: s.stamina }, sim.relic, renown, sim.balance)
             s.visitCooldown = 5
             const ordinaryVisit = nextRoll(s) < chance
-            const evangelism = ordinaryVisit ? 0 : settlementEvangelism(map)
+            const evangelism = ordinaryVisit ? 0 : roadsideEvangelism(map)
             const persuaded = evangelism > 0 && nextRoll(s) < evangelism
             const wantsVisit = (ordinaryVisit || persuaded) && s.gold >= admissionFee(map)
             const occupiedSeats = new Set([...sim.travelers.values()].flatMap(other =>


### PR DESCRIPTION
Adds a monk command to walk to a clear spot beside the main-road junction and preach until recalled or tired, giving otherwise uninterested travelers an extra 5% chance to visit the relic after the monk arrives.
Preaching combines independently with cross evangelism, does not stack across monks, respects shrine access and admission, and avoids interrupting the task with processions or flights.
The monk panel includes activity and recall controls plus rounded stamina, and the visitor forecast reflects active preaching; routes replan around new construction and monks resume their routine afterward.

Validated with 183 focused tests, TypeScript checks, and an in-game arrival, standing-preaching, and recall check with no page errors.
