### PR TITLE
Add anonymous bug reports from world settings

### DIFF
--- a/app/api/bug-report/route.test.ts
+++ b/app/api/bug-report/route.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import fixture from "../../../lib/__fixtures__/bug-report.json"
+import { BUG_REPORT_BODY_LIMIT } from "../../../lib/bug-report"
+
+let POST: typeof import("./route").POST
+const payload = () => ({ message: "A traveler is stuck.", diagnostics: structuredClone(fixture) })
+const request = (body: unknown = payload(), headers: Record<string, string> = {}) => new Request("https://game.test/api/bug-report", {
+  method: "POST", headers: { origin: "https://game.test", "content-type": "application/json", ...headers }, body: JSON.stringify(body),
+})
+let github: ReturnType<typeof vi.fn>
+beforeEach(async () => {
+  vi.resetModules()
+  vi.stubEnv("BUG_REPORT_GITHUB_TOKEN", "test-server-token")
+  github = vi.fn().mockImplementation(async () => Response.json({ number: 42 }))
+  vi.stubGlobal("fetch", github)
+  POST = (await import("./route")).POST
+})
+afterEach(() => { vi.unstubAllEnvs(); vi.unstubAllGlobals() })
+
+describe("anonymous GitHub issue endpoint", () => {
+  it("creates an issue as the server account without forwarding identifying fields or headers", async () => {
+    const report = payload()
+    Object.assign(report.diagnostics, { email: "player@example.com", url: "private-url" })
+    const response = await POST(request(report, { cookie: "session=secret", "x-forwarded-for": "192.0.2.1" }))
+    expect(response.status).toBe(201)
+    expect(await response.json()).toEqual({ url: "https://github.com/tomjohndesign/pilgrimage/issues/42" })
+    const [url, init] = github.mock.calls[0]
+    expect(url).toBe("https://api.github.com/repos/tomjohndesign/pilgrimage/issues")
+    expect(init.headers.Authorization).toBe("Bearer test-server-token")
+    expect(JSON.stringify(init)).not.toMatch(/player@example|private-url|session=secret|192\.0\.2\.1/)
+    expect(JSON.parse(init.body).body).toContain('"seed": 1234')
+    expect(response.headers.get("Cache-Control")).toBe("no-store")
+  })
+
+  it("fails clearly without a configured credential", async () => {
+    vi.stubEnv("BUG_REPORT_GITHUB_TOKEN", "")
+    expect((await POST(request())).status).toBe(503)
+    expect(github).not.toHaveBeenCalled()
+  })
+
+  it("rejects foreign origins, wrong content types and malformed reports before GitHub", async () => {
+    expect((await POST(request(payload(), { origin: "https://foreign.test" }))).status).toBe(403)
+    expect((await POST(request(payload(), { "content-type": "text/plain" }))).status).toBe(415)
+    expect((await POST(request({ message: "", diagnostics: fixture }))).status).toBe(400)
+    const malformed = new Request("https://game.test/api/bug-report", { method: "POST", headers: { origin: "https://game.test", "content-type": "application/json" }, body: "{" })
+    expect((await POST(malformed)).status).toBe(400)
+    expect(github).not.toHaveBeenCalled()
+  })
+
+  it("bounds bytes even without a content-length header", async () => {
+    expect((await POST(request({ ...payload(), unexpected: "x".repeat(BUG_REPORT_BODY_LIMIT) }))).status).toBe(413)
+    expect(github).not.toHaveBeenCalled()
+  })
+
+  it("does not expose GitHub error bodies or secrets", async () => {
+    github.mockResolvedValue(new Response("test-server-token private upstream error", { status: 401 }))
+    const response = await POST(request())
+    expect(response.status).toBe(502)
+    expect(await response.text()).not.toMatch(/test-server-token|private upstream/)
+  })
+
+  it("explains uncertain delivery without automatically retrying", async () => {
+    github.mockRejectedValue(new Error("private network details"))
+    const response = await POST(request())
+    expect(response.status).toBe(502)
+    expect((await response.json()).error).toContain("may have arrived")
+    expect(github).toHaveBeenCalledTimes(1)
+  })
+
+  it("limits issue creation attempts per instance without retaining player identifiers", async () => {
+    for (let i = 0; i < 10; i++) expect((await POST(request())).status).toBe(201)
+    expect((await POST(request())).status).toBe(429)
+    expect(github).toHaveBeenCalledTimes(10)
+  })
+})

