### PR TITLE
Keep builders assigned until construction is complete

### DIFF
--- a/lib/game/construction.test.ts
+++ b/lib/game/construction.test.ts
@@ -210,9 +210,32 @@ describe("resident construction", () => {
 })
 
 describe("monk fatigue and rest", () => {
-  it("leaves work when tired, walks to shelter, sleeps, then resumes work and prayer", () => {
+  it.each([false, true])("finishes the assigned build before resting despite exhaustion (at work: %s)", atWork => {
+    const map = fixture(), site = map.buildings[2], grounds = monkWander(map)
+    const monk = { ...createMonkRoutine(grounds, 0, makeRng(1)), ...createMonkNeeds(0) }
+    site.construction!.required = constructionWork(site.w, site.d)
+    stepMonkWork(monk, map, 1, 0.1)
+    if (atWork) {
+      for (let i = 0; i < 300 && monk.activity !== "building"; i++) stepMonkWork(monk, map, 1, 0.1)
+      expect(monk.activity).toBe("building")
+    }
+    const task = monk.buildingTask, spare = worker(map)
+    expect(task?.purpose).toBe("build")
+    monk.stamina = 0
+    for (let i = 0; i < 1500 && !isComplete(site); i++) {
+      stepMonkWork(monk, map, 1, 0.1)
+      expect(monk.buildingTask).toBe(task)
+      expect(assignBuildingTask(spare, map, "build")).toBe(false)
+    }
+    expect(isComplete(site)).toBe(true)
+    for (let i = 0; i < 300 && monk.activity !== "sleeping"; i++) stepMonkWork(monk, map, 1, 0.1)
+    expect(monk.activity).toBe("sleeping")
+    expect(monk.stamina).toBeGreaterThan(0)
+  })
+
+  it("rests before taking new work when tired, then resumes work and prayer", () => {
     const map = fixture(), grounds = monkWander(map), rng = makeRng(1)
-    const monk = { ...createMonkRoutine(grounds, 0, rng), ...createMonkNeeds(0), stamina: 26 }
+    const monk = { ...createMonkRoutine(grounds, 0, rng), ...createMonkNeeds(0), stamina: 10 }
     map.buildings[2].construction!.required = 30
     let slept = false, woke = false, built = false, prayed = false
     for (let i = 0; i < 4000; i++) {

--- a/lib/game/hospitality.test.ts
+++ b/lib/game/hospitality.test.ts
@@ -451,6 +451,39 @@ describe("shrine hospitality", () => {
 })
 
 describe("woodcutter huts", () => {
+  it.each(["hunger", "thirst", "stamina"] as const)("keeps a settled builder assigned through completion with depleted %s", need => {
+    for (const atWork of [false, true]) {
+      const { map, camp, traveler } = fixture()
+      const t = traveler(0), sim = createSim([t], map), actor = sim.travelers.get(0)!
+      const site = { ...camp, id: "construction-site", x: 5, z: 6, construction: { work: 0, required: 96 } }
+      map.buildings.push(camp, site)
+      sim.buildings = [camp]
+      actor.employer = camp.id
+      actor.activity = "idle"
+      actor.x = tileToWorldX(map, camp.x); actor.z = tileToWorldZ(map, camp.z + camp.d)
+      stepSim(sim, [t], map, 1.5, 0.1)
+      expect(actor.activity).toBe("toBuild")
+      if (atWork) {
+        run(sim, [t], map, 60, () => actor.activity === "building")
+        expect(actor.activity).toBe("building")
+      }
+      const task = actor.buildingTask
+      actor[need] = 0
+      for (let i = 0; i < 1500 && site.construction.work < site.construction.required; i++) {
+        stepSim(sim, [t], map, 1.5, 0.1)
+        expect(actor.buildingTask).toBe(task)
+        expect(["toBuild", "building"]).toContain(actor.activity)
+      }
+      expect(site.construction.work).toBe(site.construction.required)
+      run(sim, [t], map, 60, () => actor.activity === "idle")
+      expect(actor.activity).toBe("idle")
+      expect(actor.buildingTask).toBeUndefined()
+      const depleted = actor[need]
+      stepSim(sim, [t], map, 1.5, 0.1)
+      expect(actor[need]).toBeGreaterThan(depleted)
+    }
+  })
+
   it("sends an idle settled worker to build, then returns them to camp", () => {
     const { map, camp, traveler } = fixture()
     const t = traveler(0), sim = createSim([t], map), actor = sim.travelers.get(0)!

--- a/lib/game/monk-work.ts
+++ b/lib/game/monk-work.ts
@@ -9,13 +9,12 @@ export const MONK_WAKE_AT = 95
 export interface MonkNeeds { workSlot: number; stamina: number; buildingTask?: BuildingTask; jobSearch: number }
 export function createMonkNeeds(index: number): MonkNeeds { return { workSlot: index, stamina: 100 - index * 6, jobSearch: 0 } }
 
-/** Rest takes precedence over new work. Prayer and explicit player orders can finish. */
+/** Finish assigned construction before resting; tired monks cannot take new work. */
 export function stepMonkWork(s: MonkRoutine & MonkNeeds, map: GameMap, speed: number, dt: number): boolean {
   if (dt <= 0) return !!s.buildingTask
   if (s.activity !== "sleeping") s.stamina = Math.max(0, s.stamina - dt * (s.activity === "building" ? 0.8 : 0.25))
   s.jobSearch = Math.max(0, s.jobSearch - dt)
-  if (s.stamina <= MONK_TIRED_AT && s.buildingTask?.purpose !== "rest" && s.jobSearch === 0) {
-    s.buildingTask = undefined
+  if (s.stamina <= MONK_TIRED_AT && !s.buildingTask && s.jobSearch === 0) {
     if (assignBuildingTask(s, map, "rest")) { s.route = []; s.pause = 0 }
     else s.jobSearch = 3
   }

--- a/lib/game/sim.ts
+++ b/lib/game/sim.ts
@@ -1094,7 +1094,7 @@ export function stepSim(
       case "toBuild":
       case "building": {
         if (dt <= 0) break
-        if (Math.min(s.hunger, s.thirst, s.stamina) <= 40) s.buildingTask = undefined
+        // Finish the assigned site before returning to camp to recover needs.
         const state = stepBuildingTask(s, map, targetSpeed, dt)
         if (!state) {
           const camp = sim.buildings.find(b => b.id === s.employer)


### PR DESCRIPTION
Monks and settlers were abandoning construction when their needs dropped, letting other workers take over unfinished sites. They now keep their assigned build through completion, then recover before taking new work. Regression tests cover exhausted workers while traveling and building, crew reservations, and recovery after completion.

Validation: all 112 tests across construction, hospitality, monk work, and monk evangelism pass; `npm run typecheck` and `git diff --check` pass.
