### PR TITLE
Limit tree bird flocks to the first three chops

### DIFF
--- a/lib/game/wildlife/simulation.ts
+++ b/lib/game/wildlife/simulation.ts
@@ -25,6 +25,7 @@ export interface WildlifeWorld {
   burrows: RabbitBurrow[]
   animals: WildlifeAnimal[]; habitat: ReturnType<typeof wildlifeHabitat>; trees: readonly TreePlacement[]
   rng: () => number; canopy: number
+  treeDisturbances: Map<number, { chops: number; birdChop: number; flushed: boolean }>
 }
 
 export function treePerch(tree: TreePlacement, id = 0, sheltered = false) {
@@ -37,7 +38,7 @@ export function treePerch(tree: TreePlacement, id = 0, sheltered = false) {
 }
 export function createWildlife(map: GameMap, trees: readonly TreePlacement[], scale = 1): WildlifeWorld {
   const rng = makeRng(deriveSeed(map.seed ?? 0, SEED_STREAM.wildlife))
-  const world: WildlifeWorld = { animals: [], burrows: [], habitat: wildlifeHabitat(map, trees), trees, rng,
+  const world: WildlifeWorld = { animals: [], burrows: [], habitat: wildlifeHabitat(map, trees), trees, rng, treeDisturbances: new Map(),
     canopy: trees.reduce((height, tree) => Math.max(height, treePerch(tree).y), 2) + 0.8 }
   let group = 0
   const candidates = new Map<WildlifeKind, Point[]>()
@@ -135,24 +136,34 @@ export function launchBird(world: WildlifeWorld, animal: WildlifeAnimal, map: Ga
 export function startleWildlife(world: WildlifeWorld, tree: TreePlacement, map: GameMap, felled: ReadonlySet<number>) {
   const index = world.trees.indexOf(tree)
   if (index < 0 || felled.has(index)) return
+  let disturbance = world.treeDisturbances.get(index)
+  if (!disturbance) {
+    // Decide once per tree: only some crowns hide a flock, leaving on chop 1–3.
+    disturbance = { chops: 0, birdChop: world.rng() < 0.35 ? 1 + Math.floor(world.rng() * 3) : 0, flushed: false }
+    world.treeDisturbances.set(index, disturbance)
+  }
+  disturbance.chops++
+  const canFlush = disturbance.chops <= 3 && !disturbance.flushed
   let flushed = false
   for (const animal of world.animals) {
     if (animal.reserve || animal.burrowState === "inside") continue
     const near = Math.hypot(animal.x - tree.x, animal.z - tree.z) < 3.5
     if (isBird(animal.kind)) {
-      if (!animal.flight && (animal.perch === index || near)) {
+      if (canFlush && !animal.flight && (animal.perch === index || near)) {
         flushed = true; animal.frightened = 5; launchBird(world, animal, map, felled, index)
       }
     } else if (near && !isDomestic(animal.kind)) { animal.frightened = 6; animal.rest = 0; animal.target = null }
   }
-  if (!flushed && world.rng() < 0.55) {
+  if (canFlush && !flushed && disturbance.chops === disturbance.birdChop) {
     const flock = world.animals.filter(a => a.transient && a.concealed).slice(0, 2 + Math.floor(world.rng() * 2))
     for (const animal of flock) {
+      flushed = true
       Object.assign(animal, treePerch(tree, animal.id))
       animal.concealed = false; animal.reserve = false; animal.frightened = 5
       launchBird(world, animal, map, felled, index)
     }
   }
+  disturbance.flushed ||= flushed
 }
 
 export function stepWildlife(world: WildlifeWorld, map: GameMap, dt: number, scale = 1, felled: ReadonlySet<number> = new Set(), people: readonly Point[] = [], edits: Record<string, AnimalRigEdits> = {}) {

--- a/lib/game/wildlife/wildlife.test.ts
+++ b/lib/game/wildlife/wildlife.test.ts
@@ -1,6 +1,6 @@
 import * as THREE from "three"
 import { wildlifeGeometry } from "./batch"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { animalBoneLengths, animalLeg } from "../transport/animal-pose"
 import { RIG_TO_WORLD } from "../transport/assets"
 import { WALK_STANCE_FRACTION } from "../base-person/pose"
@@ -96,14 +96,42 @@ describe("birds", () => {
     }
     expect(landed).toBe(true)
   })
-  it("occasionally reveals a bounded flock from an otherwise unoccupied crown", () => {
+  it.each([0, 1, 2, 3])("reveals at most one hidden flock on an early chop (chosen chop %i)", birdChop => {
     const { map, trees } = fixture(), world = createWildlife(map, trees)
-    const tree = trees.find((_, i) => !world.animals.some(a => !a.concealed && a.perch === i))!
+    // Keep ambient birds out of this hidden-flock scenario.
+    for (const animal of world.animals) if (isBird(animal.kind)) animal.reserve = true
+    const tree = trees[0]
+    world.rng = vi.fn(() => 0.1).mockReturnValueOnce(birdChop ? 0.1 : 0.9)
+    if (birdChop) vi.mocked(world.rng).mockReturnValueOnce((birdChop - 0.5) / 3)
     const count = world.animals.length
-    for (let hit = 0; hit < 20; hit++) startleWildlife(world, tree, map, new Set())
-    expect(world.animals.filter(a => a.transient && !a.concealed).length).toBeGreaterThan(0)
+    for (let hit = 1; hit <= 20; hit++) {
+      startleWildlife(world, tree, map, new Set())
+      const flying = world.animals.filter(a => a.transient && !a.concealed)
+      expect(flying.length).toBe(hit === birdChop ? 2 : 0)
+      // Make the pool available again, as after landing and returning to cover.
+      for (const animal of flying) {
+        animal.flight = null; animal.concealed = true; animal.reserve = true
+      }
+    }
     expect(world.animals.length).toBe(count)
     expect(world.animals.filter(a => a.transient).length).toBe(6)
+  })
+  it("does not flush returning birds again or startle late arrivals after the third chop", () => {
+    const { map, trees } = fixture(), world = createWildlife(map, trees)
+    const bird = world.animals.find(a => a.kind === "sparrow" && !a.reserve)!, index = bird.perch!, tree = trees[index]
+    startleWildlife(world, tree, map, new Set())
+    expect(bird.flight).not.toBeNull()
+    Object.assign(bird, { flight: null, perch: index, x: tree.x, z: tree.z })
+    startleWildlife(world, tree, map, new Set())
+    expect(bird.flight).toBeNull()
+
+    const otherIndex = trees.findIndex(t => Math.abs(t.z - tree.z) > 7), otherTree = trees[otherIndex]
+    for (const animal of world.animals) if (isBird(animal.kind)) animal.reserve = true
+    world.rng = () => 0.9
+    for (let hit = 0; hit < 3; hit++) startleWildlife(world, otherTree, map, new Set())
+    Object.assign(bird, { reserve: false, flight: null, perch: otherIndex, x: otherTree.x, z: otherTree.z })
+    startleWildlife(world, otherTree, map, new Set())
+    expect(bird.flight).toBeNull()
   })
   it("abandons felled perches and remains airborne when there are no trees", () => {
     const { map, trees } = fixture(), world = createWildlife(map, trees)


### PR DESCRIPTION
Tree chopping could repeatedly reveal new bird flocks throughout felling. Give each tree a single 35% chance of a hidden flock that emerges on one of the first three chops, and stop chop-triggered bird flights after a tree has flushed birds once or passed its third chop. Regression coverage checks empty crowns, each early departure timing, returning birds, and late arrivals.

Validation: all 28 targeted wildlife and tree-impact tests passed, along with `npm run typecheck`.