--- a/app/api/bug-report/route.ts
+++ b/app/api/bug-report/route.ts
@@ -1,0 +1,73 @@
+import { BUG_REPORT_BODY_LIMIT, BUG_REPORT_REPOSITORY, bugReportSchema, formatBugReport } from "../../../lib/bug-report"
+
+export const runtime = "nodejs"
+
+// A bounded per-instance circuit breaker, without retaining IPs or identifiers.
+// Production also needs a shared edge rate limit; see docs/bug-reports.md.
+let windowStart = 0
+let attempts = 0
+const reply = (error: string, status: number) => Response.json({ error }, { status, headers: { "Cache-Control": "no-store" } })
+
+export async function POST(request: Request) {
+  if (request.headers.get("origin") !== new URL(request.url).origin) return reply("This request must come from the game.", 403)
+  if (request.headers.get("content-type")?.split(";")[0].trim() !== "application/json") return reply("Expected a JSON report.", 415)
+  const token = process.env.BUG_REPORT_GITHUB_TOKEN
+  if (!token) return reply("Bug reporting is not configured yet. Please try again later.", 503)
+
+  // Enforce the actual byte count, including chunked requests with no declared size.
+  if (Number(request.headers.get("content-length")) > BUG_REPORT_BODY_LIMIT) return reply("The report is too large.", 413)
+  const reader = request.body?.getReader()
+  if (!reader) return reply("The report is empty.", 400)
+  let body = ""
+  let bytes = 0
+  const decoder = new TextDecoder()
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      bytes += value.byteLength
+      if (bytes > BUG_REPORT_BODY_LIMIT) {
+        await reader.cancel()
+        return reply("The report is too large.", 413)
+      }
+      body += decoder.decode(value, { stream: true })
+    }
+    body += decoder.decode()
+  } catch {
+    return reply("The report could not be read.", 400)
+  } finally {
+    reader.releaseLock()
+  }
+  let parsed
+  try { parsed = bugReportSchema.safeParse(JSON.parse(body)) }
+  catch { return reply("The report is invalid.", 400) }
+  if (!parsed.success) return reply("Please include a message and valid session diagnostics.", 400)
+
+  const now = Date.now()
+  if (now - windowStart >= 60 * 60 * 1000) { windowStart = now; attempts = 0 }
+  if (attempts >= 10) return reply("Too many reports. Please try again in an hour.", 429)
+  attempts++
+
+  try {
+    const response = await fetch(`https://api.github.com/repos/${BUG_REPORT_REPOSITORY}/issues`, {
+      method: "POST",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+      body: JSON.stringify(formatBugReport(parsed.data)),
+      signal: AbortSignal.timeout(15_000),
+      cache: "no-store",
+    })
+    if (!response.ok) return reply("GitHub could not accept the report. Your message is still here; please try again later.", 502)
+    const issue = await response.json()
+    if (!Number.isSafeInteger(issue.number) || issue.number <= 0) throw new Error("Invalid issue response")
+    return Response.json({ url: `https://github.com/${BUG_REPORT_REPOSITORY}/issues/${issue.number}` },
+      { status: 201, headers: { "Cache-Control": "no-store" } })
+  } catch {
+    // Never forward GitHub errors, request headers or credentials to the player.
+    return reply("Delivery could not be confirmed. Your report may have arrived; please check the repository before retrying.", 502)
+  }
+}

