### PR TITLE
Prevent terrain from clipping through founding building floors

### DIFF
--- a/lib/game/map/elevation.test.ts
+++ b/lib/game/map/elevation.test.ts
@@ -7,6 +7,20 @@ import { tileToWorldX, tileToWorldZ, type GameMap } from "./types"
 import { walkingSurface } from "./walking-surface"
 
 describe("topography", () => {
+  it.each([1, 42, 7919])("keeps every founding building's floor clear of terrain for seed %i", seed => {
+    const map = generateMap({ seed })
+    for (const building of map.buildings) {
+      const foundation = groundHeight(map, building.x + (building.w - 1) / 2, building.z + (building.d - 1) / 2)
+      for (let z = building.z; z < building.z + building.d; z++) for (let x = building.x; x < building.x + building.w; x++) {
+        const i = z * map.width + x
+        for (const corner of map.elevation!.corners.slice(i * 4, i * 4 + 4)) {
+          expect(corner + 0.2, `${building.id} at ${x},${z}`).toBeCloseTo(foundation, 10)
+        }
+        expect(walkingSurface(map, tileToWorldX(map, x), tileToWorldZ(map, z))).toEqual({ height: foundation, dx: 0, dz: 0 })
+      }
+    }
+  })
+
   it.each([{ x: 2, z: 2, w: 2, d: 2 }, { x: 0, z: 0, w: 1, d: 1 }, { x: 5, z: 4, w: 3, d: 4 }])(
     "levels the entire building pad and joins its dry perimeter at $x,$z", (building) => {
       const width = 8, depth = 8, water = new Uint8Array(width * depth)

--- a/lib/game/map/elevation.ts
+++ b/lib/game/map/elevation.ts
@@ -178,7 +178,8 @@ export function finishElevation(e: ElevationInfo, width: number, depth: number, 
 }
 
 /**
- * Cut and fill a purchased footprint at the height shown by its placement ghost.
+ * Cut and fill any building footprint at its current ground-centre height
+ * (the placement ghost's height for purchases).
  * Pin every corner, including the perimeter: averaging tile heights alone would
  * let the surrounding slope poke back through the floor. Unoccupied dry tiles
  * sharing those corners meet the pad; existing foundations and water stay put.

--- a/lib/game/map/generate-map.ts
+++ b/lib/game/map/generate-map.ts
@@ -1,7 +1,7 @@
 import { beachAccess } from "./beaches"
 import { taperRiverBanks, gradeBridgeApproaches } from "./river-banks"
 import { bridgeLayout } from "./bridges"
-import { generateElevation, finishElevation, elevationStep, type ElevationInfo, type ElevationSettings } from "./elevation"
+import { generateElevation, finishElevation, levelBuildingGround, elevationStep, type ElevationInfo, type ElevationSettings } from "./elevation"
 import { drainWater } from "./hydrology"
 import { makeRng } from "../rng"
 import { computeDarkShade, computeForestShade } from "./forest-field"
@@ -854,8 +854,11 @@ export function generateMap(options: GenerateMapOptions): GameMap {
     water: waterInfo,
   }
   finishElevation(elevation, width, depth, kind, waterInfo.surface!)
+  // Corner averaging can pull surrounding slopes back through founding floors.
+  // Pin every footprint with the same cut-and-fill used for player purchases.
+  for (const building of map.buildings) map.elevation = levelBuildingGround(map, building)
   // Bridge grading and founding can raise a formerly low beach; classify sand last.
-  const sandy = beachAccess(elevation, width, depth, kind, waterInfo)
+  const sandy = beachAccess(map.elevation!, width, depth, kind, waterInfo)
   for (let i = 0; i < tiles.length; i++) if (tiles[i] === "sand" && !sandy[i]) tiles[i] = "grass"
   return map
 }


### PR DESCRIPTION
Terrain corner averaging could push nearby slopes through founding building floors, especially the monk shelter. Apply the same full-footprint leveling used for purchased buildings to every generated building after corner averaging, and classify beaches using the resulting elevation. Add regression coverage across three seeds for flat foundations and matching walking surfaces.

Validation: all 99 elevation, settlement, and game tests pass; TypeScript checking passes; Playwright before/after screenshots confirm the selected shelter floor is fully visible with no browser errors.
