### PR TITLE
Limit construction crews by building size and prefer paths

### DIFF
--- a/components/game/monks.tsx
+++ b/components/game/monks.tsx
@@ -98,6 +98,7 @@ export function Monks({ map, monks, relic, flying = false, characterScale = 1 }:
     processionRegistry.current = world.procession
     useRelicProcessionStore.setState({ available: !!world.grounds, monkId: null, stage: "idle", returnRequested: false })
     return () => {
+      for (const state of world.states) state.buildingTask = undefined
       if (preachingRegistry.current === preachers) {
         preachingRegistry.current = null
         useMonkEvangelismStore.setState({ available: false, assigned: new Set() })

--- a/components/game/travelers.tsx
+++ b/components/game/travelers.tsx
@@ -92,7 +92,10 @@ export function Travelers({
       if (!sim.travelers.has(id)) sim.travelers.set(id, traveler)
     }
     for (const id of sim.travelers.keys()) {
-      if (!fresh.travelers.has(id)) sim.travelers.delete(id)
+      if (!fresh.travelers.has(id)) {
+        sim.travelers.get(id)!.buildingTask = undefined
+        sim.travelers.delete(id)
+      }
     }
   }, [sim, travelers, map, relic])
 
@@ -102,6 +105,7 @@ export function Travelers({
   useEffect(() => {
     simRegistry.current = sim
     return () => {
+      for (const traveler of sim.travelers.values()) traveler.buildingTask = undefined
       if (simRegistry.current === sim) simRegistry.current = null
     }
   }, [sim])

--- a/lib/game/construction.test.ts
+++ b/lib/game/construction.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { assignBuildingTask, buildingEntrance, constructionStandOff, constructionStage, constructionWork, isComplete, stepBuildingTask, type Worker } from "./construction"
+import { assignBuildingTask, buildingEntrance, constructionBuilders, constructionStandOff, constructionStage, constructionWork, isComplete, stepBuildingTask, type Worker } from "./construction"
 import { constructionParts } from "./building-art/construction"
 import { structureParts } from "./building-art/structure"
 import { generateMap } from "./map/generate-map"
@@ -49,6 +49,39 @@ describe("resident construction", () => {
     expect(constructionWork(4, 3)).toBe(864)
   })
 
+  it.each([[1, 1, 1], [2, 1, 1], [2, 2, 1], [3, 2, 2], [3, 3, 3], [4, 4, 4], [8, 8, 4]])(
+    "limits a %s by %s site to %s builders, including those still walking", (w, d, limit) => {
+      const map = fixture(), site = map.buildings[2]
+      Object.assign(site, { x: 0, z: 10, w, d })
+      // Keep the largest footprint and frontage inside the fixture.
+      map.depth = 24; map.tiles = Array(map.width * map.depth).fill("grass")
+      const actors = Array.from({ length: 5 }, () => worker(map, 10, 20))
+      expect(constructionBuilders(w, d)).toBe(limit)
+      for (let i = 0; i < actors.length; i++) expect(assignBuildingTask(actors[i], map, "build")).toBe(i < limit)
+      expect(site.construction!.work).toBe(0)
+      expect(new Set(actors.slice(0, limit).map(actor => actor.buildingTask!.slot % 4)).size).toBe(limit)
+      // Republishing the map must preserve reservations and let an existing worker reroute.
+      const published = { ...map, buildings: [...map.buildings] }
+      expect(assignBuildingTask(actors[0], published, "build", site.id)).toBe(true)
+      expect(assignBuildingTask(actors[limit], published, "build")).toBe(false)
+      actors[0].buildingTask = undefined
+      expect(assignBuildingTask(actors[limit], published, "build")).toBe(true)
+    },
+  )
+
+  it("sends spare builders to another site and releases reservations for rest", () => {
+    const map = fixture(), a = worker(map), b = worker(map), c = worker(map)
+    const site = map.buildings[2]
+    expect(assignBuildingTask(a, map, "build")).toBe(true)
+    map.buildings.push({ ...site, id: "second-site", x: 12, construction: { work: 0, required: 96 } })
+    expect(assignBuildingTask(b, map, "build")).toBe(true)
+    expect(b.buildingTask!.buildingId).toBe("second-site")
+    expect(assignBuildingTask(c, map, "build")).toBe(false)
+    expect(assignBuildingTask(a, map, "rest")).toBe(true)
+    expect(assignBuildingTask(c, map, "build")).toBe(true)
+    expect(c.buildingTask!.buildingId).toBe(site.id)
+  })
+
   it.each([false, true])("keeps the current job when another site is placed (at work: %s)", atWork => {
     const map = fixture(), actor = worker(map), site = map.buildings[2]
     assignBuildingTask(actor, map, "build")
@@ -91,6 +124,7 @@ describe("resident construction", () => {
 
   it("adds cooperative work without crediting absent or paused workers", () => {
     const map = fixture(), site = map.buildings[2], a = worker(map, 2, 12), b = worker(map, 2, 12)
+    site.w = 3
     for (const actor of [a, b]) {
       assignBuildingTask(actor, map, "build")
       while (actor.buildingTask!.route.length) stepBuildingTask(actor, map, 1, 0.1)
@@ -128,6 +162,7 @@ describe("resident construction", () => {
 
   it.each([0.5, 1.5, 4])("stands at mallet reach from the wall at character scale %s", scale => {
     const map = fixture(), site = map.buildings[2]
+    site.w = 4; site.d = 4
     const actors = Array.from({ length: 4 }, (_, workSlot) => ({ ...worker(map), workSlot, workScale: scale }))
     for (const actor of actors) {
       assignBuildingTask(actor, map, "build")

--- a/lib/game/construction.ts
+++ b/lib/game/construction.ts
@@ -10,6 +10,8 @@ import type { WanderSpot } from "./monk-wander"
 export interface Construction { work: number; required: number; cost?: { gold: number; wood: number } }
 /** Worker-seconds: small sites finish quickly; doubling the area quadruples the work. */
 export function constructionWork(w: number, d: number): number { return Math.max(12, 6 * (w * d) ** 2) }
+/** Small sites need one builder; each additional four tiles adds a place, up to four. */
+export function constructionBuilders(w: number, d: number): number { return Math.min(4, Math.max(1, Math.ceil(w * d / 4))) }
 export function isComplete(building: BuildingDef): boolean {
   return !building.construction || building.construction.work >= building.construction.required
 }
@@ -30,6 +32,16 @@ export interface BuildingTask {
   buildings: readonly BuildingDef[]
 }
 export interface Worker extends WanderSpot { buildingTask?: BuildingTask; workSlot?: number; workScale?: number }
+// Construction survives map publications and is shared by monks and settlers.
+// Keep reservations out of saved game data; a cancelled/replaced task frees its place.
+const buildingCrews = new WeakMap<Construction, Map<Worker, BuildingTask>>()
+function constructionCrew(building: BuildingDef): Map<Worker, BuildingTask> {
+  const construction = building.construction!
+  let crew = buildingCrews.get(construction)
+  if (!crew) { crew = new Map(); buildingCrews.set(construction, crew) }
+  for (const [worker, task] of crew) if (worker.buildingTask !== task) crew.delete(worker)
+  return crew
+}
 export function workerRoute(map: GameMap, actor: WanderSpot, goal: TilePos): WanderSpot[] | null {
   const start = { x: worldToTileX(map, actor.x), z: worldToTileZ(map, actor.z) }
   // A footprint may be placed beneath an idle resident. Let them leave that
@@ -59,21 +71,26 @@ function taskPosition(map: GameMap, building: BuildingDef, purpose: BuildingTask
   return { destination: { x: cx + offset.x, z: cz + offset.z, y: surfaceHeight(map, frontage.x, frontage.z) }, frontage }
 }
 
-/** Only reachable jobs qualify; several free residents may cooperate on one site. */
+/** Reserve a place before walking so en-route builders count toward the site's crew. */
 export function assignBuildingTask(actor: Worker, map: GameMap, purpose: BuildingTask["purpose"], focusedBuildingId?: string): boolean {
   const candidates = map.buildings.filter(b => purpose === "build" ? !isComplete(b) : isMonkShelter(b) && isComplete(b))
     .filter(b => !focusedBuildingId || b.id === focusedBuildingId)
     .sort((a, b) => Math.hypot(tileToWorldX(map, a.x) - actor.x, tileToWorldZ(map, a.z) - actor.z) -
       Math.hypot(tileToWorldX(map, b.x) - actor.x, tileToWorldZ(map, b.z) - actor.z))
   for (const building of candidates) {
+    const crew = purpose === "build" ? constructionCrew(building) : null
+    const others = crew ? [...crew.keys()].filter(worker => worker !== actor) : []
+    if (others.length >= constructionBuilders(building.w, building.d)) continue
     for (let attempt = 0; attempt < (purpose === "build" ? 4 : 1); attempt++) {
       const slot = (actor.workSlot ?? 0) + attempt
+      if (others.some(worker => worker.buildingTask!.slot % 4 === slot % 4)) continue
       const { destination, frontage } = taskPosition(map, building, purpose, slot, actor.workScale)
       const route = purpose === "build" ? workerRoute(map, actor, frontage) : routeToDestination(map, actor, destination)
       if (!route) continue
       if (purpose === "build") route.push(destination)
       actor.buildingTask = { buildingId: building.id, purpose, slot, heading: Math.PI + buildingYaw(building.rotation), route,
         destination: { ...destination }, buildings: map.buildings }
+      crew?.set(actor, actor.buildingTask)
       return true
     }
   }

--- a/lib/game/map/terrain.ts
+++ b/lib/game/map/terrain.ts
@@ -26,6 +26,11 @@ export function isWoods(id: TerrainId): boolean {
   return id === "forest" || id === "darkwood"
 }
 
+/** A modest detour along a road beats crossing open ground; off-road goals stay reachable. */
+export function walkingRouteCost(id: TerrainId): number {
+  return id === "path" || id === "track" || id === "bridge" ? 1 : 3
+}
+
 export interface TerrainDef {
   id: TerrainId
   label: string

--- a/lib/game/monk-wander.ts
+++ b/lib/game/monk-wander.ts
@@ -3,8 +3,8 @@ import { buildingStepAllowed, containsTile, shrineFurnitureClear } from "./build
 import { surfaceHeight } from "./map/bridges"
 import { walkingSurface } from "./map/walking-surface"
 import { elevationStep } from "./map/elevation"
-import { ROUTE_DIRS } from "./map/route"
-import { TERRAIN } from "./map/terrain"
+import { MinHeap, ROUTE_DIRS } from "./map/route"
+import { TERRAIN, walkingRouteCost } from "./map/terrain"
 import { tileAt, tileToWorldX, tileToWorldZ, type GameMap, type TilePos } from "./map/types"
 import { buildingAt } from "./settlement"
 
@@ -58,6 +58,7 @@ export function monkWander(map: GameMap, radius = 3) {
     if (!reachable.has(n)) { reachable.add(n); queue.push(n) }
   }
   const nodes = queue.map(id => candidates.get(id)!)
+  const nodeIndices = new Map(queue.map((id, index) => [id, index]))
   const prayerSpots: WanderSpot[] = []
   if (layout) for (const [dx, dz] of ROUTE_DIRS) {
     const target = { x: tileToWorldX(map, layout.altarTile.x + dx), z: tileToWorldZ(map, layout.altarTile.z + dz) }
@@ -80,11 +81,22 @@ export function monkWander(map: GameMap, radius = 3) {
       const first = nearest(start), last = nearest(goal)
       if (!first || !last) return []
       const a = key(first.tile), b = key(last.tile)
-      const parents = new Map<string, string | null>([[a, null]]), open = [a]
-      for (let head = 0; head < open.length; head++) {
-        const current = open[head]
+      const parents = new Map<string, string | null>([[a, null]])
+      const costs = new Map<string, number>([[a, 0]]), closed = new Set<string>(), open = new MinHeap()
+      open.push(nodeIndices.get(a)!, 0)
+      while (open.size) {
+        const current = queue[open.pop()]
+        if (closed.has(current)) continue
+        closed.add(current)
         if (current === b) break
-        for (const n of adjacent.get(current)!) if (!parents.has(n)) { parents.set(n, current); open.push(n) }
+        const from = candidates.get(current)!.tile
+        for (const n of adjacent.get(current)!) {
+          const to = candidates.get(n)!.tile
+          const cost = costs.get(current)! + Math.hypot(to.x - from.x, to.z - from.z)
+            * walkingRouteCost(tileAt(map, Math.round(to.x), Math.round(to.z))!)
+          if (cost >= (costs.get(n) ?? Infinity)) continue
+          costs.set(n, cost); parents.set(n, current); open.push(nodeIndices.get(n)!, cost)
+        }
       }
       if (!parents.has(b)) return []
       const path: WanderSpot[] = []

--- a/lib/game/settlement-route.test.ts
+++ b/lib/game/settlement-route.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest"
+import { settlementRoute } from "./settlement-route"
+import { workerRoute } from "./construction"
+import { monkWander } from "./monk-wander"
+import { tileAt, tileToWorldX, tileToWorldZ, worldToTileX, worldToTileZ, type GameMap, type TilePos } from "./map/types"
+import type { TerrainId } from "./map/terrain"
+import { surfaceHeight } from "./map/bridges"
+
+function fixture(surface: TerrainId = "path"): GameMap {
+  const map: GameMap = { width: 12, depth: 12, tiles: Array(144).fill("grass"), buildings: [] }
+  for (let x = 2; x <= 8; x++) map.tiles[7 * map.width + x] = surface
+  return map
+}
+const start = { x: 2, z: 6 }, goal = { x: 8, z: 6 }
+function world(map: GameMap, p: TilePos) {
+  return { x: tileToWorldX(map, p.x), y: surfaceHeight(map, p.x, p.z), z: tileToWorldZ(map, p.z) }
+}
+
+describe("characters prefer paths", () => {
+  it.each(["path", "track", "bridge"] as TerrainId[])("takes a modest %s detour instead of cutting across grass", surface => {
+    const map = fixture(surface)
+    const route = settlementRoute(map, [], start, goal)!
+    expect(route).toHaveLength(9)
+    expect(route.filter(p => tileAt(map, p.x, p.z) === surface)).toHaveLength(7)
+    expect(route.at(-1)).toEqual(goal)
+    const worker = workerRoute(map, world(map, start), goal)!
+    expect(worker.map(p => ({ x: worldToTileX(map, p.x), z: worldToTileZ(map, p.z) }))).toEqual(route)
+  })
+
+  it("crosses open ground when there is no useful path", () => {
+    const map = fixture()
+    for (let x = 2; x <= 8; x++) { map.tiles[7 * map.width + x] = "grass"; map.tiles[x] = "path" }
+    const route = settlementRoute(map, [], start, goal)!
+    expect(route).toHaveLength(7)
+    expect(route.every(p => p.z === 6)).toBe(true)
+  })
+
+  it("does not let a preferred path bypass water or building obstacles", () => {
+    const map = fixture()
+    map.tiles[7 * map.width + 5] = "water"
+    map.buildings.push({ id: "wall", x: 4, z: 7, w: 1, d: 1, height: 1, label: "Wall", color: "", roofColor: "" })
+    const route = settlementRoute(map, map.buildings, start, goal)!
+    expect(route.at(-1)).toEqual(goal)
+    expect(route.some(p => p.z === 7 && (p.x === 4 || p.x === 5))).toBe(false)
+    for (let z = 0; z < map.depth; z++) map.tiles[z * map.width + 5] = "water"
+    expect(settlementRoute(map, map.buildings, start, goal)).toBeNull()
+  })
+
+  it("uses the same path preference while monks wander the grounds", () => {
+    const map = fixture()
+    map.buildings = [{ id: "hovel", x: 5, z: 4, w: 1, d: 1, height: 1, label: "Hovel", color: "", roofColor: "" }]
+    map.site = { hovelId: "hovel", door: { x: 5, z: 5 }, junction: 0, branch: [] }
+    const route = monkWander(map).route(world(map, start), world(map, goal))
+    expect(route.at(-1)).toEqual(world(map, goal))
+    expect(route.filter(p => worldToTileZ(map, p.z) === 7)).toHaveLength(7)
+  })
+})

--- a/lib/game/settlement-route.ts
+++ b/lib/game/settlement-route.ts
@@ -1,10 +1,10 @@
 import { buildingStepAllowed } from "./building-navigation"
 import { elevationStep } from "./map/elevation"
-import { ROUTE_DIRS } from "./map/route"
-import { isWoods, TERRAIN } from "./map/terrain"
+import { MinHeap, ROUTE_DIRS } from "./map/route"
+import { isWoods, TERRAIN, walkingRouteCost } from "./map/terrain"
 import { tileAt, type BuildingDef, type GameMap, type TilePos } from "./map/types"
 
-/** Walk around water and footprints; woodcutters may enter the woods to work. */
+/** Prefer paths around water and footprints; woodcutters may enter the woods to work. */
 export function settlementRoute(
   map: GameMap,
   buildings: readonly BuildingDef[],
@@ -19,10 +19,16 @@ export function settlementRoute(
   const origin = key(start)
   const end = key(goal)
   const parents = new Map<number, number>([[origin, -1]])
-  const queue = [start]
-  for (let head = 0; head < queue.length; head++) {
-    const p = queue[head]
-    const current = key(p)
+  const costs = new Map<number, number>([[origin, 0]])
+  const closed = new Set<number>()
+  const queue = new MinHeap()
+  const heuristic = (p: TilePos) => Math.abs(p.x - goal.x) + Math.abs(p.z - goal.z)
+  queue.push(origin, heuristic(start))
+  while (queue.size) {
+    const current = queue.pop()
+    if (closed.has(current)) continue
+    closed.add(current)
+    const p = { x: current % map.width, z: Math.floor(current / map.width) }
     if (current === end) {
       const result: TilePos[] = []
       for (let i = end; i !== -1; i = parents.get(i)!) {
@@ -38,9 +44,11 @@ export function settlementRoute(
       if (!buildingStepAllowed(map, buildings, p, next, enterShrine, seatAccess)) continue
       const index = key(next)
       if (map.tiles[current] !== "bridge" && terrain !== "bridge" && !Number.isFinite(elevationStep(map.elevation, current, index))) continue
-      if (parents.has(index)) continue
+      const cost = costs.get(current)! + walkingRouteCost(terrain)
+      if (cost >= (costs.get(index) ?? Infinity)) continue
+      costs.set(index, cost)
       parents.set(index, current)
-      queue.push(next)
+      queue.push(index, cost + heuristic(next))
     }
   }
   return null


### PR DESCRIPTION
Small construction sites, including crosses and 2×2 buildings, now reserve one builder, with larger footprints allowing up to four and workers already walking to a site counting toward the limit. Reservations are shared by monks and settlers, prevent overlapping work slots, and are released when tasks change or characters leave. Settlement travel and monk wandering now prefer paths, tracks, and bridges while retaining off-path access and obstacle checks.

Validation: all 775 tests passed with `npm test -- --maxWorkers=2 --testTimeout=60000`, and `npm run typecheck` passed.