--- a/components/game/bug-report-dialog.tsx
+++ b/components/game/bug-report-dialog.tsx
@@ -1,0 +1,101 @@
+"use client"
+
+import { useRef, useState } from "react"
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog"
+import { BUG_REPORT_MESSAGE_LIMIT, BUG_REPORT_REPOSITORY, type BugReportDiagnostics } from "@/lib/bug-report"
+import { HudButton } from "./hud-button"
+
+/** The diagnostic snapshot stays fixed while the player reviews and submits it. */
+export function BugReportDialog({ diagnostics, onClose }: {
+  diagnostics: BugReportDiagnostics | null
+  onClose: () => void
+}) {
+  const [message, setMessage] = useState("")
+  const [sending, setSending] = useState(false)
+  const [error, setError] = useState("")
+  const [issueUrl, setIssueUrl] = useState("")
+  const inFlight = useRef(false)
+
+  function close() {
+    if (inFlight.current) return
+    setError("")
+    setIssueUrl("")
+    onClose()
+  }
+
+  async function submit() {
+    if (!diagnostics || !message.trim() || inFlight.current) return
+    inFlight.current = true
+    setSending(true)
+    setError("")
+    try {
+      const response = await fetch("/api/bug-report", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "omit",
+        body: JSON.stringify({ message, diagnostics }),
+        signal: AbortSignal.timeout(25_000),
+      })
+      const result = await response.json()
+      if (!response.ok) {
+        setError(typeof result.error === "string" ? result.error : "The report could not be sent. Please try again later.")
+        return
+      }
+      const prefix = `https://github.com/${BUG_REPORT_REPOSITORY}/issues/`
+      if (typeof result.url !== "string" || !result.url.startsWith(prefix) || !/^\d+$/.test(result.url.slice(prefix.length))) throw new Error("Invalid response")
+      setIssueUrl(result.url)
+      setMessage("")
+    } catch {
+      setError("Delivery could not be confirmed. Your report may have arrived; check the repository before retrying. Your message has been kept.")
+    } finally {
+      inFlight.current = false
+      setSending(false)
+    }
+  }
+
+  return <Dialog open={diagnostics !== null} onOpenChange={open => { if (!open) close() }}>
+    <DialogContent className="hud-report max-h-[85dvh] overflow-y-auto rounded-none border-rule bg-parchment text-ink sm:max-w-xl"
+      showCloseButton={!sending}
+      onKeyDown={event => event.stopPropagation()}
+      onEscapeKeyDown={event => { if (sending) event.preventDefault() }}
+      onInteractOutside={event => event.preventDefault()}
+      onCloseAutoFocus={event => {
+        event.preventDefault()
+        document.getElementById("bug-report-button")?.focus()
+      }}>
+      <DialogTitle className="font-display text-lg">Report a bug</DialogTitle>
+      <DialogDescription className="text-sm text-ink-light">
+        Your message and the diagnostics below will be posted to the Pilgrimage GitHub repository through the game’s account.
+        No player account, IP address, cookies, browsing history, or raw logs are attached.
+        Reports may be public. Please leave names, contact details, and other personal information out of your message.
+      </DialogDescription>
+      {issueUrl ? <div role="status" className="space-y-4 text-sm">
+        <p>Thank you. Your bug report was created.</p>
+        <a href={issueUrl} target="_blank" rel="noopener noreferrer" className="text-gold underline">View issue on GitHub</a>
+        <div><HudButton onClick={close}>Done</HudButton></div>
+      </div> : <form className="grid gap-4" onSubmit={event => { event.preventDefault(); void submit() }}>
+        <div className="grid gap-2">
+          <label htmlFor="bug-report-message" className="font-display text-xs">What went wrong?</label>
+          <textarea id="bug-report-message" required maxLength={BUG_REPORT_MESSAGE_LIMIT} rows={5}
+            value={message} disabled={sending} onChange={event => setMessage(event.target.value)}
+            placeholder="What were you doing? What happened, and what did you expect? Include steps to reproduce the problem."
+            className="w-full resize-y select-text border border-rule bg-parchment-dark p-3 text-base text-ink placeholder:text-ink-light focus:outline-gold" />
+          <span className="text-xs text-ink-light">{message.length} / {BUG_REPORT_MESSAGE_LIMIT}</span>
+        </div>
+        <details className="min-w-0 border border-rule p-3 text-sm">
+          <summary className="cursor-pointer text-gold">Review session diagnostics</summary>
+          <p className="my-2 text-ink-light">Captured when this form opened. Includes game settings and state, browser family and major version, screen size category, and error counts. Up to 100 buildings; no full replay or error text.</p>
+          <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-all select-text text-xs" tabIndex={0}>{JSON.stringify(diagnostics, null, 2)}</pre>
+        </details>
+        {error && <div role="alert" className="text-sm text-red">
+          <p>{error}</p>
+          <a href={`https://github.com/${BUG_REPORT_REPOSITORY}/issues`} target="_blank" rel="noopener noreferrer" className="underline">Check existing reports</a>
+        </div>}
+        <div className="flex justify-end gap-3">
+          <HudButton disabled={sending} onClick={close}>Cancel</HudButton>
+          <HudButton type="submit" disabled={sending || !message.trim()}>{sending ? "Sending…" : "Submit bug report"}</HudButton>
+        </div>
+      </form>}
+    </DialogContent>
+  </Dialog>
+}

--- a/components/game/game-hud.css
+++ b/components/game/game-hud.css
@@ -123,7 +123,7 @@
 .hud-world-heading { display: flex; align-items: center; justify-content: space-between; padding: 0 0 var(--hud-space); font-family: var(--font-cinzel), serif; font-size: 14px; }
 .hud-world-heading button { cursor: pointer; }
 .hud-inspector { min-height: 0; overflow-y: auto; overscroll-behavior: contain; border-bottom: 1px solid #8c784c; }
-.hud-inspector, .hud-world, .hud-menu {
+.hud-inspector, .hud-world, .hud-menu, .hud-report {
   --parchment: #211e16;
   --parchment-dark: #423725;
   --ink: #f2e8d5;
@@ -168,3 +168,5 @@
 .hud-traffic { position: absolute; top: calc(var(--hud-header-height) + var(--hud-space) * 2); left: var(--hud-space); width: 216px; gap: 8px; padding: 3px var(--hud-space); z-index: 24; font-size: 12px; }
 .hud-traffic input { min-width: 0; width: 100%; accent-color: #bea067; }
 .hud-traffic output { min-width: 34px; text-align: right; font-variant-numeric: tabular-nums; }
+
+.hud-report { font-family: var(--font-garamond), Georgia, serif; }

--- a/components/game/game-hud.tsx
+++ b/components/game/game-hud.tsx
@@ -24,7 +24,7 @@ import { TERRAIN } from "@/lib/game/map/terrain"
 import { tileAt, type BuildingDef, type GameMap } from "@/lib/game/map/types"
 import { nerve } from "@/lib/game/route-choice"
 import { parseSeed } from "@/lib/game/rng"
-import { CURRENT_VERSION } from "@/lib/changelog"
+import { CHANGELOG, CURRENT_VERSION } from "@/lib/changelog"
 import { SITE_MENU } from "@/lib/site-menu"
 import { ACTIVITY_LABELS, simRegistry, type SimTraveler } from "@/lib/game/sim"
 import { useRelicProcessionStore } from "@/lib/game/relic-procession-store"
@@ -46,6 +46,11 @@ import { individualRenown, relicRenown } from "@/lib/game/settlement"
 import { buildCatalog, buildingIncomeLabel } from "@/lib/game/balance"
 import { useBalanceStore } from "@/lib/game/balance-store"
 import { MusicPlayer } from "./music-player"
+import { HudButton } from "./hud-button"
+import { BugReportDialog } from "./bug-report-dialog"
+import { browserDiagnostics, diagnosticsSchema, type BugReportDiagnostics } from "@/lib/bug-report"
+import { useBugReportRuntime } from "@/hooks/use-bug-report-runtime"
+import { useSimulationStore } from "@/lib/game/simulation-store"
 import { Section, Tuner } from "./property-controls"
 import { BuildControls, HudClock, HudHelp, HudResources } from "./hud-controls"
 
@@ -83,25 +88,6 @@ function Label({ children }: { children: React.ReactNode }) {
     <div className="font-display text-[9px] uppercase tracking-[2px] text-gold">{children}</div>
   )
 }
-
-function HudButton({
-  children,
-  onClick,
-}: {
-  children: React.ReactNode
-  onClick: () => void
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="pointer-events-auto border border-rule bg-parchment-dark px-2 py-1 font-display text-[9px] uppercase tracking-[2px] text-ink transition-colors hover:border-gold hover:text-red"
-    >
-      {children}
-    </button>
-  )
-}
-
 
 function TrafficDensity({ value, travelerCount, onChange }: {
   value: number
@@ -614,7 +600,9 @@ export function GameHud({
   onPixelationChange,
   onReroll,
   onSeedChange,
+  cheats,
 }: {
+  cheats: { blasterPastor: boolean; lastMarch: boolean }
   economy: ReturnType<typeof useSettlement>
   map: GameMap | null
   seed: number | null
@@ -630,6 +618,39 @@ export function GameHud({
   onReroll: () => void
   onSeedChange: (seed: number) => void
 }) {
+  const readRuntime = useBugReportRuntime()
+  const [report, setReport] = useState<BugReportDiagnostics | null>(null)
+  const [reportError, setReportError] = useState("")
+  function openBugReport() {
+    const build = useBuildStore.getState()
+    const buildings = map?.buildings ?? []
+    const snapshot = diagnosticsSchema.safeParse({
+      version: CHANGELOG[0].version,
+      environment: process.env.NODE_ENV === "development" ? "development" : "production",
+      ...readRuntime(),
+      ...browserDiagnostics(navigator.userAgent, window.innerWidth),
+      seed, settings, pixelation,
+      camera: useCameraStore.getState(),
+      simulation: { ...useSimulationStore.getState(), time: build.simulation?.time ?? build.time },
+      population: { travelers: travelers.length, monks: monks.length, residents: economy.residents.length, relicTraffic },
+      settlement: { ...economy.settlement.resources, visits: economy.visits,
+        shrineAdmission: economy.settlement.shrineAdmission, felledTrees: build.felled.size, woodPiles: build.piles.length },
+      buildings: buildings.slice(0, 100).map(building => ({
+        x: building.x, z: building.z, w: building.w, d: building.d, rotation: building.rotation ?? 0,
+        type: !building.buildType ? "founding"
+          : ["shelter", "monk-shelter", "workshop", "garden", "cross", "hall", "storehouse"].includes(building.buildType) ? building.buildType : "other",
+        construction: building.construction ?? null,
+      })),
+      omittedBuildings: Math.max(0, buildings.length - 100),
+      cheats,
+    })
+    if (!snapshot.success) {
+      setReportError("Session diagnostics could not be captured. Try opening the report again after the map has loaded.")
+      return
+    }
+    setReportError("")
+    setReport(snapshot.data)
+  }
   const set = (patch: Partial<MapSettings>) => onSettingsChange({ ...settings, ...patch })
   const selection = useCameraStore((s) => s.selection)
   const [menuOpen, setMenuOpen] = useState(false)
@@ -717,6 +738,7 @@ export function GameHud({
 
   return (
     <Tooltip.Provider delayDuration={180} skipDelayDuration={100}>
+    <BugReportDialog diagnostics={report} onClose={() => setReport(null)} />
     <div className="game-hud">
       <div className="hud-frame" aria-hidden="true" />
       <header className="hud-header">
@@ -760,7 +782,11 @@ export function GameHud({
 
       {panel === "world" && <aside id="world-settings" className="hud-world hud-well" aria-label="World settings">
         <div className="hud-world-heading"><span>World</span><button type="button" aria-label="Close world settings" onClick={() => setPanel(null)}><X size={16} /></button></div>
-        <div className="mb-4"><HudButton onClick={onReroll}>✦ New Map</HudButton></div>
+        <div className="mb-4 flex flex-wrap gap-2">
+          <HudButton onClick={onReroll}>✦ New Map</HudButton>
+          <HudButton id="bug-report-button" onClick={openBugReport}>Report a bug</HudButton>
+        </div>
+        {reportError && <p role="alert" className="mb-4 text-sm text-red">{reportError}</p>}
         {SHOW_PROPERTY_PANELS && <>
         <Section {...section("Seed")}>
           <SeedField seed={seed} onSeedChange={onSeedChange} />

--- a/components/game/game-shell.tsx
+++ b/components/game/game-shell.tsx
@@ -336,6 +336,7 @@ export function GameShell({
         </div>
       )}
       <GameHud
+        cheats={{ blasterPastor, lastMarch }}
         map={map}
         seed={seed}
         relic={relic}

--- a/components/game/hud-button.tsx
+++ b/components/game/hud-button.tsx
@@ -1,0 +1,9 @@
+import type { ButtonHTMLAttributes } from "react"
+
+/** Compact parchment button shared by the HUD panels and report dialog. */
+export function HudButton({ children, className = "", type = "button", ...props }: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return <button type={type} {...props}
+    className={`pointer-events-auto border border-rule bg-parchment-dark px-2 py-1 font-display text-[9px] uppercase tracking-[2px] text-ink transition-colors hover:border-gold hover:text-red disabled:cursor-not-allowed disabled:opacity-50 ${className}`}>
+    {children}
+  </button>
+}

--- a/docs/bug-reports.md
+++ b/docs/bug-reports.md
@@ -1,0 +1,63 @@
+# In-game bug reports
+
+Open **World settings → Report a bug**. The form captures a fixed diagnostic
+snapshot, accepts a message, lets the player review the snapshot, and creates
+an issue in `tomjohndesign/pilgrimage`. It retains the draft if delivery fails
+or the dialog is closed. Successful submissions show the issue link.
+
+## Server configuration
+
+Set `BUG_REPORT_GITHUB_TOKEN` in the deployment's server environment (or
+`.env.local` for local development) and restart/redeploy. Use a dedicated
+reporting account's fine-grained GitHub token restricted to this repository,
+with **Issues: read and write**. Enable issues on the repository. Never use a
+`NEXT_PUBLIC_` variable for the credential. The player does not log in to GitHub;
+the credential's owner appears as the issue author.
+
+The integration uses GitHub's [Create an issue REST endpoint](https://docs.github.com/en/rest/issues/issues#create-an-issue).
+No labels, assignees or other repository writes are needed. A missing credential
+returns an explicit unavailable message; no fallback asks the player to post
+under their own GitHub identity. Tests mock GitHub and do not create real issues.
+
+Before enabling the public endpoint, configure a shared rate limit at the
+hosting edge/WAF for `POST /api/bug-report` (for example, 10 requests per hour
+per source and a repository-wide hourly cap). The route also caps attempts to
+10 per hour per server instance, bounds actual request bytes to 48 KB, checks
+same-origin JSON submissions, and times out GitHub calls. Its in-memory cap
+resets on restart and is **not shared across serverless instances**. Origin
+checks prevent cross-site browser submissions, but are not bot authentication.
+The application stores no IP addresses or stable player identifiers.
+
+## Diagnostic privacy and scope
+
+`lib/bug-report.ts` is the allowlist shared by the browser preview and server.
+Unknown keys are stripped recursively before anything is forwarded to GitHub.
+Automated diagnostic fields are bounded numbers, booleans, or fixed enums,
+except for the validated release version. They include:
+
+- Release, development/production mode, approximate session minutes, browser
+  family/major version, broad operating system, and viewport size category.
+- Map seed, generation/movement settings, elevation and pixelation settings.
+- Camera position/zoom/rotation, simulation clock/speed/pause state, cheat flags,
+  population counts, treasury, admissions, and resource counts.
+- Up to 100 building footprints, types, rotations and construction progress;
+  the number omitted is explicit. Building labels and identifiers are excluded.
+- Counts of browser errors, unhandled rejections and WebGL context losses since
+  the game HUD mounted. Error text, stack traces and failed resource URLs are
+  never recorded by this feature.
+
+This is a diagnostic snapshot, not a full save or replay. It excludes player
+names, account details, cookies, local storage, page URLs, query strings,
+referrers, raw user-agent strings, device/GPU identifiers, and screenshots.
+The request to GitHub contains only the generated title and report body; client
+headers are not forwarded. Reporting does not add analytics or persistent IDs.
+Normal hosting/network logs are controlled by the hosting provider separately.
+
+The message is intentional free text. The form explains that reports may be
+public and asks players to omit personal information. Arbitrary prose cannot
+be guaranteed anonymous; review the message before submitting. GitHub mentions
+are defanged and the message is fenced as plain text.
+
+A delivery timeout can occur after GitHub creates an issue. The form therefore
+asks the player to check existing reports before retrying rather than retrying
+automatically. No live issues are created during automated validation.

--- a/hooks/use-bug-report-runtime.ts
+++ b/hooks/use-bug-report-runtime.ts
@@ -1,0 +1,27 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+
+/** Count failures without storing messages, stacks, file names or rejection values. */
+export function useBugReportRuntime() {
+  const runtime = useRef({ started: 0, errors: 0, rejections: 0, webglContextLosses: 0 })
+  useEffect(() => {
+    runtime.current.started = performance.now()
+    const error = () => { runtime.current.errors++ }
+    const rejection = () => { runtime.current.rejections++ }
+    const contextLost = () => { runtime.current.webglContextLosses++ }
+    window.addEventListener("error", error)
+    window.addEventListener("unhandledrejection", rejection)
+    document.addEventListener("webglcontextlost", contextLost, true)
+    return () => {
+      window.removeEventListener("error", error)
+      window.removeEventListener("unhandledrejection", rejection)
+      document.removeEventListener("webglcontextlost", contextLost, true)
+    }
+  }, [])
+  return () => ({
+    sessionMinutes: Math.max(0, Math.round((performance.now() - runtime.current.started) / 60_000)),
+    runtimeErrors: { errors: runtime.current.errors, rejections: runtime.current.rejections,
+      webglContextLosses: runtime.current.webglContextLosses },
+  })
+}

--- a/lib/__fixtures__/bug-report.json
+++ b/lib/__fixtures__/bug-report.json
@@ -1,0 +1,132 @@
+{
+  "version": "0.0.97",
+  "environment": "production",
+  "sessionMinutes": 3,
+  "browser": "Chrome",
+  "browserMajor": 140,
+  "platform": "macOS",
+  "viewport": "large",
+  "runtimeErrors": {
+    "errors": 1,
+    "rejections": 0,
+    "webglContextLosses": 0
+  },
+  "seed": 1234,
+  "settings": {
+    "size": 1,
+    "coverage": 1,
+    "glades": 1,
+    "clearings": 1,
+    "darkForests": 1,
+    "relicDistance": 1,
+    "traffic": 1,
+    "walkSpeed": 1,
+    "characterFps": 1,
+    "stride": 1,
+    "paceVariation": 1,
+    "pathEase": 1,
+    "acceleration": 1,
+    "baseSize": 1,
+    "draftSize": 1,
+    "road": 1,
+    "roadOpacity": 1,
+    "roadShade": 1,
+    "roadEdgeLine": 1,
+    "roadEdgeWidth": 1,
+    "water": 1,
+    "rivers": 1,
+    "lakes": 1,
+    "ponds": 1,
+    "walkSync": true,
+    "characterModel": "base",
+    "elevation": {
+      "noiseSeed": 0.0,
+      "maxHeight": 2.4,
+      "scale": 36.0,
+      "detail": 0.12,
+      "power": 2.0,
+      "cliffLength": 20.0,
+      "cliffRoughness": 0.7,
+      "cliffDensity": 1.0,
+      "bridgeSag": 0.55,
+      "cliffHeight": 1.0,
+      "cliffThreshold": 0.65,
+      "slopeCost": 24.0,
+      "bankTaper": 10.0,
+      "bankSlope": 0.16,
+      "beachHeight": 0.3,
+      "beachSlope": 0.25,
+      "lakeTaper": 14.0,
+      "lakeCliffs": 0.25,
+      "lakeShelf": 3.0,
+      "erosionScale": 9.0,
+      "bankWidth": 5.0,
+      "riverCut": 0.8,
+      "cutFrequency": 0.55,
+      "riverDrop": 0.002,
+      "waterfallDrop": 0.8,
+      "waterfallSpacing": 90.0,
+      "waterDepth": 0.4,
+      "edgeWidth": 0.045,
+      "edgeStrength": 0.7,
+      "shimmerCoverage": 0.45,
+      "shimmerSize": 6.0,
+      "shimmerSpeed": 0.5,
+      "shimmerStrength": 0.35,
+      "waterfallTurbulence": 0.75,
+      "turbulenceReach": 3.0,
+      "turbulenceSpeed": 1.8,
+      "foam": 0.45
+    }
+  },
+  "pixelation": {
+    "pixelated": true,
+    "pixelsPerUnit": 16,
+    "outputDpr": 1
+  },
+  "camera": {
+    "targetX": 0,
+    "targetZ": 0,
+    "viewIndex": 0,
+    "viewSize": 32,
+    "outlineMode": "overlap"
+  },
+  "simulation": {
+    "paused": false,
+    "speed": 2,
+    "time": 100
+  },
+  "population": {
+    "travelers": 10,
+    "monks": 3,
+    "residents": 3,
+    "relicTraffic": 2
+  },
+  "settlement": {
+    "gold": 120,
+    "wood": 160,
+    "visits": 4,
+    "shrineAdmission": 1,
+    "felledTrees": 0,
+    "woodPiles": 0
+  },
+  "buildings": [
+    {
+      "x": 5,
+      "z": 6,
+      "w": 2,
+      "d": 2,
+      "rotation": 0,
+      "type": "shelter",
+      "construction": {
+        "work": 10,
+        "required": 30
+      }
+    }
+  ],
+  "omittedBuildings": 0,
+  "cheats": {
+    "blasterPastor": false,
+    "lastMarch": false
+  }
+}

--- a/lib/bug-report.test.ts
+++ b/lib/bug-report.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest"
+import fixture from "./__fixtures__/bug-report.json"
+import { browserDiagnostics, bugReportSchema, diagnosticsSchema, formatBugReport } from "./bug-report"
+
+describe("bug report privacy", () => {
+  it("keeps pertinent diagnostics but strips unknown fields recursively", () => {
+    const input = structuredClone(fixture)
+    const dirty = {
+      ...input, email: "player@example.com", url: "https://game.test/?secret=token",
+      userAgent: "private-device-identifier", logs: ["private file path"],
+      camera: { ...input.camera, selection: { id: "private-name" } },
+      settings: { ...input.settings, email: "private-name", elevation: { ...input.settings.elevation, token: "secret" } },
+      buildings: [{ ...input.buildings[0], label: "private-name", id: "private-name",
+        construction: { ...input.buildings[0].construction, contact: "private-name" } }],
+    }
+    expect(diagnosticsSchema.parse(dirty)).toEqual(input)
+    const issue = formatBugReport({ message: "The traveler is stuck.", diagnostics: dirty } as never)
+    expect(issue.body).toContain('"seed": 1234')
+    for (const secret of ["private-name", "player@example.com", "private-device", "secret", "private file path"]) {
+      expect(JSON.stringify(issue)).not.toContain(secret)
+    }
+  })
+
+  it("rejects identifying strings smuggled into allowed diagnostic fields", () => {
+    for (const patch of [{ version: "tom/branch" }, { browser: "player@example.com" }, { seed: "user-123" }, { platform: "Tom's MacBook" }]) {
+      expect(diagnosticsSchema.safeParse({ ...fixture, ...patch }).success).toBe(false)
+    }
+    expect(diagnosticsSchema.safeParse({ ...fixture, seed: Infinity }).success).toBe(false)
+  })
+
+  it("requires a bounded message and bounds building attachments", () => {
+    for (const message of ["   ", "x".repeat(4001)]) {
+      expect(bugReportSchema.safeParse({ message, diagnostics: fixture }).success).toBe(false)
+    }
+    expect(diagnosticsSchema.safeParse({ ...fixture, buildings: Array(101).fill(fixture.buildings[0]) }).success).toBe(false)
+  })
+
+  it("preserves prose while fencing pasted Markdown and defanging mentions", () => {
+    const issue = formatBugReport(bugReportSchema.parse({ message: "```\n@someone\n# Look here\n```", diagnostics: fixture }))
+    expect(issue.body).toContain("````text\n```\n@\u200bsomeone\n# Look here\n```\n````")
+    expect(issue.title).toBe("Bug report — Pilgrimage 0.0.97")
+  })
+
+  it("reduces user agents to coarse compatibility fields", () => {
+    expect(browserDiagnostics("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/140.0.123.45 Safari/537.36 secret-user", 1440))
+      .toEqual({ browser: "Chrome", browserMajor: 140, platform: "macOS", viewport: "large" })
+    expect(browserDiagnostics("Mozilla/5.0 Chrome/140.0 Safari/537.36 Edg/140.0", 800).browser).toBe("Edge")
+    expect(browserDiagnostics("Mozilla/5.0 (iPhone) Version/18.2 Mobile Safari/604.1", 390))
+      .toEqual({ browser: "Safari", browserMajor: 18, platform: "iOS", viewport: "small" })
+    expect(browserDiagnostics("unrecognized private browser", 800).browser).toBe("Other")
+  })
+})

--- a/lib/bug-report.ts
+++ b/lib/bug-report.ts
@@ -1,0 +1,85 @@
+import { z } from "zod"
+
+export const BUG_REPORT_REPOSITORY = "tomjohndesign/pilgrimage"
+export const BUG_REPORT_MESSAGE_LIMIT = 4000
+export const BUG_REPORT_BODY_LIMIT = 48_000
+const number = z.number().finite().min(-1e12).max(1e12)
+const count = z.number().int().min(0).max(1e12)
+const numericFields = <T extends string>(keys: readonly T[]) =>
+  z.object(Object.fromEntries(keys.map(key => [key, number])) as Record<T, typeof number>)
+
+/** Explicit allowlist shared by the preview and server. Unknown keys are stripped
+ * at every level; never serialize a store, browser object, URL or raw log. */
+export const diagnosticsSchema = z.object({
+  version: z.string().regex(/^\d+\.\d+\.\d+$/).max(24),
+  environment: z.enum(["development", "production"]),
+  sessionMinutes: count,
+  browser: z.enum(["Firefox", "Edge", "Chrome", "Safari", "Other"]),
+  browserMajor: count.max(999).nullable(),
+  platform: z.enum(["Android", "iOS", "Windows", "macOS", "Linux", "Other"]),
+  viewport: z.enum(["small", "medium", "large"]),
+  runtimeErrors: z.object({ errors: count, rejections: count, webglContextLosses: count }),
+  seed: number.nullable(),
+  settings: numericFields([
+    "size", "coverage", "glades", "clearings", "darkForests", "relicDistance", "traffic",
+    "walkSpeed", "characterFps", "stride", "paceVariation", "pathEase", "acceleration",
+    "baseSize", "draftSize", "road", "roadOpacity", "roadShade", "roadEdgeLine", "roadEdgeWidth",
+    "water", "rivers", "lakes", "ponds",
+  ]).extend({
+    walkSync: z.boolean(), characterModel: z.enum(["base", "callings"]),
+    elevation: numericFields([
+      "noiseSeed", "maxHeight", "scale", "detail", "power", "cliffLength", "cliffRoughness",
+      "cliffDensity", "bridgeSag", "cliffHeight", "cliffThreshold", "slopeCost", "bankTaper",
+      "bankSlope", "beachHeight", "beachSlope", "lakeTaper", "lakeCliffs", "lakeShelf",
+      "erosionScale", "bankWidth", "riverCut", "cutFrequency", "riverDrop", "waterfallDrop",
+      "waterfallSpacing", "waterDepth", "edgeWidth", "edgeStrength", "shimmerCoverage",
+      "shimmerSize", "shimmerSpeed", "shimmerStrength", "waterfallTurbulence", "turbulenceReach",
+      "turbulenceSpeed", "foam",
+    ]),
+  }),
+  pixelation: z.object({ pixelated: z.boolean(), pixelsPerUnit: number, outputDpr: number }),
+  camera: numericFields(["targetX", "targetZ", "viewIndex", "viewSize"]).extend({
+    outlineMode: z.enum(["overlap", "silhouette", "off"]),
+  }),
+  simulation: z.object({ paused: z.boolean(), speed: number, time: number }),
+  population: z.object({ travelers: count, monks: count, residents: count, relicTraffic: count }),
+  settlement: numericFields(["gold", "wood", "visits", "shrineAdmission", "felledTrees", "woodPiles"]),
+  buildings: z.array(numericFields(["x", "z", "w", "d", "rotation"]).extend({
+    type: z.enum(["founding", "shelter", "monk-shelter", "workshop", "garden", "cross", "hall", "storehouse", "other"]),
+    construction: numericFields(["work", "required"]).nullable(),
+  })).max(100),
+  omittedBuildings: count,
+  cheats: z.object({ blasterPastor: z.boolean(), lastMarch: z.boolean() }),
+})
+export type BugReportDiagnostics = z.infer<typeof diagnosticsSchema>
+export const bugReportSchema = z.object({
+  message: z.string().trim().min(1).max(BUG_REPORT_MESSAGE_LIMIT),
+  diagnostics: diagnosticsSchema,
+})
+
+/** Only the explicit message is free text. A longer fence keeps pasted Markdown
+ * inside the message block; defang mentions to avoid notifying arbitrary users. */
+export function formatBugReport(input: z.infer<typeof bugReportSchema>) {
+  const report = bugReportSchema.parse(input)
+  const message = report.message.replace(/@/g, "@\u200b")
+  const fence = "`".repeat(Math.max(3, ...Array.from(message.matchAll(/`+/g), match => match[0].length + 1)))
+  return {
+    title: `Bug report — Pilgrimage ${report.diagnostics.version}`,
+    body: `## Player message\n\n${fence}text\n${message}\n${fence}\n\n## Session diagnostics\n\n\`\`\`json\n${JSON.stringify(report.diagnostics, null, 2)}\n\`\`\`\n\nSubmitted through the in-game bug report form. No player identity is attached.`,
+  }
+}
+
+/** Coarse compatibility information only. Never return the raw user-agent. */
+export function browserDiagnostics(userAgent: string, width: number) {
+  const match = /(?:Edg|EdgiOS|EdgA)\/(\d+)/.exec(userAgent)
+    ?? /(?:Firefox|FxiOS)\/(\d+)/.exec(userAgent)
+    ?? /(?:Chrome|CriOS)\/(\d+)/.exec(userAgent)
+    ?? /Version\/(\d+).*Safari\//.exec(userAgent)
+  const browser = !match ? "Other" : /Edg/.test(match[0]) ? "Edge"
+    : /Firefox|FxiOS/.test(match[0]) ? "Firefox" : /Chrome|CriOS/.test(match[0]) ? "Chrome" : "Safari"
+  const platform = /Android/.test(userAgent) ? "Android" : /iPhone|iPad|iPod/.test(userAgent) ? "iOS"
+    : /Windows/.test(userAgent) ? "Windows" : /Macintosh|Mac OS X/.test(userAgent) ? "macOS"
+      : /Linux/.test(userAgent) ? "Linux" : "Other"
+  return { browser, browserMajor: match ? Math.min(999, Number(match[1])) : null, platform,
+    viewport: width < 700 ? "small" : width < 1200 ? "medium" : "large" } as const
+}


### PR DESCRIPTION
Players can now open World settings → Report a bug, add a message, review a fixed diagnostic snapshot, and submit a GitHub issue through the game's reporting account, with drafts retained on failure.

The form reuses the HUD styling and shared dialog, while the client/server allowlist, error counters, payload limits, origin checks, and per-instance throttle exclude automatic identity data and raw logs.

Delivery requires `BUG_REPORT_GITHUB_TOKEN` and a shared edge rate limit, documented in `docs/bug-reports.md`.

Validation: production build, typecheck, 12 report tests, and desktop/mobile browser checks passed; the full suite had 1,047 passes and one simulation timeout that passed on an isolated rerun.
