### PR TITLE
Rig editor: bake progress, correct drag targets, bone drags, and key resets

### DIFF
--- a/components/animal-lab.tsx
+++ b/components/animal-lab.tsx
@@ -30,7 +30,7 @@ const HABITATS: Record<AnimalSubject, string> = {
 import { CharacterAnimationDock } from "./character-rig-editor"
 import { AnimalRigInspector, type AnimalInspection } from "./animal-rig-editor"
 import { useAnimalRigStore } from "@/lib/game/wildlife/rig-store"
-import { ANIMAL_FRAMES, EMPTY_ANIMAL_EDITS, animalPoseKey, type AnimalJoint, type AnimalRigEdits } from "@/lib/game/wildlife/rig-edits"
+import { ANIMAL_FRAMES, EMPTY_ANIMAL_EDITS, animalClearFrame, animalPoseKey, type AnimalJoint, type AnimalRigEdits } from "@/lib/game/wildlife/rig-edits"
 import { BASE_PERSON } from "@/lib/game/base-person/pose"
 import { ASSET_ZOOMS, useAssetPreviewStore, usePreviewWheel } from "./asset-preview-controls"
 const DIRECTIONS = BASE_PERSON.directions
@@ -70,12 +70,28 @@ export function AnimalLab({ mode, onModeChange, active = true }: AssetEditorNavi
   const [joints, setJoints] = useState<AnimalInspection>({}), [selectedJoint, setSelectedJoint] = useState<AnimalJoint>("head")
   const [history, setHistory] = useState<AnimalRigEdits[]>([]), [future, setFuture] = useState<AnimalRigEdits[]>([])
   const dragEdit = useRef<AnimalRigEdits | null>(null)
-  const edits = useAnimalRigStore(state => state.designs[subject]) ?? EMPTY_ANIMAL_EDITS
+  // A drag poses a local draft; the persisted store (and its localStorage write) only sees the release.
+  const [draft, setDraft] = useState<AnimalRigEdits | null>(null)
+  const stored = useAnimalRigStore(state => state.designs[subject]) ?? EMPTY_ANIMAL_EDITS
+  const edits = draft ?? stored
   const save = useAnimalRigStore(state => state.save)
-  useEffect(() => { setHistory([]); setFuture([]); setFrame(0); setSelectedJoint("head") }, [subject])
-  const commit = (next: AnimalRigEdits) => { if (!dragEdit.current) setHistory(h => [...h.slice(-49), edits]); setFuture([]); save(subject, next) }
+  useEffect(() => { setHistory([]); setFuture([]); setFrame(0); setSelectedJoint("head"); setDraft(null) }, [subject])
+  const commit = (next: AnimalRigEdits) => {
+    if (dragEdit.current) { setDraft(next); return }
+    setHistory(h => [...h.slice(-49), edits]); setFuture([]); save(subject, next)
+  }
+  const endDrag = () => {
+    const before = dragEdit.current
+    if (!before) return
+    dragEdit.current = null
+    setDraft(current => {
+      if (current && JSON.stringify(current) !== JSON.stringify(before)) { setHistory(h => [...h.slice(-49), before]); setFuture([]); save(subject, current) }
+      return null
+    })
+  }
   const actions = animalActions(subject), action = actions.includes(motion) ? motion : actions.includes("graze") ? "graze" : bird ? "fly" : "idle"
   const actionLabel = ACTION_LABELS[action]
+  const frameKeyed = (step: number) => Object.values(edits.clips[action]?.keys ?? {}).some(keys => keys?.some(key => key.frame === step))
   return <AssetEditorFrame mode={mode} onModeChange={onModeChange} version="11 animals" label="Animal asset playground"
     controlsOpen={controlsOpen} onControlsToggle={() => setControlsOpen(v => !v)}
     status={`${lineup ? "All animals" : ANIMAL_SUBJECTS[subject]} · ${actionLabel}${playing ? "" : " · Paused"}`}
@@ -122,13 +138,13 @@ export function AnimalLab({ mode, onModeChange, active = true }: AssetEditorNavi
           <div style={{ transform: `translate(${offset[0]}px, ${offset[1]}px)` }}>
           {active && <AnimalPreview subject={subject} lineup={lineup} motion={action} playing={playing} row={row} zoom={zoom} rate={rate} coat={coat} horseVariant={horseVariant} onSelect={choose} directionCanvases={directionCanvases} showRig={showRig} construction={construction && !bird && !equine} frame={frame} edits={edits} joints={joints} selected={selectedJoint}
             onInspect={(next, inspection) => { setFrame(next); setJoints(inspection) }} onJoint={joint => { setSelectedJoint(joint); setPlaying(false) }}
-            onPose={(joint, value) => commit(animalPoseKey(edits, action, joint, { frame, offset: value, radius: 4 }, frame))}
-            onDrag={active => { if (active) { dragEdit.current = edits; setPlaying(false) } else if (dragEdit.current) { setHistory(h => [...h.slice(-49), dragEdit.current!]); dragEdit.current = null } }} />}
+            onPose={changes => commit(changes.reduce((next, [joint, value]) => animalPoseKey(next, action, joint, { frame, offset: value, radius: 4 }, frame), edits))}
+            onDrag={active => { if (active) { dragEdit.current = edits; setPlaying(false) } else endDrag() }} />}
           </div>
           <span className="person-stage-caption">{lineup ? "Deer · sheep · goats · rabbits · birds · boars · foxes · donkey · horse" : `${equine ? ANIMAL_SUBJECTS[subject] : WILDLIFE_PROFILES[subject].label} · ${actionLabel}`}</span>
         </div>
         {showRig && !lineup && <AnimalRigInspector joints={joints} selected={selectedJoint} onSelect={joint => { setSelectedJoint(joint); setPlaying(false) }} edits={edits} clip={action} frame={frame}
-          onChange={commit} bird={bird} equine={equine}
+          onChange={commit} frameKeyed={frameKeyed(frame)} onResetFrame={() => commit(animalClearFrame(edits, action, frame))} bird={bird} equine={equine}
           canUndo={history.length > 0} canRedo={future.length > 0}
           onUndo={() => { const previous = history.at(-1); if (previous) { setFuture(f => [...f, edits]); setHistory(h => h.slice(0, -1)); save(subject, previous) } }}
           onRedo={() => { const next = future.at(-1); if (next) { setHistory(h => [...h, edits]); setFuture(f => f.slice(0, -1)); save(subject, next) } }} />}
@@ -136,7 +152,7 @@ export function AnimalLab({ mode, onModeChange, active = true }: AssetEditorNavi
         <CharacterAnimationDock directions={DIRECTIONS} row={row} onDirection={next => { setRow(next); setLineup(false) }}
           renderDirection={index => <span role="img" aria-label={`${DIRECTIONS[index]} direction`} className="block shrink-0" style={{ width: 64, height: 64 }}><canvas ref={canvas => { directionCanvases.current[index] = canvas }} width={64} height={64} style={{ imageRendering: "pixelated" }} /></span>}
           frameCount={ANIMAL_FRAMES} frame={frame} clipLabel={actionLabel}
-          keyed={step => Object.values(edits.clips[action]?.keys ?? {}).some(keys => keys?.some(key => key.frame === step))}
+          keyed={step => frameKeyed(step)}
           onFrame={next => { setFrame(next); setPlaying(false); setLineup(false) }} />
       </div>
     </div>

--- a/components/animal-preview.tsx
+++ b/components/animal-preview.tsx
@@ -31,7 +31,7 @@ export function AnimalPreview({ subject, lineup, motion, playing, row, zoom, rat
   subject: AnimalSubject; lineup: boolean; motion: AnimalMotion; playing: boolean; row: number; zoom: number; rate: number; coat: string; horseVariant: HorseVariant; onSelect: (subject: AnimalSubject) => void
   directionCanvases: RefObject<(HTMLCanvasElement | null)[]>
   construction: boolean; showRig: boolean; frame: number; edits: AnimalRigEdits; joints: AnimalInspection; selected: AnimalJoint
-  onInspect: (frame: number, joints: AnimalInspection) => void; onJoint: (joint: AnimalJoint) => void; onPose: (joint: AnimalJoint, offset: Point3) => void; onDrag: (active: boolean) => void
+  onInspect: (frame: number, joints: AnimalInspection) => void; onJoint: (joint: AnimalJoint) => void; onPose: (changes: [AnimalJoint, Point3][]) => void; onDrag: (active: boolean) => void
 }) {
   const host = useRef<HTMLDivElement>(null)
   const state = useRef({ motion, playing, row, rate, showRig, inspectedFrame, edits, onInspect })
@@ -84,11 +84,12 @@ export function AnimalPreview({ subject, lineup, motion, playing, row, zoom, rat
         if(shelter)scene.add(hole.root)
         scene.add(rig.root); renderer.render(scene, camera)
         context.clearRect(0, 0, canvas.width, canvas.height); context.drawImage(renderer.domElement, 0, 0)
-        if (kind === subject && now - inspectedAt > 50) {
+        // Handles follow every frame while the rig is shown so a drag never trails the pointer.
+        if (kind === subject && now - inspectedAt > (s.showRig ? 15 : 50)) {
           const inspection: AnimalInspection = {}
           for (const [name, joint] of Object.entries(s.showRig && rig.root.visible ? rig.joints() : {})) {
             point.set(...joint.position); rig.root.localToWorld(point); point.project(camera)
-            inspection[name as AnimalJoint] = { ...joint, screen: [(point.x + 1) * 32, (1 - point.y) * 32] }
+            inspection[name as AnimalJoint] = { ...joint, screen: [(point.x + 1) * 32, (1 - point.y) * 32], depth: point.z }
           }
           s.onInspect(Math.floor(phase * ANIMAL_FRAMES), inspection); inspectedAt = now
         }

--- a/components/animal-rig-editor.tsx
+++ b/components/animal-rig-editor.tsx
@@ -8,14 +8,14 @@ import type { Point3 } from "@/lib/game/base-person/pose"
 export type AnimalInspection = Partial<Record<AnimalJoint, InspectedJoint>>
 export function AnimalRigOverlay({ joints, selected, row, edits, clip, phase, onSelect, onChange, onDrag }: {
   joints: AnimalInspection; selected: AnimalJoint; row: number; edits: AnimalRigEdits; clip: AnimalClip; phase: number
-  onSelect: (joint: AnimalJoint) => void; onChange: (joint: AnimalJoint, offset: Point3) => void; onDrag: (active: boolean) => void
+  onSelect: (joint: AnimalJoint) => void; onChange: (changes: [AnimalJoint, Point3][]) => void; onDrag: (active: boolean) => void
 }) {
   return <JointOverlay joints={joints} selected={selected} row={row} bones={joints.neck ? ANIMAL_BONES : [...ANIMAL_BONES, ["chest", "head"]]} labels={ANIMAL_JOINT_LABELS} label="Animal rig"
     offset={joint => animalOffset(edits, clip, joint, phase)} onSelect={onSelect} onChange={onChange} onDrag={onDrag} />
 }
-export function AnimalRigInspector({ joints, selected, onSelect, edits, clip, frame, onChange, onUndo, onRedo, canUndo, canRedo, bird, equine }: {
-  joints: AnimalInspection; selected: AnimalJoint; onSelect: (joint: AnimalJoint) => void; edits: AnimalRigEdits; clip: AnimalClip; frame: number
-  onChange: (edits: AnimalRigEdits) => void; onUndo: () => void; onRedo: () => void; canUndo: boolean; canRedo: boolean; bird: boolean; equine: boolean
+export function AnimalRigInspector({ joints, selected, onSelect, edits, clip, frame, frameKeyed, onChange, onResetFrame, onUndo, onRedo, canUndo, canRedo, bird, equine }: {
+  joints: AnimalInspection; selected: AnimalJoint; onSelect: (joint: AnimalJoint) => void; edits: AnimalRigEdits; clip: AnimalClip; frame: number; frameKeyed: boolean
+  onChange: (edits: AnimalRigEdits) => void; onResetFrame: () => void; onUndo: () => void; onRedo: () => void; canUndo: boolean; canRedo: boolean; bird: boolean; equine: boolean
 }) {
   const input = useRef<HTMLInputElement>(null), [message, setMessage] = useState("")
   const current = edits.clips[clip] ?? {}, offset = animalOffset(edits, clip, selected, frame / ANIMAL_FRAMES)
@@ -26,9 +26,10 @@ export function AnimalRigInspector({ joints, selected, onSelect, edits, clip, fr
     const a = document.createElement("a"); a.href = url; a.download = "animal-rig.json"; a.click(); URL.revokeObjectURL(url)
   }
   return <CharacterRigInspector joints={joints} selected={selected} labels={ANIMAL_JOINT_LABELS} onSelect={onSelect}
-    offset={offset} frame={frame} radius={key?.radius ?? 4} maxRadius={10} keyed={!!key}
+    offset={offset} frame={frame} radius={key?.radius ?? 4} maxRadius={10} keyed={!!key} frameKeyed={frameKeyed}
     onChange={update} onRadius={radius => onChange(animalPoseKey(edits, clip, selected, { frame, offset, radius }, frame))}
     onReset={() => onChange(animalPoseKey(edits, clip, selected, null, frame))}
+    onResetKey={() => update([0, 0, 0])} onResetFrame={onResetFrame}
     onResetClip={() => { const clips = { ...edits.clips }; delete clips[clip]; onChange({ ...edits, clips }) }}
     canUndo={canUndo} canRedo={canRedo} onUndo={onUndo} onRedo={onRedo}
     footer={<>

--- a/components/base-person-lab.css
+++ b/components/base-person-lab.css
@@ -111,6 +111,8 @@
 .person-rig-axes label { min-width: 0; }
 .person-steps button[data-keyed="true"] { box-shadow: inset 0 -3px #f5ce72; }
 .person-stage-error { position: absolute; top: 8px; left: 8px; right: 8px; background: #211e16e8; padding: 8px; font-size: 12px; pointer-events: none; }
+.person-stage-progress { position: absolute; top: 8px; right: 8px; display: flex; flex-direction: column; gap: 5px; padding: 6px 10px; font-size: 11px; color: #f2e8d5; pointer-events: none; }
+.person-stage-progress > i { display: block; height: 3px; background: #f5ce72; transition: width .12s linear; }
 @media (max-width: 1150px) { .person-rig-inspector { width: 210px; } }
 @media (max-width: 900px) { .person-stage-layout:has(.person-rig-inspector) { flex-direction: column; } .person-rig-inspector { width: 100%; max-height: 190px; } .person-rig-fields { gap: 6px; } }
 .person-json-dialog { position: fixed; inset: 0; margin: auto; width: min(760px, calc(100vw - 32px)); max-height: calc(100dvh - 32px); overflow-y: auto; background: #211e16; color: #f2e8d5; border: 1px solid #d4b57a; padding: 0; box-shadow: 0 20px 80px #0009; }

--- a/components/base-person-lab.tsx
+++ b/components/base-person-lab.tsx
@@ -10,7 +10,7 @@ import "./game/game-hud.css"
 import "./base-person-lab.css"
 import { actionPlaybackRate } from "@/lib/game/base-person/activity"
 import { BASE_PERSON, PERSON_CLIPS, SOCKET_NAMES, type BaseClip } from "@/lib/game/base-person/pose"
-import { bakeChoppingBlock, cachedPersonBake, renderPersonPreview, type BasePersonBake, type PersonPreview } from "@/lib/game/base-person/bake"
+import { bakeChoppingBlock, bakePersonProgressively, personFrameRenderer, personSessionKey, renderPersonPreview, type BakeProgress, type BasePersonBake, type PersonPreview, type PersonSession } from "@/lib/game/base-person/bake"
 
 import { DEFAULT_DESIGN, DESIGN_CONTROLS, HAIR_STYLES, HAT_STYLES, TUNIC_STYLES, PERSON_PRESETS, personRecipe, withBodyType, validatePersonDesign, type DesignKey, type PersonDesign } from "@/lib/game/base-person/design"
 import { usePopulationStore } from "@/lib/game/base-person/population-store"
@@ -39,7 +39,7 @@ import { characterEditsJson, parseCharacterEdits, restoreCharacterDesign } from 
 import { CharacterAnimationDock } from "./character-rig-editor"
 import { RigOverlay, RigInspector } from "./person-rig-editor"
 import { inspectRig } from "@/lib/game/base-person/rig-inspection"
-import { poseOffset, setPoseKey, type EditableJoint, type PoseEdits } from "@/lib/game/base-person/pose-edits"
+import { clearFrameKeys, poseOffset, setPoseKey, type EditableJoint, type PoseEdits } from "@/lib/game/base-person/pose-edits"
 import type { RigJoint } from "@/lib/game/base-person/rig-joints"
 import { staffMotion } from "@/lib/game/base-person/staff-motion"
 import type { Point3 } from "@/lib/game/base-person/pose"
@@ -169,6 +169,7 @@ export function BasePersonLab({ mode, onModeChange, active = true }: AssetEditor
   const [history, setHistory] = useState<PoseEdits[]>([])
   const [future, setFuture] = useState<PoseEdits[]>([])
   const dragSnapshot = useRef<PoseEdits | null>(null)
+  const latestEdits = useRef<PoseEdits | undefined>(undefined); latestEdits.current = design.poseEdits
   useEffect(() => {
     try {
       const stored = JSON.parse(localStorage.getItem(DRAFT_KEY) ?? "null")
@@ -185,9 +186,10 @@ export function BasePersonLab({ mode, onModeChange, active = true }: AssetEditor
   useEffect(() => {
     if (!draftsReady) return
     drafts.current[character] = design
+    if (dragging) return // Every draft is serialised here; wait for the pointer to settle.
     try { localStorage.setItem(DRAFT_KEY, JSON.stringify({ templateVersion: BASE_PERSON.version, character, drafts: drafts.current })) }
     catch { setMessage("Browser storage is unavailable. Copy edits as JSON to keep a backup.") }
-  }, [design, character, draftsReady])
+  }, [design, character, draftsReady, dragging])
   const jsonDialog = useRef<HTMLDialogElement>(null)
   const jsonArea = useRef<HTMLTextAreaElement>(null)
   const [jsonText, setJsonText] = useState("")
@@ -228,56 +230,75 @@ export function BasePersonLab({ mode, onModeChange, active = true }: AssetEditor
     drafts.current[character] = design
     setCharacter(id); setDesign(drafts.current[id] ?? { ...initial }); setHistory([]); setFuture([]); setMessage("")
   }
-  const inspected = useMemo(() => isPerson && showRig ? inspectRig(design, clip, frame % PERSON_CLIPS[clip].frames, row) : {}, [isPerson, showRig, design, clip, frame, row])
+  // One render session per design serves both the rig handles and the live preview, so a drag keeps its rig and compiled shaders.
+  const session = useRef<{ key: string; session: PersonSession } | null>(null)
+  const previewSession = (design: PersonDesign) => {
+    const key = personSessionKey(design)
+    if (session.current?.key !== key) { session.current?.session.dispose(); session.current = { key, session: personFrameRenderer(design) } }
+    return session.current.session
+  }
+  useEffect(() => () => { session.current?.session.dispose(); session.current = null }, [])
+  const inspected = useMemo(() => isPerson && showRig ? inspectRig(design, clip, frame % PERSON_CLIPS[clip].frames, row, previewSession(design).rig) : {}, [isPerson, showRig, design, clip, frame, row]) // eslint-disable-line react-hooks/exhaustive-deps
   const editFrame = (joint: EditableJoint) => joint === "staffTip" && clip === "walk" && staffMotion(frame / PERSON_CLIPS.walk.frames, personRecipe(design).body).planted ? 0 : frame % PERSON_CLIPS[clip].frames
   const currentOffset = (joint: EditableJoint) => poseOffset(design.poseEdits, clip, joint, editFrame(joint) / PERSON_CLIPS[clip].frames)
   const selectedKey = design.poseEdits?.[clip]?.[selectedJoint as EditableJoint]?.find(k => k.frame === editFrame(selectedJoint as EditableJoint))
+  const frameKeyed = (step: number) => Object.values(design.poseEdits?.[clip] ?? {}).some(keys => keys?.some(key => key.frame === step))
   const radius = selectedKey?.radius ?? Math.min(3, Math.max(1, Math.floor(PERSON_CLIPS[clip].frames / 2)))
   const commitPose = (edits: PoseEdits) => {
     if (JSON.stringify(edits) === JSON.stringify(design.poseEdits ?? {})) return
     if (!dragSnapshot.current) { setHistory(h => [...h.slice(-49), design.poseEdits ?? {}]); setFuture([]) }
+    latestEdits.current = edits
     setDesign(d => ({ ...d, poseEdits: edits })); setMessage("")
   }
-  const changeJoint = (joint: EditableJoint, offset: Point3, blend = radius) => {
+  const changeJoints = (changes: [EditableJoint, Point3][], blend = radius) => {
     setPlaying(false)
-    const at = editFrame(joint)
-    if (joint === "staffTip" && (clip === "idle" || (clip === "walk" && staffMotion(frame / PERSON_CLIPS.walk.frames, personRecipe(design).body).planted))) offset = [offset[0], 0, offset[2]]
-    commitPose(setPoseKey(design.poseEdits, clip, joint, { frame: at, offset, radius: blend }, at))
+    let edits: PoseEdits = design.poseEdits ?? {}
+    for (let [joint, offset] of changes) {
+      const at = editFrame(joint)
+      if (joint === "staffTip" && (clip === "idle" || (clip === "walk" && staffMotion(frame / PERSON_CLIPS.walk.frames, personRecipe(design).body).planted))) offset = [offset[0], 0, offset[2]]
+      edits = setPoseKey(edits, clip, joint, { frame: at, offset, radius: blend }, at)
+    }
+    commitPose(edits)
   }
+  const changeJoint = (joint: EditableJoint, offset: Point3, blend = radius) => changeJoints([[joint, offset]], blend)
   const rigDragging = (active: boolean) => {
     setDragging(active); setPlaying(false)
     if (active) dragSnapshot.current = structuredClone(design.poseEdits ?? {})
     else if (dragSnapshot.current) {
       const before = dragSnapshot.current; dragSnapshot.current = null
-      if (JSON.stringify(before) !== JSON.stringify(design.poseEdits ?? {})) { setHistory(h => [...h.slice(-49), before]); setFuture([]) }
+      // The release may commit its final coalesced move in this same event, ahead of the next render.
+      if (JSON.stringify(before) !== JSON.stringify(latestEdits.current ?? {})) { setHistory(h => [...h.slice(-49), before]); setFuture([]) }
     }
   }
+  const [bakeProgress, setBakeProgress] = useState<BakeProgress | null>(null)
   useEffect(() => {
     setBusy(true)
     const target = window as unknown as { __basePersonBake?: BasePersonBake }
     delete target.__basePersonBake
-    if (dragging || !isPerson) { if (!isPerson) setBusy(false); return }
+    if (dragging || !isPerson) { if (!isPerson) { setBusy(false); setBakeProgress(null) } return }
+    let job: ReturnType<typeof bakePersonProgressively> | undefined
+    // Sheets bake between browser tasks, one row at a time, so the stage can show progress and stay responsive.
     const timer = setTimeout(() => {
-      try {
-        const result = cachedPersonBake(design)
-        setBake(result); setError("")
-        target.__basePersonBake = result
-      } catch (e) { setError(e instanceof Error ? e.message : "The base sprite could not render.") }
-      setBusy(false)
+      job = bakePersonProgressively(design, setBakeProgress)
+      job.promise.then(result => {
+        if (!result) return // Superseded by a newer design.
+        setBake(result); setError(""); target.__basePersonBake = result
+        setBusy(false); setBakeProgress(null)
+      }, e => { setError(e instanceof Error ? e.message : "The base sprite could not render."); setBusy(false); setBakeProgress(null) })
     }, 180)
-    return () => { clearTimeout(timer); delete target.__basePersonBake }
+    return () => { clearTimeout(timer); job?.cancel(); delete target.__basePersonBake }
   }, [design, dragging, isPerson])
   useEffect(() => {
     if (sheetMatchesDesign || !isPerson) return
-    // Coalesce inputs into a paint, without waiting for the user to stop dragging.
+    // Coalesce inputs into a paint, without waiting for the user to stop dragging; a drag refreshes only the facing on screen.
     const request = requestAnimationFrame(() => {
       try {
-        setPreview(renderPersonPreview(design, clip, frame % PERSON_CLIPS[clip].frames, sides))
+        setPreview(renderPersonPreview(design, clip, frame % PERSON_CLIPS[clip].frames, sides, dragging ? [row] : undefined, previewSession(design)))
         setError("")
       } catch (e) { setError(e instanceof Error ? e.message : "The preview could not render.") }
     })
     return () => cancelAnimationFrame(request)
-  }, [design, clip, frame, sides, sheetMatchesDesign, isPerson])
+  }, [design, clip, frame, sides, sheetMatchesDesign, isPerson, dragging, row])
   useEffect(() => {
     if (!active || !playing || frameCount === 1 || onMap) return
     const timer = setInterval(() => setFrame((f) => subject === "knight" || (subject === "cart" && shopState !== "opening" && shopState !== "packing") ? f + 1 : (f + 1) % frameCount), 1000 / (fps * animationRate))
@@ -289,8 +310,11 @@ export function BasePersonLab({ mode, onModeChange, active = true }: AssetEditor
   const step = frame % frameCount
   const firstColumn = isKnight ? mountedKnight && knightClip === "walk" ? 1 : 0 : isPerson ? 0 : subject === "cart" ? cartColumn(cargo, cartMode, 0) : grazing ? transportMetadata.animalClips.graze.start : clip === "idle" ? transportMetadata.animalClips.idle.start : transportMetadata.animalClips.walk.start
   const visibleFrame = live ? 0 : subject === "cart" ? cartMode === "shop" ? Math.round((shopState === "opening" ? step / 47 : shopState === "packing" ? 1 - step / 47 : 1) * (TRANSPORT.shopFrames - 1)) : step % TRANSPORT.wheelFrames : firstColumn + step
-  const url = isKnight ? `/textures/knights/${KNIGHT.version}/${mountedKnight ? `mounted-${animalCoat("horse", coat).id}` : `knight-${knightClip}`}.png` : !isPerson ? subject === "cart" ? cartUrl(cargo, cartMode, 1, cartPuller === "hand") : animalUrl(subject, animalCoat(subject, coat).id) : live?.url ?? (bake ? clip === "walk" || clip === "idle" ? sides ? clip === "walk" ? bake.debugWalk : bake.debugIdle : bake[clip] : sides ? bake.actions[clip].debug : bake.actions[clip].url : "")
-  const shadowUrl = !isPerson || sides ? undefined : live?.shadowUrl ?? (clip === "walk" ? bake?.shadowWalk : clip === "idle" ? bake?.shadowIdle : bake?.actions[clip].shadow)
+  const bakedSheet = bake ? clip === "walk" || clip === "idle" ? sides ? clip === "walk" ? bake.debugWalk : bake.debugIdle : bake[clip] : sides ? bake.actions[clip].debug : bake.actions[clip].url : ""
+  const bakedShadow = sides ? undefined : clip === "walk" ? bake?.shadowWalk : clip === "idle" ? bake?.shadowIdle : bake?.actions[clip].shadow
+  const url = isKnight ? `/textures/knights/${KNIGHT.version}/${mountedKnight ? `mounted-${animalCoat("horse", coat).id}` : `knight-${knightClip}`}.png` : !isPerson ? subject === "cart" ? cartUrl(cargo, cartMode, 1, cartPuller === "hand") : animalUrl(subject, animalCoat(subject, coat).id) : live?.url ?? bakedSheet
+  const shadowUrl = !isPerson || sides ? undefined : live?.shadowUrl ?? bakedShadow
+  const partialLive = !!live && live.rows.length < BASE_PERSON.directions.length
   const renderPalette = personRecipe(design).renderPalette
   const sockets = isPerson ? live?.sockets[row] ?? bake?.metadata.clips[clip][row * columns + visibleFrame]?.sockets : undefined
   const pixels = isKnight ? mountedKnight ? knightMetadata.cellSize : knightMetadata.person.cellSize : isPerson ? BASE_PERSON.cellSize : subject === "cart" ? cartMode === "shop" ? SHOP.cellSize : CART.cellSize : transportMetadata.cellSize
@@ -327,7 +351,7 @@ export function BasePersonLab({ mode, onModeChange, active = true }: AssetEditor
     version={isPerson ? `Base person · v${BASE_PERSON.version}` : `${SUBJECTS[subject]} · ${isKnight ? KNIGHT.version : TRANSPORT.version}`}
     controlsOpen={controlsOpen} onControlsToggle={() => setControlsOpen(!controlsOpen)}
     roadHref={`/play?characters=base&baseSize=1.5&fps=${fps}`}
-    status={onMap ? "Merchant journey and turning simulations · game scale" : !isPerson ? `${subject === "horse" ? transportMetadata.animalProfiles[horseVariant].label : SUBJECTS[subject]} · ${clipLabel}` : dragging ? "Live preview · release to finish sprite sheets." : busy ? "Updating sprite sheets…" : populationBuilding ? `Updating road characters · ${Math.round(populationProgress * 100)}%` : populationError || message || "Ready · changes preview instantly"}
+    status={onMap ? "Merchant journey and turning simulations · game scale" : !isPerson ? `${subject === "horse" ? transportMetadata.animalProfiles[horseVariant].label : SUBJECTS[subject]} · ${clipLabel}` : dragging ? "Live preview · release to finish sprite sheets." : busy ? bakeProgress ? `Updating sprite sheets · ${Math.round(bakeProgress.done / bakeProgress.total * 100)}%` : "Updating sprite sheets…" : populationBuilding ? `Updating road characters · ${Math.round(populationProgress * 100)}%` : populationError || message || "Ready · changes preview instantly"}
     detail={onMap ? "8 camera angles · game scale" : `${subject === "cart" ? CART.directions : 8} directions · ${Number((fps * animationRate).toFixed(1))} fps`}>
     <div className="person-workspace">
       <aside className={`person-controls hud-well ${controlsOpen ? "is-open" : ""}`} aria-label="Character controls">
@@ -474,7 +498,7 @@ export function BasePersonLab({ mode, onModeChange, active = true }: AssetEditor
           </div> : isKnight && showSquire ? <KnightEntourage mounted={mountedKnight} row={row} frame={frame} variant={knightVariant} walking={knightClip === "walk"} url={url} visibleFrame={visibleFrame} columns={columns} cellSize={pixels} rows={atlasRows} zoom={fittedZoom} offset={previewOffset} name={`Knight ${direction}, frame ${step + 1}`} /> : <div className="person-sprite" style={{ width: pixels * fittedZoom, height: pixels * fittedZoom, transform: `translate(${previewOffset[0]}px, ${previewOffset[1]}px)` }}>
             {isPerson && onion && !live && columns > 1 && <div className="absolute inset-0 opacity-25"><Tile url={url} row={row} frame={(visibleFrame + columns - 1) % columns} columns={columns} zoom={fittedZoom} name="Previous frame ghost" /></div>}
             <Tile url={url} shadowUrl={shadowUrl} row={rowOffset + row * directionStep} frame={visibleFrame} columns={columns} cellSize={pixels} rows={atlasRows} zoom={fittedZoom} name={`${SUBJECTS[subject]} ${direction}, frame ${step + 1}`} />
-            {isPerson && showRig && <RigOverlay joints={inspected} selected={selectedJoint} row={row} offset={currentOffset} onSelect={joint => { setSelectedJoint(joint); setPlaying(false) }} onChange={changeJoint} onDrag={rigDragging} />}
+            {isPerson && showRig && <RigOverlay joints={inspected} selected={selectedJoint} row={row} offset={currentOffset} onSelect={joint => { setSelectedJoint(joint); setPlaying(false) }} onChange={changeJoints} onDrag={rigDragging} />}
             {isPerson && guides && <svg aria-label="Origin and attachment guides" className="pointer-events-none absolute inset-0 h-full w-full" viewBox={`0 0 ${pixels} ${pixels}`}>
               <path d={`M${BASE_PERSON.anchor[0]} 0V${pixels} M0 ${BASE_PERSON.anchor[1]}H${pixels}`} stroke="#d9d5a7" strokeWidth="0.15" strokeDasharray="1 1" />
               {SOCKET_NAMES.map(name => {
@@ -484,20 +508,25 @@ export function BasePersonLab({ mode, onModeChange, active = true }: AssetEditor
             </svg>}
           </div>}
           {isPerson && (error || storeError) && <p role="alert" className="person-stage-error">{error || storeError} Adjust the pose or undo to recover.</p>}
+          {isPerson && !dragging && bakeProgress && <div className="person-stage-progress hud-well" role="status" aria-live="polite"><span>Updating sprite sheets · {Math.round(bakeProgress.done / bakeProgress.total * 100)}%</span><i style={{ width: `${bakeProgress.done / bakeProgress.total * 100}%` }} /></div>}
           <div className="person-stage-caption" style={onMap ? { display: "none" } : undefined}>{view === "native" ? "Actual pixels · 1×" : view === "sheet" ? `${SUBJECTS[subject]} atlas · ${columns * atlasRows} poses` : `${direction} · ${fittedZoom}×${view === "character" ? " · Drag left / right to turn · Shift-drag to pan · Scroll to zoom" : ""}`}</div>
         </div>
-        {isPerson && showRig && <RigInspector joints={inspected} selected={selectedJoint} offset={currentOffset(selectedJoint as EditableJoint)} frame={frame} radius={radius} maxRadius={Math.max(1, Math.floor(PERSON_CLIPS[clip].frames / 2))} keyed={!!selectedKey}
+        {isPerson && showRig && <RigInspector joints={inspected} selected={selectedJoint} offset={currentOffset(selectedJoint as EditableJoint)} frame={frame} radius={radius} maxRadius={Math.max(1, Math.floor(PERSON_CLIPS[clip].frames / 2))} keyed={!!selectedKey} frameKeyed={frameKeyed(frame % PERSON_CLIPS[clip].frames)}
           onSelect={joint => { setSelectedJoint(joint); setPlaying(false) }} onChange={offset => changeJoint(selectedJoint as EditableJoint, offset)} onRadius={blend => changeJoint(selectedJoint as EditableJoint, currentOffset(selectedJoint as EditableJoint), blend)}
           onReset={() => commitPose(setPoseKey(design.poseEdits, clip, selectedJoint as EditableJoint, null, editFrame(selectedJoint as EditableJoint)))}
+          onResetKey={() => changeJoint(selectedJoint as EditableJoint, [0, 0, 0])}
+          onResetFrame={() => { const step = frame % PERSON_CLIPS[clip].frames; commitPose(step === 0 ? clearFrameKeys(design.poseEdits, clip, 0) : clearFrameKeys(setPoseKey(design.poseEdits, clip, "staffTip", null, editFrame("staffTip")), clip, step)) }}
           onResetClip={() => { const edits = { ...design.poseEdits }; delete edits[clip]; commitPose(edits) }}
           canUndo={history.length > 0} canRedo={future.length > 0}
           onUndo={() => { const previous = history.at(-1); if (previous) { setFuture(f => [...f, design.poseEdits ?? {}]); setHistory(h => h.slice(0, -1)); setDesign(d => ({ ...d, poseEdits: previous })) } }}
           onRedo={() => { const next = future.at(-1); if (next) { setHistory(h => [...h, design.poseEdits ?? {}]); setFuture(f => f.slice(0, -1)); setDesign(d => ({ ...d, poseEdits: next })) } }} />}
         </div>
         <CharacterAnimationDock directions={BASE_PERSON.directions} row={row} onDirection={next => { setRow(next); if (!onMap) setView("character") }}
-          renderDirection={index => (!isPerson || bake) && <Tile url={url} shadowUrl={shadowUrl} row={rowOffset + index * directionStep} frame={visibleFrame} columns={columns} cellSize={pixels} rows={atlasRows} zoom={BASE_PERSON.cellSize / pixels} name={`${BASE_PERSON.directions[index]} direction`} />}
+          renderDirection={index => (!isPerson || bake) && (partialLive
+            ? <Tile url={bakedSheet} shadowUrl={bakedShadow} row={index} frame={step} columns={PERSON_CLIPS[clip].frames} name={`${BASE_PERSON.directions[index]} direction`} />
+            : <Tile url={url} shadowUrl={shadowUrl} row={rowOffset + index * directionStep} frame={visibleFrame} columns={columns} cellSize={pixels} rows={atlasRows} zoom={BASE_PERSON.cellSize / pixels} name={`${BASE_PERSON.directions[index]} direction`} />)}
           frameCount={frameCount} maxFrames={isPerson ? frameCount : 24} frame={step} clipLabel={clipLabel} showFrames={!onMap}
-          keyed={step => isPerson && Object.values(design.poseEdits?.[clip] ?? {}).some(keys => keys?.some(key => key.frame === step))}
+          keyed={step => isPerson && frameKeyed(step)}
           onFrame={next => { setFrame(next); setPlaying(false); setView("character") }} />
       </div>
     </div>

--- a/components/character-rig-editor.tsx
+++ b/components/character-rig-editor.tsx
@@ -1,48 +1,85 @@
 "use client"
 
-import { useRef, type ReactNode } from "react"
-import { rigDragDelta } from "@/lib/game/base-person/rig-inspection"
+import { useEffect, useRef, type ReactNode } from "react"
+import { orderJoints, pickBone, pickJoint, rigDragDelta, type InspectedJoint } from "@/lib/game/base-person/rig-inspection"
 import { MAX_POSE_OFFSET } from "@/lib/game/base-person/pose-edits"
 import type { Point3 } from "@/lib/game/base-person/pose"
+
+/** Sprite pixels around a handle that still grab it; at 6× zoom that is a 30 px target. */
+const PICK_RADIUS = 2.5
+/** A handle this close (its drawn size) wins outright; beyond that a bone under the pointer is preferred. */
+const HANDLE_RADIUS = 1.25
+/** Sprite pixels either side of a bone line that grab the bone, moving both of its joints together. */
+const BONE_RADIUS = 1.2
 
 /** Shared rig controls for every character family.
  * @see https://app.paper.design/file/01M1QTYBYHXP4H1BXFQ79N18AP/2-0
  */
-export function JointOverlay<J extends string>({ joints, selected, row, offset, onSelect, onChange, onDrag, bones, labels, label = "Character rig" }: {
+export function JointOverlay<J extends string>({ joints, selected, row, offset, onSelect, onChange, onDrag, bones, carried = [], labels, label = "Character rig" }: {
   bones: readonly [J, J][]; labels: Record<J, string>; label?: string
-  joints: Partial<Record<J, import("@/lib/game/base-person/rig-inspection").InspectedJoint>>; selected: J; row: number; offset: (joint: J) => Point3
-  onSelect: (joint: J) => void; onChange: (joint: J, offset: Point3) => void; onDrag: (active: boolean) => void
+  /** Bones whose first joint carries the second: dragging the bone moves the first joint only, and the second follows. */
+  carried?: readonly [J, J][]
+  joints: Partial<Record<J, InspectedJoint>>; selected: J; row: number; offset: (joint: J) => Point3
+  onSelect: (joint: J) => void; onChange: (changes: [J, Point3][]) => void; onDrag: (active: boolean) => void
 }) {
-  const drag = useRef<{ joint: J; x: number; y: number; offset: Point3; scale: number } | null>(null)
-  return <svg className="person-rig-overlay" viewBox="0 0 64 64" aria-label={label}>
-    <g pointerEvents="none">{bones.map(([a, b]) => joints[a] && joints[b] && <line key={`${a}-${b}`} x1={joints[a]!.screen[0]} y1={joints[a]!.screen[1]} x2={joints[b]!.screen[0]} y2={joints[b]!.screen[1]} stroke={a.startsWith("left") ? "#73d9fa" : "#ffe293"} strokeWidth=".32" />)}</g>
-    {(Object.entries(joints) as [J, import("@/lib/game/base-person/rig-inspection").InspectedJoint][]).map(([name, joint]) => <circle key={name} role="button" tabIndex={0} aria-label={labels[name]} aria-pressed={selected === name}
+  const drag = useRef<{ joints: [J, Point3][]; pointer: number; x: number; y: number; scale: number; pending: [number, number] | null; frame: number } | null>(null)
+  const live = useRef({ joints, row, onChange, onDrag }); live.current = { joints, row, onChange, onDrag }
+  const local = (svg: SVGSVGElement, clientX: number, clientY: number): [number, number, number] => {
+    const box = svg.getBoundingClientRect(), scale = box.width / 64
+    return [(clientX - box.left) / scale, (clientY - box.top) / scale, scale]
+  }
+  // One pose update per animation frame keeps a fast pointer from queueing rig rebuilds.
+  const flush = () => {
+    const start = drag.current
+    if (!start) return
+    start.frame = 0
+    if (!start.pending) return
+    const [x, y] = start.pending; start.pending = null
+    const delta = rigDragDelta((x - start.x) / start.scale, (y - start.y) / start.scale, live.current.row)
+    live.current.onChange(start.joints.map(([joint, offset]) => [joint, offset.map((v, i) => Math.max(-MAX_POSE_OFFSET, Math.min(MAX_POSE_OFFSET, v + delta[i]))) as Point3]))
+  }
+  const finish = () => { if (drag.current) { cancelAnimationFrame(drag.current.frame); drag.current = null; live.current.onDrag(false) } }
+  useEffect(() => finish, []) // Unmounting mid-drag still tells the owner the drag ended.
+  return <svg className="person-rig-overlay" viewBox="0 0 64 64" aria-label={label} style={{ touchAction: "none" }}
+    onPointerDown={event => {
+      if (event.button !== 0 || !event.isPrimary || drag.current) return
+      const [x, y, scale] = local(event.currentTarget, event.clientX, event.clientY)
+      // A bone drag carries both of its joints; whichever of them can be posed moves.
+      const joint = pickJoint(joints, x, y, HANDLE_RADIUS) ?? (pickBone(joints, bones, x, y, BONE_RADIUS) ? null : pickJoint(joints, x, y, PICK_RADIUS))
+      const bone = joint ? null : pickBone(joints, bones, x, y, BONE_RADIUS)
+      const grabbed: J[] = joint ? [joint] : bone ?? []
+      if (!grabbed.length) return // Empty sprite area still turns or pans the stage.
+      event.stopPropagation(); event.preventDefault()
+      const carries = !!bone && carried.some(([a, b]) => a === bone[0] && b === bone[1]) && joints[bone[0]]?.editable
+      const movable = (carries ? [bone[0]] : grabbed).filter(name => joints[name]?.editable)
+      onSelect(movable[0] ?? grabbed[0])
+      if (!movable.length) return
+      event.currentTarget.setPointerCapture(event.pointerId)
+      drag.current = { joints: movable.map(name => [name, offset(name)]), pointer: event.pointerId, x: event.clientX, y: event.clientY, scale, pending: null, frame: 0 }
+      onDrag(true)
+    }}
+    onPointerMove={event => {
+      const start = drag.current
+      if (!start || start.pointer !== event.pointerId) return
+      start.pending = [event.clientX, event.clientY]
+      if (!start.frame) start.frame = requestAnimationFrame(flush)
+    }}
+    onPointerUp={event => { if (drag.current?.pointer === event.pointerId) { cancelAnimationFrame(drag.current.frame); flush(); finish() } }}
+    onPointerCancel={finish} onLostPointerCapture={finish}>
+    <g pointerEvents="none">{bones.map(([a, b]) => joints[a] && joints[b] && <line key={`${a}-${b}`} x1={joints[a]!.screen[0]} y1={joints[a]!.screen[1]} x2={joints[b]!.screen[0]} y2={joints[b]!.screen[1]} stroke={a.startsWith("left") ? "#73d9fa" : "#ffe293"} strokeWidth=".32" strokeLinecap="round" />)}</g>
+    {orderJoints(joints).map(([name, joint]) => <circle key={name} role="button" tabIndex={0} aria-label={labels[name]} aria-pressed={selected === name}
       cx={joint.screen[0]} cy={joint.screen[1]} r={selected === name ? 1 : .7} stroke="#191d19" strokeWidth=".25" fill={selected === name ? "#fff" : joint.editable ? name.startsWith("left") ? "#73d9fa" : "#ffe293" : "#a3ac99"}
-      style={{ cursor: joint.editable ? "grab" : "pointer", touchAction: "none" }}
-      onKeyDown={event => { if (event.key === "Enter" || event.key === " ") { event.preventDefault(); onSelect(name) } }}
-      onPointerDown={event => {
-        onSelect(name)
-        if (!joint.editable) return
-        event.preventDefault(); event.currentTarget.setPointerCapture(event.pointerId)
-        drag.current = { joint: name as J, x: event.clientX, y: event.clientY, offset: offset(name as J), scale: event.currentTarget.ownerSVGElement!.getBoundingClientRect().width / 64 }
-        onDrag(true)
-      }}
-      onPointerMove={event => {
-        const start = drag.current
-        if (!start) return
-        const delta = rigDragDelta((event.clientX - start.x) / start.scale, (event.clientY - start.y) / start.scale, row)
-        onChange(start.joint, start.offset.map((v, i) => Math.max(-MAX_POSE_OFFSET, Math.min(MAX_POSE_OFFSET, v + delta[i]))) as Point3)
-      }}
-      onLostPointerCapture={() => { if (drag.current) { drag.current = null; onDrag(false) } }}>
+      style={{ cursor: joint.editable ? "grab" : "pointer" }}
+      onKeyDown={event => { if (event.key === "Enter" || event.key === " ") { event.preventDefault(); onSelect(name) } }}>
       <title>{labels[name]}{joint.reason ? ` · ${joint.reason}` : " · drag to pose"}</title>
     </circle>)}
   </svg>
 }
 
-export function CharacterRigInspector<J extends string>({ joints, selected, offset, frame, radius, maxRadius, keyed, onSelect, onChange, onRadius, onReset, onResetClip, onUndo, onRedo, canUndo, canRedo, labels, children, footer, axisLocked }: {
-  joints: Partial<Record<J, import("@/lib/game/base-person/rig-inspection").InspectedJoint>>; selected: J; offset: Point3; frame: number; radius: number; maxRadius: number; keyed: boolean
+export function CharacterRigInspector<J extends string>({ joints, selected, offset, frame, radius, maxRadius, keyed, frameKeyed, onSelect, onChange, onRadius, onReset, onResetKey, onResetFrame, onResetClip, onUndo, onRedo, canUndo, canRedo, labels, children, footer, axisLocked }: {
+  joints: Partial<Record<J, InspectedJoint>>; selected: J; offset: Point3; frame: number; radius: number; maxRadius: number; keyed: boolean; frameKeyed: boolean
   onSelect: (joint: J) => void; onChange: (offset: Point3) => void; onRadius: (radius: number) => void
-  onReset: () => void; onResetClip: () => void; onUndo: () => void; onRedo: () => void; canUndo: boolean; canRedo: boolean
+  onReset: () => void; onResetKey: () => void; onResetFrame: () => void; onResetClip: () => void; onUndo: () => void; onRedo: () => void; canUndo: boolean; canRedo: boolean
   labels: Record<J, string>; children?: ReactNode; footer?: ReactNode; axisLocked?: (axis: number) => boolean
 }) {
   const joint = joints[selected]
@@ -50,7 +87,7 @@ export function CharacterRigInspector<J extends string>({ joints, selected, offs
     <div className="person-panel-heading">Frame {frame + 1} · {keyed ? "Key pose" : "Blended pose"}</div>
     <div className="person-rig-fields">
       <label className="person-choice">Joint<select aria-label="Selected rig joint" value={selected} onChange={e => onSelect(e.target.value as J)}>{Object.keys(joints).map(name => <option key={name} value={name}>{labels[name as J]}</option>)}</select></label>
-      <p className="person-hint">Drag a gold or blue node. Rotate the view to adjust depth. Grey nodes follow the skeleton.</p>
+      <p className="person-hint">Drag a gold or blue node, or a bone to move both its joints. Rotate the view to adjust depth. Grey nodes follow the joints around them.</p>
       <div className="person-rig-axes">{["X", "Y", "Z"].map((axis, i) => <label key={axis}>{axis} offset<input aria-label={`${axis} joint offset`} type="number" step="0.01" min={-MAX_POSE_OFFSET} max={MAX_POSE_OFFSET} disabled={!joint?.editable || (axisLocked?.(i) ?? false)} value={Number(offset[i].toFixed(3))} onChange={event => {
         const value = event.currentTarget.valueAsNumber
         if (!Number.isFinite(value)) return
@@ -61,7 +98,10 @@ export function CharacterRigInspector<J extends string>({ joints, selected, offs
       <p className="person-hint">Keys blend into nearby frames and across the loop seam. Arm and leg lengths stay fixed.{selected === "staffTip" ? " A planted staff shares its ground position across contact frames." : ""}</p>
       {joint?.reason && <p className="person-hint">{joint.reason}</p>}
       {children}
-      <div className="person-presets"><button className="hud-action" disabled={!canUndo} onClick={onUndo}>Undo pose</button><button className="hud-action" disabled={!canRedo} onClick={onRedo}>Redo pose</button><button className="hud-action" disabled={!keyed} onClick={onReset}>Clear key</button><button className="hud-action" onClick={onResetClip}>Reset clip</button></div>
+      <div className="person-presets"><button className="hud-action" disabled={!canUndo} onClick={onUndo}>Undo pose</button><button className="hud-action" disabled={!canRedo} onClick={onRedo}>Redo pose</button>
+        <button className="hud-action" disabled={!joint?.editable || offset.every(v => v === 0)} onClick={onResetKey}>Reset key</button><button className="hud-action" disabled={!keyed} onClick={onReset}>Clear key</button>
+        <button className="hud-action" disabled={!frameKeyed} onClick={onResetFrame}>Reset frame</button><button className="hud-action" onClick={onResetClip}>Reset clip</button></div>
+      <p className="person-hint">Reset key returns this joint to its original pose here and keeps the key. Clear key removes it so neighbours blend through. Reset frame returns every joint on this frame.</p>
       {footer}
     </div>
   </aside>

--- a/components/person-rig-editor.tsx
+++ b/components/person-rig-editor.tsx
@@ -2,7 +2,7 @@
 
 import type { ComponentProps } from "react"
 import { JointOverlay, CharacterRigInspector } from "./character-rig-editor"
-import { RIG_BONES, RIG_LABELS, type RigJoint } from "@/lib/game/base-person/rig-joints"
+import { RIG_BONES, RIG_CARRIED_BONES, RIG_LABELS, type RigJoint } from "@/lib/game/base-person/rig-joints"
 import { type RigInspection } from "@/lib/game/base-person/rig-inspection"
 import { type EditableJoint } from "@/lib/game/base-person/pose-edits"
 import type { Point3 } from "@/lib/game/base-person/pose"
@@ -12,10 +12,10 @@ import type { Point3 } from "@/lib/game/base-person/pose"
  */
 export function RigOverlay({ joints, selected, row, offset, onSelect, onChange, onDrag }: {
   joints: RigInspection; selected: RigJoint; row: number; offset: (joint: EditableJoint) => Point3
-  onSelect: (joint: RigJoint) => void; onChange: (joint: EditableJoint, offset: Point3) => void; onDrag: (active: boolean) => void
+  onSelect: (joint: RigJoint) => void; onChange: (changes: [EditableJoint, Point3][]) => void; onDrag: (active: boolean) => void
 }) {
-  return <JointOverlay joints={joints} selected={selected} row={row} bones={RIG_BONES} labels={RIG_LABELS}
-    offset={joint => offset(joint as EditableJoint)} onSelect={onSelect} onChange={(joint, value) => onChange(joint as EditableJoint, value)} onDrag={onDrag} />
+  return <JointOverlay joints={joints} selected={selected} row={row} bones={RIG_BONES} carried={RIG_CARRIED_BONES} labels={RIG_LABELS}
+    offset={joint => offset(joint as EditableJoint)} onSelect={onSelect} onChange={changes => onChange(changes as [EditableJoint, Point3][])} onDrag={onDrag} />
 }
 
 export function RigInspector(props: Omit<ComponentProps<typeof CharacterRigInspector<RigJoint>>, "labels" | "axisLocked" | "footer">) {

--- a/lib/game/base-person/bake.ts
+++ b/lib/game/base-person/bake.ts
@@ -2,6 +2,7 @@ import * as THREE from "three"
 import { personCamera } from "./camera"
 import { BASE_PERSON, PERSON_CLIPS, WALK_CLIP_STRIDES, ACTION_CLIPS, SOCKET_NAMES, type BaseClip, type ActionClip, type SocketName } from "./pose"
 import { DEFAULT_DESIGN, personRecipe, type PersonDesign } from "./design"
+import type { PoseEdits } from "./pose-edits"
 import { personCastShadow } from "./shadow"
 import { inkPersonFrame } from "./ink"
 import { createBasePersonRig } from "./rig"
@@ -77,11 +78,14 @@ export function personFrameRenderer(design: PersonDesign, extraPalette: string[]
   maskCanvas.width = size; maskCanvas.height = size
   const maskContext = maskCanvas.getContext("2d", { willReadFrequently: true })!
   return {
-    recipe,
-    render(clip: BaseClip, phase: number, row: number, debug: boolean, poseOverride?: (rig: ReturnType<typeof createBasePersonRig>) => void) {
+    recipe, rig,
+    /** `edits` lets a long-lived session preview pose drafts without rebuilding the rig. */
+    render(clip: BaseClip, phase: number, row: number, debug: boolean, poseOverride?: (rig: ReturnType<typeof createBasePersonRig>) => void, edits: PoseEdits | undefined = recipe.design.poseEdits) {
+      // A progressive bake and a live preview may interleave on the shared renderer.
+      if (renderer.domElement.width !== size || renderer.domElement.height !== size) renderer.setSize(size, size, false)
       rig.trackSides(debug)
       rig.view(row)
-      rig.pose(phase * (clip === "walk" ? WALK_CLIP_STRIDES : 1), clip)
+      rig.pose(phase * (clip === "walk" ? WALK_CLIP_STRIDES : 1), clip, edits)
       poseOverride?.(rig)
       renderer.render(scene, camera)
       context.clearRect(0, 0, size, size)
@@ -144,12 +148,19 @@ export interface PersonPreview {
   clip: BaseClip
   frame: number
   sides: boolean
+  /** Sheet rows that were rendered; a drag only refreshes the facing on screen. */
+  rows: number[]
   sockets: FrameRegistration["sockets"][]
 }
 
-/** Only the eight currently visible poses; avoids rebuilding four atlases during a drag. */
-export function renderPersonPreview(design: PersonDesign, clip: BaseClip, frame: number, sides: boolean): PersonPreview {
-  const session = personFrameRenderer(design)
+const ALL_ROWS = [0, 1, 2, 3, 4, 5, 6, 7]
+export type PersonSession = ReturnType<typeof personFrameRenderer>
+/** Everything but pose keys: sessions built for the same key can render any pose draft of that design. */
+export const personSessionKey = (design: PersonDesign) => JSON.stringify({ ...personRecipe(design).design, poseEdits: undefined })
+/** Only the currently visible poses; avoids rebuilding four atlases during a drag.
+ * Pass a `session` made for the same `personSessionKey` to keep its rig and compiled shaders across drafts; it stays open. */
+export function renderPersonPreview(design: PersonDesign, clip: BaseClip, frame: number, sides: boolean, rows: readonly number[] = ALL_ROWS, shared?: PersonSession): PersonPreview {
+  const session = shared ?? personFrameRenderer(design)
   const size = session.recipe.cellSize
   const canvas = document.createElement("canvas")
   canvas.width = size; canvas.height = 8 * size
@@ -162,82 +173,132 @@ export function renderPersonPreview(design: PersonDesign, clip: BaseClip, frame:
   const depthContext = depth.getContext("2d")!
   const sockets: PersonPreview["sockets"] = []
   try {
-    for (let row = 0; row < 8; row++) {
-      const rendered = session.render(clip, frame / PERSON_CLIPS[clip].frames, row, sides)
+    for (const row of rows) {
+      const rendered = session.render(clip, frame / PERSON_CLIPS[clip].frames, row, sides, undefined, design.poseEdits)
       context.drawImage(rendered.canvas, 0, row * size)
       if (rendered.shadow) shadowContext.drawImage(rendered.shadow, 0, row * size)
       if (rendered.depth) depthContext.drawImage(rendered.depth, 0, row * size)
-      sockets.push(rendered.sockets)
+      sockets[row] = rendered.sockets
     }
-    return { url: canvas.toDataURL("image/png"), depthUrl: depth.toDataURL("image/png"), shadowUrl: shadow.toDataURL("image/png"), design, clip, frame, sides, sockets }
-  } finally { session.dispose() }
+    return { url: canvas.toDataURL("image/png"), depthUrl: depth.toDataURL("image/png"), shadowUrl: shadow.toDataURL("image/png"), design, clip, frame, sides, rows: [...rows], sockets }
+  } finally { if (!shared) session.dispose() }
 }
 
-/** Bake directly at final pixel resolution, without crops or per-pose resizing. */
-export function bakeBasePerson(design: PersonDesign = DEFAULT_DESIGN, diagnostics = true): BasePersonBake {
-  const session = personFrameRenderer(design)
-  const recipe = session.recipe, size = recipe.cellSize
-  const clips = Object.fromEntries(Object.keys(PERSON_CLIPS).map(clip => [clip, []])) as unknown as Record<BaseClip, FrameRegistration[]>
-  let safePadding = size
-  const shadows = {} as Record<BaseClip, string>
-  const depths = {} as Record<BaseClip, string>
-  const render = (clip: BaseClip, debug: boolean) => {
-    const columns = PERSON_CLIPS[clip].frames
+interface ClipBake { url: string; shadow: string; depth: string; debug: string; frames: FrameRegistration[]; padding: number }
+export interface BakeProgress { done: number; total: number }
+const BAKE_ORDER: BaseClip[] = [...ACTION_CLIPS, "walk", "idle"]
+const clipCache = new Map<string, ClipBake>()
+const CLIP_CACHE_LIMIT = 4 * BAKE_ORDER.length
+
+/** A clip's frames depend on the design and only that clip's own pose keys, so editing one pose re-renders one sheet. */
+export function personClipBakeKey(design: PersonDesign, clip: BaseClip) {
+  return JSON.stringify([clip, { ...design, poseEdits: design.poseEdits?.[clip] ?? null }])
+}
+
+/** Bake directly at final pixel resolution, one sheet row per step so callers can paint progress or stop early. */
+export function* bakePersonSteps(design: PersonDesign = DEFAULT_DESIGN, diagnostics = true): Generator<BakeProgress, BasePersonBake> {
+  const recipe = personRecipe(design), size = recipe.cellSize
+  const passes = diagnostics ? 2 : 1, total = BAKE_ORDER.length * 8 * passes
+  let done = 0, session: ReturnType<typeof personFrameRenderer> | undefined
+  const results = {} as Record<BaseClip, ClipBake>
+  const sheet = (columns: number) => {
     const canvas = document.createElement("canvas")
     canvas.width = columns * size; canvas.height = 8 * size
-    const context = canvas.getContext("2d")!
-    const shadow = document.createElement("canvas")
-    shadow.width = canvas.width; shadow.height = canvas.height
-    const shadowContext = shadow.getContext("2d")!
-    const depth = document.createElement("canvas")
-    depth.width = canvas.width; depth.height = canvas.height
-    const depthContext = depth.getContext("2d")!
-    for (let row = 0; row < 8; row++) {
-      for (let frame = 0; frame < columns; frame++) {
-        const rendered = session.render(clip, frame / columns, row, debug)
-        context.drawImage(rendered.canvas, frame * size, row * size)
-        if (!debug) {
-          if (rendered.shadow) shadowContext.drawImage(rendered.shadow, frame * size, row * size)
-          if (rendered.depth) depthContext.drawImage(rendered.depth, frame * size, row * size)
-          safePadding = Math.min(safePadding, rendered.padding)
-          clips[clip].push({ direction: recipe.directions[row], frame, phase: frame / columns, sockets: rendered.sockets })
-        }
-      }
-    }
-    if (!debug) shadows[clip] = shadow.toDataURL("image/png")
-    if (!debug) depths[clip] = depth.toDataURL("image/png")
-    return canvas.toDataURL("image/png")
+    return { canvas, context: canvas.getContext("2d")! }
   }
   try {
-    const actions = Object.fromEntries(ACTION_CLIPS.map(clip => {
-      const url = render(clip, false)
-      return [clip, { url, shadow: shadows[clip], depth: depths[clip], debug: diagnostics ? render(clip, true) : "" }]
-    })) as BasePersonBake["actions"]
-    return {
-      actions,
-      walk: render("walk", false), idle: render("idle", false),
-      debugWalk: diagnostics ? render("walk", true) : "", debugIdle: diagnostics ? render("idle", true) : "",
-      shadowWalk: shadows.walk, shadowIdle: shadows.idle,
-      depthWalk: depths.walk, depthIdle: depths.idle,
-      metadata: {
-        template: recipe.id, depthEncoding: SPRITE_DEPTH_ENCODING, version: recipe.version, cellSize: size,
-        nominalHeightPixels: recipe.nominalHeightPixels, renderPalette: recipe.renderPalette,
-        anchor: recipe.anchor, directions: recipe.directions,
-        frameCount: PERSON_CLIPS.walk.frames, walkStrides: WALK_CLIP_STRIDES, camera: recipe.camera,
-        design: recipe.design, safePadding,
-        handedness: "+X = anatomical left; +Z = forward. Never mirror a dressed sprite.", clips,
-      },
+    yield { done, total } // Announce the bake before the first row so the editor can show it starting.
+    for (const clip of BAKE_ORDER) {
+      const key = personClipBakeKey(recipe.design, clip), columns = PERSON_CLIPS[clip].frames
+      let entry = clipCache.get(key)
+      if (entry && (!diagnostics || entry.debug)) { results[clip] = entry; done += 8 * passes; yield { done, total }; continue }
+      session ??= personFrameRenderer(design)
+      if (!entry) {
+        const color = sheet(columns), shadow = sheet(columns), depth = sheet(columns)
+        const frames: FrameRegistration[] = []
+        let padding = size
+        for (let row = 0; row < 8; row++) {
+          for (let frame = 0; frame < columns; frame++) {
+            const rendered = session.render(clip, frame / columns, row, false)
+            color.context.drawImage(rendered.canvas, frame * size, row * size)
+            if (rendered.shadow) shadow.context.drawImage(rendered.shadow, frame * size, row * size)
+            if (rendered.depth) depth.context.drawImage(rendered.depth, frame * size, row * size)
+            padding = Math.min(padding, rendered.padding)
+            frames.push({ direction: recipe.directions[row], frame, phase: frame / columns, sockets: rendered.sockets })
+          }
+          done++; yield { done, total }
+        }
+        entry = { url: color.canvas.toDataURL("image/png"), shadow: shadow.canvas.toDataURL("image/png"), depth: depth.canvas.toDataURL("image/png"), debug: "", frames, padding }
+      } else done += 8
+      if (diagnostics) {
+        const debug = sheet(columns)
+        for (let row = 0; row < 8; row++) {
+          for (let frame = 0; frame < columns; frame++) debug.context.drawImage(session.render(clip, frame / columns, row, true).canvas, frame * size, row * size)
+          done++; yield { done, total }
+        }
+        entry = { ...entry, debug: debug.canvas.toDataURL("image/png") }
+      }
+      clipCache.delete(key); clipCache.set(key, entry)
+      if (clipCache.size > CLIP_CACHE_LIMIT) clipCache.delete(clipCache.keys().next().value!)
+      results[clip] = entry
     }
-  } finally { session.dispose() }
+  } finally { session?.dispose() }
+  const clips = Object.fromEntries(BAKE_ORDER.map(clip => [clip, results[clip].frames])) as Record<BaseClip, FrameRegistration[]>
+  const actions = Object.fromEntries(ACTION_CLIPS.map(clip => [clip, { url: results[clip].url, shadow: results[clip].shadow, depth: results[clip].depth, debug: results[clip].debug }])) as BasePersonBake["actions"]
+  return {
+    actions,
+    walk: results.walk.url, idle: results.idle.url,
+    debugWalk: results.walk.debug, debugIdle: results.idle.debug,
+    shadowWalk: results.walk.shadow, shadowIdle: results.idle.shadow,
+    depthWalk: results.walk.depth, depthIdle: results.idle.depth,
+    metadata: {
+      template: recipe.id, depthEncoding: SPRITE_DEPTH_ENCODING, version: recipe.version, cellSize: size,
+      nominalHeightPixels: recipe.nominalHeightPixels, renderPalette: recipe.renderPalette,
+      anchor: recipe.anchor, directions: recipe.directions,
+      frameCount: PERSON_CLIPS.walk.frames, walkStrides: WALK_CLIP_STRIDES, camera: recipe.camera,
+      design: recipe.design, safePadding: Math.min(...BAKE_ORDER.map(clip => results[clip].padding)),
+      handedness: "+X = anatomical left; +Z = forward. Never mirror a dressed sprite.", clips,
+    },
+  }
+}
+
+export function bakeBasePerson(design: PersonDesign = DEFAULT_DESIGN, diagnostics = true): BasePersonBake {
+  const steps = bakePersonSteps(design, diagnostics)
+  for (;;) { const next = steps.next(); if (next.done) return next.value }
 }
 
 const cache = new Map<string, BasePersonBake>()
-export function cachedPersonBake(design: PersonDesign = DEFAULT_DESIGN): BasePersonBake {
-  const key = JSON.stringify(personRecipe(design).design)
-  const existing = cache.get(key)
-  if (existing) return existing
-  const result = bakeBasePerson(design)
+const bakeKey = (design: PersonDesign) => JSON.stringify(personRecipe(design).design)
+function rememberBake(key: string, result: BasePersonBake) {
   cache.set(key, result)
   if (cache.size > 4) cache.delete(cache.keys().next().value!)
   return result
+}
+export function cachedPersonBake(design: PersonDesign = DEFAULT_DESIGN): BasePersonBake {
+  const key = bakeKey(design)
+  return cache.get(key) ?? rememberBake(key, bakeBasePerson(design))
+}
+
+/** Wait for a frame to paint (React commits its scheduled render first), then continue in a fresh task. */
+const paintFrame = () => new Promise<void>(resolve => requestAnimationFrame(() => setTimeout(resolve, 0)))
+const PAINT_BUDGET_MS = 40
+
+/** Bake with regular paint breaks so the editor can show progress; cancelling resolves null and releases the renderer. */
+export function bakePersonProgressively(design: PersonDesign, onProgress: (progress: BakeProgress) => void): { promise: Promise<BasePersonBake | null>; cancel: () => void } {
+  const key = bakeKey(design), ready = cache.get(key)
+  if (ready) return { promise: Promise.resolve(ready), cancel: () => {} }
+  const steps = bakePersonSteps(design)
+  let cancelled = false
+  const promise = (async () => {
+    let painted = performance.now()
+    for (;;) {
+      if (cancelled) { steps.return(undefined as unknown as BasePersonBake); return null }
+      const next = steps.next()
+      if (next.done) return rememberBake(key, next.value)
+      onProgress(next.value)
+      // Cached clips fly past; only real rendering earns a paint break, so the total stays close to a straight bake.
+      if (next.value.done === 0 || performance.now() - painted > PAINT_BUDGET_MS) { await paintFrame(); painted = performance.now() }
+    }
+  })()
+  return { promise, cancel: () => { cancelled = true } }
 }

--- a/lib/game/base-person/edited-leg.ts
+++ b/lib/game/base-person/edited-leg.ts
@@ -3,18 +3,24 @@ import { legPose, WALK_STANCE_FRACTION, type BaseClip, type BodySide, type Point
 import { poseOffset, type PoseEdits } from "./pose-edits"
 import type { PersonRecipe } from "./design"
 
-/** Pose editing retains bone lengths, forward knees and planted walking feet. */
-export function editedLeg(side: BodySide, phase: number, clip: BaseClip, b: PersonRecipe["body"], edits?: PoseEdits, localRotation = new THREE.Quaternion()) {
+/** Pose editing retains bone lengths, forward knees and planted walking feet.
+ * `pelvisShift` (root space) moves the hip with an authored pelvis offset; the ankle stays put and the leg re-solves. */
+export function editedLeg(side: BodySide, phase: number, clip: BaseClip, b: PersonRecipe["body"], edits?: PoseEdits, localRotation = new THREE.Quaternion(), pelvisShift: Point3 = [0, 0, 0]) {
   const base = legPose(side, phase, clip, b)
   const footOffset = new THREE.Vector3(...poseOffset(edits, clip, side === "left" ? "leftFoot" : "rightFoot", phase)).applyQuaternion(localRotation).toArray()
   const kneeOffset = new THREE.Vector3(...poseOffset(edits, clip, side === "left" ? "leftKnee" : "rightKnee", phase)).applyQuaternion(localRotation).toArray()
-  if ([...footOffset, ...kneeOffset].every(v => v === 0)) return base
+  const hipOffset = new THREE.Vector3(...poseOffset(edits, clip, side === "left" ? "leftHip" : "rightHip", phase)).add(new THREE.Vector3(...pelvisShift)).applyQuaternion(localRotation).toArray()
+  if ([...footOffset, ...kneeOffset, ...hipOffset].every(v => v === 0)) return base
   const walking = clip === "walk" || clip === "carrying" || clip === "procession"
   const p = ((phase + (side === "right" ? 0.5 : 0)) % 1 + 1) % 1
   const swing = (p - WALK_STANCE_FRACTION) / (1 - WALK_STANCE_FRACTION)
   const weight = walking ? base.planted ? 0 : Math.min(1, Math.max(0, Math.sin(swing * Math.PI) * 3)) : 1
-  const hip = new THREE.Vector3(...base.hip)
+  const shift = new THREE.Vector3(...pelvisShift).applyQuaternion(localRotation)
+  const hipKey = new THREE.Vector3(...hipOffset).sub(shift)
   const ankle = new THREE.Vector3(...base.ankle).addScaledVector(new THREE.Vector3(...footOffset), weight)
+  // A planted foot stays put, so a hip key that would overstretch the leg is shortened instead.
+  const hip = new THREE.Vector3(...base.hip).add(shift)
+  hip.addScaledVector(hipKey, base.planted ? reachScale(hip.clone().sub(ankle), hipKey, b.thighLength + b.shinLength - 1e-6) : 1)
   ankle.y = Math.max(b.ankleHeight, ankle.y)
   const axis = ankle.clone().sub(hip)
   const length = Math.max(Math.abs(b.thighLength - b.shinLength) + 1e-6, Math.min(axis.length(), b.thighLength + b.shinLength - 1e-6))
@@ -27,5 +33,27 @@ export function editedLeg(side: BodySide, phase: number, clip: BaseClip, b: Pers
   if (bend.dot(forward) < 0.005) bend.addScaledVector(forward, 0.005 - bend.dot(forward))
   bend.normalize()
   const knee = hip.clone().addScaledVector(axis, along).addScaledVector(bend, Math.sqrt(Math.max(0, b.thighLength ** 2 - along ** 2)))
-  return { ...base, knee: knee.toArray() as Point3, ankle: ankle.toArray() as Point3 }
+  return { ...base, hip: hip.toArray() as Point3, knee: knee.toArray() as Point3, ankle: ankle.toArray() as Point3 }
+}
+
+/** Shorten a pelvis offset (root space) until every planted foot can still reach it with straight legs. */
+export function reachablePelvisShift(phase: number, clip: BaseClip, b: PersonRecipe["body"], shift: Point3, localRotation = new THREE.Quaternion()): Point3 {
+  const local = new THREE.Vector3(...shift).applyQuaternion(localRotation)
+  if (local.lengthSq() === 0) return shift
+  const reach = b.thighLength + b.shinLength - 1e-6
+  let scale = 1
+  for (const side of ["left", "right"] as const) {
+    const base = legPose(side, phase, clip, b)
+    if (!base.planted) continue
+    scale = Math.min(scale, reachScale(new THREE.Vector3(...base.hip).sub(new THREE.Vector3(...base.ankle)), local, reach))
+  }
+  return shift.map(v => v * scale) as Point3
+}
+
+/** Largest t in [0, 1] with |from + t·delta| ≤ reach. */
+function reachScale(from: THREE.Vector3, delta: THREE.Vector3, reach: number) {
+  if (delta.lengthSq() === 0 || from.clone().add(delta).length() <= reach) return 1
+  const a = delta.lengthSq(), half = from.dot(delta), c = from.lengthSq() - reach * reach
+  const root = half * half - a * c
+  return Math.max(0, Math.min(1, root < 0 ? 0 : (-half + Math.sqrt(root)) / a))
 }

--- a/lib/game/base-person/pose-edits.test.ts
+++ b/lib/game/base-person/pose-edits.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, it } from "vitest"
 import * as THREE from "three"
-import { poseOffset, setPoseKey, validatePoseEdits, type PoseEdits } from "./pose-edits"
+import { clearFrameKeys, poseOffset, setPoseKey, validatePoseEdits, type PoseEdits } from "./pose-edits"
 import { DEFAULT_DESIGN, PERSON_PRESETS, personRecipe, validatePersonDesign } from "./design"
 import { createBasePersonRig } from "./rig"
-import { inspectRig, rigDragDelta } from "./rig-inspection"
+import { inspectRig, orderJoints, pickBone, pickJoint, rigDragDelta, type InspectedJoint } from "./rig-inspection"
+import { personClipBakeKey } from "./bake"
 import { personCamera } from "./camera"
-import { PERSON_CLIPS, type Point3 } from "./pose"
+import { PERSON_CLIPS, legPose, type Point3 } from "./pose"
 import { staffDimensions } from "./staff-motion"
 
 const distance = (a: Point3, b: Point3) => new THREE.Vector3(...a).distanceTo(new THREE.Vector3(...b))
@@ -25,7 +26,38 @@ describe("editable pose keys", () => {
     const poseEdits = setPoseKey(undefined, "idle", "head", { frame: 0, radius: 1, offset: [0, 0.1, 0] }, 0)
     const design = { ...DEFAULT_DESIGN, poseEdits }
     expect(validatePersonDesign(JSON.parse(JSON.stringify(design)))).toEqual(design)
-    for (const value of [null, { fly: {} }, { walk: { chest: [] } }, { walk: { head: [{ frame: 20, radius: 1, offset: [0, 0, 0] }] } }, { walk: { head: [{ frame: 0, radius: 1, offset: [0, Infinity, 0] }] } }]) expect(() => validatePoseEdits(value)).toThrow()
+    for (const value of [null, { fly: {} }, { walk: { staffTop: [] } }, { walk: { head: [{ frame: 20, radius: 1, offset: [0, 0, 0] }] } }, { walk: { head: [{ frame: 0, radius: 1, offset: [0, Infinity, 0] }] } }]) expect(() => validatePoseEdits(value)).toThrow()
+  })
+  it("returns a whole frame to the generated pose while keeping other frames", () => {
+    let edits = setPoseKey(undefined, "walk", "head", { frame: 4, radius: 2, offset: [0.1, 0, 0] }, 4)
+    edits = setPoseKey(edits, "walk", "leftHand", { frame: 4, radius: 2, offset: [0, 0.1, 0] }, 4)
+    edits = setPoseKey(edits, "walk", "leftHand", { frame: 9, radius: 2, offset: [0, 0.2, 0] }, 9)
+    const cleared = clearFrameKeys(edits, "walk", 4)
+    expect(cleared.walk?.head).toEqual([])
+    expect(cleared.walk?.leftHand).toEqual([{ frame: 9, radius: 2, offset: [0, 0.2, 0] }])
+    expect(poseOffset(cleared, "walk", "head", 4 / 20)).toEqual([0, 0, 0])
+    expect(clearFrameKeys(undefined, "idle", 0)).toEqual({})
+  })
+  it("keys one clip's sheet to that clip's own pose edits only", () => {
+    const design = { ...DEFAULT_DESIGN, poseEdits: setPoseKey(undefined, "walk", "head", { frame: 0, radius: 1, offset: [0.1, 0, 0] }, 0) }
+    expect(personClipBakeKey(design, "idle")).toBe(personClipBakeKey(DEFAULT_DESIGN, "idle"))
+    expect(personClipBakeKey(design, "walk")).not.toBe(personClipBakeKey(DEFAULT_DESIGN, "walk"))
+    expect(personClipBakeKey(design, "walk")).not.toBe(personClipBakeKey(design, "idle"))
+    expect(personClipBakeKey({ ...design, hands: design.hands + 0.1 }, "idle")).not.toBe(personClipBakeKey(design, "idle"))
+  })
+  it("picks the editable handle under a pointer over covering skeleton nodes and stacks near joints last", () => {
+    const joints: Partial<Record<"leftHand" | "rightHand" | "chest" | "pelvis", InspectedJoint>> = {
+      chest: { position: [0, 0, 0], screen: [32, 30], editable: false, depth: 0.2 },
+      leftHand: { position: [0, 0, 0], screen: [32, 30.6], editable: true, depth: 0.5 },
+      rightHand: { position: [0, 0, 0], screen: [33, 31], editable: true, depth: 0.1 },
+      pelvis: { position: [0, 0, 0], screen: [32, 40], editable: false, depth: 0.2 },
+    }
+    expect(pickJoint(joints, 32, 30, 2.5)).toBe("leftHand")
+    expect(pickJoint(joints, 33.2, 31, 2.5)).toBe("rightHand")
+    expect(pickJoint(joints, 32, 40, 2.5)).toBe("pelvis")
+    expect(pickJoint(joints, 32, 38.5, 2.5)).toBe("pelvis") // A grey node clearly under the pointer still wins.
+    expect(pickJoint(joints, 10, 10, 2.5)).toBeNull()
+    expect(orderJoints(joints).map(([name]) => name)).toEqual(["chest", "pelvis", "leftHand", "rightHand"])
   })
   it("unprojects pointer motion correctly in every facing", () => {
     const camera = personCamera()
@@ -56,11 +88,77 @@ describe("editable pose keys", () => {
       }
     } finally { plain.dispose(); edited.dispose() }
   })
+  it("poses the skeleton's own joints: pelvis carries the body, chest carries head and arms, hips and shoulders move their limbs", () => {
+    const base = PERSON_PRESETS.Traveler, b = personRecipe(base).body
+    const key = (offset: Point3) => [{ frame: 0, radius: 3, offset }]
+    const plain = createBasePersonRig(personRecipe(base))
+    const posed = (poseEdits: PoseEdits) => createBasePersonRig(personRecipe({ ...base, poseEdits }))
+    const rigs = [plain]
+    try {
+      plain.pose(0, "walk"); const a = plain.joints()
+      const pelvis = posed({ walk: { pelvis: key([0, -0.04, 0.01]) } }); rigs.push(pelvis); pelvis.pose(0, "walk"); const p = pelvis.joints()
+      for (const joint of ["pelvis", "chest", "head", "leftShoulder", "leftHip", "rightHip"] as const) p[joint]!.forEach((v, i) => expect(v - a[joint]![i]).toBeCloseTo([0, -0.04, 0.01][i], 6))
+      expect(distance(p.leftFoot!, a.leftFoot!)).toBeLessThan(1e-6) // Planted feet stay on the ground.
+      // A pull the support leg cannot follow is shortened rather than lifting the planted foot.
+      const stretch = posed({ walk: { pelvis: key([0.3, 0.2, 0.3]) } }); rigs.push(stretch); stretch.pose(0, "walk"); const st = stretch.joints()
+      expect(distance(st.leftFoot!, a.leftFoot!)).toBeLessThan(1e-6)
+      expect(st.pelvis![1]).toBeGreaterThan(a.pelvis![1]); expect(st.pelvis![1] - a.pelvis![1]).toBeLessThan(0.2)
+      expect(distance(st.leftHip!, st.leftFoot!)).toBeLessThanOrEqual(b.thighLength + b.shinLength)
+      const chest = posed({ walk: { chest: key([0, 0.04, 0.06]) } }); rigs.push(chest); chest.pose(0, "walk"); const c = chest.joints()
+      for (const joint of ["chest", "head", "leftShoulder", "rightShoulder"] as const) c[joint]!.forEach((v, i) => expect(v - a[joint]![i]).toBeCloseTo([0, 0.04, 0.06][i], 6))
+      expect(c.pelvis).toEqual(a.pelvis)
+      const shoulder = posed({ walk: { rightShoulder: key([-0.05, 0.03, 0]) } }); rigs.push(shoulder); shoulder.pose(0, "walk"); const sh = shoulder.joints()
+      sh.rightShoulder!.forEach((v, i) => expect(v - a.rightShoulder![i]).toBeCloseTo([-0.05, 0.03, 0][i], 6))
+      expect(sh.leftShoulder).toEqual(a.leftShoulder)
+      // A hip key moves a swinging leg's root freely; on a planted leg it is shortened so the foot stays down.
+      const swingKey = [{ frame: 15, radius: 3, offset: [0.03, 0, -0.03] as Point3 }]
+      const hip = posed({ walk: { leftHip: swingKey } }); rigs.push(hip)
+      plain.pose(15 / 20, "walk"); const a15 = plain.joints(); hip.pose(15 / 20, "walk"); const h = hip.joints()
+      h.leftHip!.forEach((v, i) => expect(v - a15.leftHip![i]).toBeCloseTo([0.03, 0, -0.03][i], 6))
+      expect(distance(h.leftFoot!, a15.leftFoot!)).toBeLessThan(1e-6)
+      const plantedHip = posed({ walk: { leftHip: key([0.3, 0.3, 0]) } }); rigs.push(plantedHip); plantedHip.pose(0, "walk"); const ph = plantedHip.joints()
+      expect(distance(ph.leftFoot!, a.leftFoot!)).toBeLessThan(1e-6)
+      expect(distance(ph.leftHip!, ph.leftFoot!)).toBeLessThanOrEqual(b.thighLength + b.shinLength)
+      for (const joints of [p, st, c, sh, h, ph]) for (const side of ["left", "right"] as const) {
+        expect(distance(joints[`${side}Hip`]!, joints[`${side}Knee`]!)).toBeCloseTo(b.thighLength, 6)
+        expect(distance(joints[`${side}Knee`]!, joints[`${side}Foot`]!)).toBeCloseTo(b.shinLength, 6)
+        expect(distance(joints[`${side}Shoulder`]!, joints[`${side}Elbow`]!)).toBeCloseTo(b.upperArmLength, 6)
+      }
+      for (const rig of rigs.slice(1)) { rig.pose(0.3, "walk"); rig.pose(0, "walk") }
+      expect(pelvis.joints()).toEqual(p); expect(chest.joints()).toEqual(c) // No accumulation across poses.
+    } finally { rigs.forEach(rig => rig.dispose()) }
+  })
+  it("picks the bone under the pointer only when no handle is", () => {
+    const joints: Partial<Record<"a" | "b" | "c", InspectedJoint>> = {
+      a: { position: [0, 0, 0], screen: [10, 10], editable: true }, b: { position: [0, 0, 0], screen: [30, 10], editable: true }, c: { position: [0, 0, 0], screen: [30, 30], editable: false },
+    }
+    const bones: [ "a" | "b" | "c", "a" | "b" | "c"][] = [["a", "b"], ["b", "c"]]
+    expect(pickBone(joints, bones, 20, 10.8, 1.2)).toEqual(["a", "b"])
+    expect(pickBone(joints, bones, 29.5, 20, 1.2)).toEqual(["b", "c"])
+    expect(pickBone(joints, bones, 20, 13, 1.2)).toBeNull()
+    expect(pickBone(joints, bones, 45, 10, 1.2)).toBeNull() // Beyond the segment's end.
+  })
+  it("reports leg handles at the rig's actual hip, knee and ankle", () => {
+    const rig = createBasePersonRig(personRecipe(DEFAULT_DESIGN)), b = personRecipe(DEFAULT_DESIGN).body
+    try {
+      for (const frame of [0, 7, 13]) {
+        rig.view(0); rig.pose(frame / 20, "walk")
+        const joints = rig.joints()
+        for (const side of ["left", "right"] as const) {
+          const leg = legPose(side, frame / 20, "walk", b)
+          expect(distance(joints[`${side}Hip`]!, leg.hip)).toBeLessThan(1e-6)
+          expect(distance(joints[`${side}Knee`]!, leg.knee)).toBeLessThan(1e-6)
+          expect(distance(joints[`${side}Foot`]!, leg.ankle)).toBeLessThan(1e-6)
+        }
+      }
+    } finally { rig.dispose() }
+  })
   it("shows every activity and locks planted feet while allowing swing edits", () => {
     for (const clip of Object.keys(PERSON_CLIPS) as (keyof typeof PERSON_CLIPS)[]) {
       const joints = inspectRig(DEFAULT_DESIGN, clip, 0, 1)
       expect(joints.head?.editable).toBe(true)
-      expect(joints.pelvis?.editable).toBe(false)
+      expect(joints.pelvis?.editable).toBe(true)
+      expect(joints.chest?.editable).toBe(true)
       for (const joint of Object.values(joints)) expect([...joint.position, ...joint.screen].every(Number.isFinite)).toBe(true)
     }
     expect(inspectRig(DEFAULT_DESIGN, "walk", 0, 1).leftFoot?.editable).toBe(false)

--- a/lib/game/base-person/pose-edits.ts
+++ b/lib/game/base-person/pose-edits.ts
@@ -1,6 +1,6 @@
 import { PERSON_CLIPS, type BaseClip, type Point3 } from "./pose"
 
-export const EDITABLE_JOINTS = ["head", "leftHand", "rightHand", "leftElbow", "rightElbow", "leftKnee", "rightKnee", "leftFoot", "rightFoot", "staffTip"] as const
+export const EDITABLE_JOINTS = ["head", "chest", "pelvis", "leftShoulder", "rightShoulder", "leftHand", "rightHand", "leftElbow", "rightElbow", "leftHip", "rightHip", "leftKnee", "rightKnee", "leftFoot", "rightFoot", "staffTip"] as const
 export type EditableJoint = typeof EDITABLE_JOINTS[number]
 export interface PoseKey { frame: number; offset: Point3; radius: number }
 export type PoseEdits = Partial<Record<BaseClip, Partial<Record<EditableJoint, PoseKey[]>>>>
@@ -57,4 +57,11 @@ export function setPoseKey(edits: PoseEdits | undefined, clip: BaseClip, joint: 
   if (key) keys.push(key)
   result[clip] = { ...result[clip], [joint]: keys.sort((a, b) => a.frame - b.frame) }
   return validatePoseEdits(result)
+}
+
+/** Return one frame to the generated pose for every joint by dropping its keys there. */
+export function clearFrameKeys(edits: PoseEdits | undefined, clip: BaseClip, frame: number): PoseEdits {
+  let result = edits ?? {}
+  for (const joint of Object.keys(result[clip] ?? {}) as EditableJoint[]) result = setPoseKey(result, clip, joint, null, frame)
+  return result
 }

--- a/lib/game/base-person/rig-inspection.ts
+++ b/lib/game/base-person/rig-inspection.ts
@@ -6,24 +6,26 @@ import { BASE_PERSON, PERSON_CLIPS, WALK_CLIP_STRIDES, walkFoot, type BaseClip, 
 import { EDITABLE_JOINTS, type EditableJoint } from "./pose-edits"
 import type { RigJoint } from "./rig-joints"
 
-export interface InspectedJoint { position: Point3; screen: [number, number]; editable: boolean; reason?: string }
+/** `depth` is the projected camera depth (smaller is nearer) so overlapping handles stack correctly. */
+export interface InspectedJoint { position: Point3; screen: [number, number]; editable: boolean; reason?: string; depth?: number }
 export type RigInspection = Partial<Record<RigJoint, InspectedJoint>>
 
-export function inspectRig(design: PersonDesign, clip: BaseClip, frame: number, row: number): RigInspection {
-  const recipe = personRecipe(design), rig = createBasePersonRig(recipe), camera = personCamera()
+/** Pass a `shared` rig built for the same design (pose keys aside) to skip rebuilding one per inspection; it is left intact. */
+export function inspectRig(design: PersonDesign, clip: BaseClip, frame: number, row: number, shared?: ReturnType<typeof createBasePersonRig>): RigInspection {
+  const recipe = personRecipe(design), rig = shared ?? createBasePersonRig(recipe), camera = personCamera()
   const phase = frame / PERSON_CLIPS[clip].frames * (clip === "walk" ? WALK_CLIP_STRIDES : 1)
   try {
-    rig.view(row); rig.pose(phase, clip)
+    rig.view(row); rig.pose(phase, clip, design.poseEdits)
     const result: RigInspection = {}
     for (const [name, position] of Object.entries(rig.joints()) as [RigJoint, Point3][]) {
       const projected = rig.root.localToWorld(new THREE.Vector3(...position)).project(camera)
       const groundLocked = (name === "leftFoot" || name === "rightFoot") && (clip === "walk" || clip === "carrying" || clip === "procession") && walkFoot(name === "leftFoot" ? "left" : "right", phase, recipe.body).planted
       const editable = EDITABLE_JOINTS.includes(name as EditableJoint) && !groundLocked
-      result[name] = { position, screen: [(projected.x + 1) * BASE_PERSON.cellSize / 2, (1 - projected.y) * BASE_PERSON.cellSize / 2], editable,
-        reason: groundLocked ? "Planted foot: ground contact stays locked. Select a swing frame to adjust it." : !editable ? "This joint follows the body proportions and the shared skeleton." : undefined }
+      result[name] = { position, screen: [(projected.x + 1) * BASE_PERSON.cellSize / 2, (1 - projected.y) * BASE_PERSON.cellSize / 2], editable, depth: projected.z,
+        reason: groundLocked ? "Planted foot: ground contact stays locked. Select a swing frame to adjust it." : !editable ? "This point follows the joints around it; drag those instead." : undefined }
     }
     return result
-  } finally { rig.dispose() }
+  } finally { if (!shared) rig.dispose() }
 }
 
 export function rigDragDelta(dx: number, dy: number, row: number): Point3 {
@@ -31,4 +33,38 @@ export function rigDragDelta(dx: number, dy: number, row: number): Point3 {
   const zero = new THREE.Vector3(0, 0, 0).unproject(camera)
   return new THREE.Vector3(dx * 2 / size, -dy * 2 / size, 0).unproject(camera).sub(zero)
     .applyAxisAngle(new THREE.Vector3(0, 1, 0), row * Math.PI / 4).toArray() as Point3
+}
+
+/** Handles nearest the viewer draw last, and every editable handle sits above the grey skeleton ones. */
+export function orderJoints<J extends string>(joints: Partial<Record<J, InspectedJoint>>): [J, InspectedJoint][] {
+  return (Object.entries(joints) as [J, InspectedJoint][]).sort(([, a], [, b]) =>
+    Number(a.editable) - Number(b.editable) || (b.depth ?? 0) - (a.depth ?? 0))
+}
+
+/** Sprite pixels of head start an editable handle gets over a grey skeleton node under the same pointer. */
+const EDITABLE_PREFERENCE = 1
+/** Reach for the nearest handle under the pointer; an editable one wins over a grey one that covers it. */
+export function pickJoint<J extends string>(joints: Partial<Record<J, InspectedJoint>>, x: number, y: number, radius: number): J | null {
+  let best: { joint: J; score: number } | null = null
+  for (const [name, joint] of Object.entries(joints) as [J, InspectedJoint][]) {
+    const distance = Math.hypot(joint.screen[0] - x, joint.screen[1] - y)
+    if (distance > radius) continue
+    const score = distance + (joint.editable ? 0 : EDITABLE_PREFERENCE) + (joint.depth ?? 0) * 1e-3
+    if (!best || score < best.score) best = { joint: name, score }
+  }
+  return best?.joint ?? null
+}
+
+/** The bone under the pointer, when no handle is: distance from the point to the segment between two shown joints. */
+export function pickBone<J extends string>(joints: Partial<Record<J, InspectedJoint>>, bones: readonly [J, J][], x: number, y: number, radius: number): [J, J] | null {
+  let best: { bone: [J, J]; distance: number } | null = null
+  for (const bone of bones) {
+    const a = joints[bone[0]], b = joints[bone[1]]
+    if (!a || !b) continue
+    const dx = b.screen[0] - a.screen[0], dy = b.screen[1] - a.screen[1], length = dx * dx + dy * dy
+    const t = length > 0 ? Math.max(0, Math.min(1, ((x - a.screen[0]) * dx + (y - a.screen[1]) * dy) / length)) : 0
+    const distance = Math.hypot(a.screen[0] + t * dx - x, a.screen[1] + t * dy - y)
+    if (distance <= radius && (!best || distance < best.distance)) best = { bone, distance }
+  }
+  return best?.bone ?? null
 }

--- a/lib/game/base-person/rig-joints.ts
+++ b/lib/game/base-person/rig-joints.ts
@@ -16,3 +16,8 @@ export const RIG_BONES: [RigJoint, RigJoint][] = [
   ["pelvis", "leftHip"], ["leftHip", "leftKnee"], ["leftKnee", "leftFoot"],
   ["pelvis", "rightHip"], ["rightHip", "rightKnee"], ["rightKnee", "rightFoot"], ["staffTip", "staffTop"],
 ]
+/** Bones whose first joint already carries the second through the hierarchy: a bone drag moves only that joint. */
+export const RIG_CARRIED_BONES: [RigJoint, RigJoint][] = [
+  ["pelvis", "chest"], ["chest", "head"], ["chest", "leftShoulder"], ["chest", "rightShoulder"],
+  ["pelvis", "leftHip"], ["pelvis", "rightHip"], ["leftShoulder", "leftElbow"], ["rightShoulder", "rightElbow"],
+]

--- a/lib/game/base-person/rig.ts
+++ b/lib/game/base-person/rig.ts
@@ -3,8 +3,8 @@ import { preachingMotion } from "./preaching"
 import { buildingMotion, MALLET_HEAD_HEIGHT } from "./building"
 import * as THREE from "three"
 import { createWoodLogGeometry, WOOD_LOG } from "../wood-log"
-import { editedLeg } from "./edited-leg"
-import { poseOffset } from "./pose-edits"
+import { editedLeg, reachablePelvisShift } from "./edited-leg"
+import { poseOffset, type EditableJoint, type PoseEdits } from "./pose-edits"
 import type { RigJoints } from "./rig-joints"
 import { staffMotion } from "./staff-motion"
 import { createRoadAccessories } from "./road-accessories"
@@ -530,7 +530,7 @@ export function createBasePersonRig(recipe = personRecipe()) {
   // Solve both arm bones to a hand target in the upper body's coordinates.
   const reach = (limb: typeof limbs[number], target: Point3, palm = false, pole?: THREE.Vector3) => {
     const start = limb.shoulder.position.clone(), end = new THREE.Vector3(...target)
-    end.y -= chest.position.y
+    end.sub(chest.position)
     const axis = end.clone().sub(start)
     const lowerLength = b.forearmLength + (palm ? 0.04 * recipe.design.hands : 0)
     const distance = Math.max(Math.abs(b.upperArmLength - lowerLength) + 0.001, Math.min(axis.length(), b.upperArmLength + lowerLength - 0.001))
@@ -567,6 +567,8 @@ export function createBasePersonRig(recipe = personRecipe()) {
     joints(): RigJoints {
       root.updateMatrixWorld(true)
       const point = (object: THREE.Object3D, local = new THREE.Vector3()) => root.worldToLocal(object.localToWorld(local)).toArray() as Point3
+      const segmentEnds = (object: THREE.Object3D): [Point3, Point3] => [point(object, new THREE.Vector3(0, -0.5, 0)), point(object, new THREE.Vector3(0, 0.5, 0))]
+      const span = (a: Point3, b: Point3) => Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2])
       const result: RigJoints = { pelvis: point(body), head: point(head) }
       const shoulders = limbs.map(limb => point(limb.shoulder))
       result.chest = shoulders[0].map((v, i) => (v + shoulders[1][i]) / 2) as Point3
@@ -575,9 +577,14 @@ export function createBasePersonRig(recipe = personRecipe()) {
         result[`${side}Shoulder`] = point(limb.shoulder)
         result[`${side}Elbow`] = point(limb.elbow)
         result[`${side}Hand`] = point(side === "left" ? sockets.leftHand : sockets.rightHand)
-        result[`${side}Hip`] = point(limb.thigh, new THREE.Vector3(0, 0.5, 0))
-        result[`${side}Knee`] = point(limb.thigh, new THREE.Vector3(0, -0.5, 0))
-        result[`${side}Foot`] = point(limb.shin, new THREE.Vector3(0, -0.5, 0))
+        // Leg segments are unit cylinders stretched between two joints. Seated and mounted poses aim them the
+        // opposite way from bone(), so read the ends geometrically: the hip is the thigh end nearest the pelvis,
+        // the knee the other end, and the ankle the shin end away from the knee.
+        const thighEnds = segmentEnds(limb.thigh), shinEnds = segmentEnds(limb.shin)
+        const hipEnd = Number(span(thighEnds[1], result.pelvis!) < span(thighEnds[0], result.pelvis!))
+        result[`${side}Hip`] = thighEnds[hipEnd]
+        result[`${side}Knee`] = thighEnds[1 - hipEnd]
+        result[`${side}Foot`] = shinEnds[Number(span(shinEnds[1], result[`${side}Knee`]!) > span(shinEnds[0], result[`${side}Knee`]!))]
       }
       const staff = root.getObjectByName("walking-staff")
       if (staff?.visible && staff.children[0]) {
@@ -620,7 +627,7 @@ export function createBasePersonRig(recipe = personRecipe()) {
 
       })
     },
-    pose(phase: number, clip: BaseClip = "walk") {
+    pose(phase: number, clip: BaseClip = "walk", edits: PoseEdits | undefined = recipe.design.poseEdits) {
       for (const part of headPivot.children) {
         if (part.name.startsWith("head-covering")) part.visible = !uncoverHead(recipe.design.bodyType, clip)
       }
@@ -650,9 +657,19 @@ export function createBasePersonRig(recipe = personRecipe()) {
       const shaftGrip = splitting ? THREE.MathUtils.clamp(axeHeadHeight - (heldGrip.y - (0.10 * chopping.axeScale + 0.035)) / chopping.axeScale, 0, 0.50) * split.parked : 0
       poseRoot.rotation.set(sleep ? -Math.PI / 2 : 0, sleep && female ? Math.PI / 2 : 0, 0)
       poseRoot.position.set(0, sleep ? female ? b.shoulderOffset + 0.06 : b.torsoTop * 0.78 : 0, sleep ? (b.headCenter + b.headHeight) / 2 + 0.03 : 0)
-      body.position.y = b.hipHeight + drop
+      body.position.set(0, b.hipHeight + drop, 0)
       body.rotation.x = gather ? 0.18 + gathering.reach * 0.3 : felling ? 0.10 : splitting ? split.lean : praying ? 0.12 + wave * 0.025 : sleep ? wave * 0.008 : chair ? 0.015 : seated ? 0.008 * wave : 0
       body.rotation.y = felling ? swing.twist : splitting ? split.twist : motion.hipYaw
+      // Authored offsets for the skeleton's own joints: the pelvis carries everything, the chest carries head and arms.
+      const rootOffset = (joint: EditableJoint) => new THREE.Vector3(...poseOffset(edits, clip, joint, phase))
+      const pelvisOffset = new THREE.Vector3(...reachablePelvisShift(phase, clip, b, rootOffset("pelvis").toArray() as Point3, poseRoot.quaternion.clone().invert()))
+      body.position.add(pelvisOffset.clone().applyQuaternion(poseRoot.quaternion.clone().invert()))
+      chest.position.set(0, waist - b.hipHeight, 0)
+      const chestOffset = rootOffset("chest")
+      if (chestOffset.lengthSq() > 0) {
+        root.updateMatrixWorld(true)
+        chest.position.add(body.worldToLocal(root.localToWorld(chestOffset)).sub(body.worldToLocal(root.localToWorld(new THREE.Vector3()))))
+      }
       if (chair) headPivot.rotation.x = .16 + wave * .004
       if (splitting) headPivot.rotation.x = -body.rotation.x * 0.65
       headPivot.rotation.y = felling ? -swing.twist * 0.55 : splitting ? -split.twist * 0.6 : -motion.chestYaw
@@ -723,12 +740,17 @@ export function createBasePersonRig(recipe = personRecipe()) {
         geometry.computeVertexNormals()
       }
       for (const limb of limbs) {
-        const leg = editedLeg(limb.side, phase, clip, b, recipe.design.poseEdits, poseRoot.quaternion.clone().invert())
+        const leg = editedLeg(limb.side, phase, clip, b, edits, poseRoot.quaternion.clone().invert(), pelvisOffset.toArray() as Point3)
         bone(limb.thigh, leg.hip, leg.knee)
         bone(limb.shin, leg.knee, leg.ankle)
         limb.foot.position.set(leg.ankle[0], leg.ankle[1] - b.ankleHeight + b.footHeight / 2, leg.ankle[2] + b.footLength * 0.22)
         limb.foot.rotation.y = chop ? (limb.side === "left" ? 1 : -1) * 0.22 : 0
-        limb.shoulder.position.y = b.shoulderHeight - waist - (limb.rear ? 0.045 : 0)
+        limb.shoulder.position.set((limb.side === "left" ? 1 : -1) * b.shoulderOffset, b.shoulderHeight - waist - (limb.rear ? 0.045 : 0), 0)
+        const shoulderOffset = rootOffset(limb.side === "left" ? "leftShoulder" : "rightShoulder")
+        if (shoulderOffset.lengthSq() > 0) {
+          root.updateMatrixWorld(true)
+          limb.shoulder.position.add(chest.worldToLocal(root.localToWorld(shoulderOffset)).sub(chest.worldToLocal(root.localToWorld(new THREE.Vector3()))))
+        }
         const seamStart = limb.seamStart.clone()
         seamStart.y -= waist
         const seamVector = limb.shoulder.position.clone().sub(seamStart)
@@ -747,10 +769,10 @@ export function createBasePersonRig(recipe = personRecipe()) {
         limb.hand.scale.set(chop ? 0.065 : 0.043, chop ? 0.055 : 0.06, chop ? 0.060 : 0.04).multiplyScalar(recipe.design.hands)
         limb.hand.quaternion.identity()
         if (recipe.design.walkingStick && (clip === "walk" || clip === "idle") && limb.side === "right") {
-          const { grip } = staffMotion(phase, b, clip === "walk", recipe.design.poseEdits)
+          const { grip } = staffMotion(phase, b, clip === "walk", edits)
           root.updateMatrixWorld(true)
           const target = chest.worldToLocal(root.localToWorld(new THREE.Vector3(...grip)))
-          target.y += chest.position.y
+          target.add(chest.position)
           reach(limb, target.toArray() as Point3, true)
           root.updateMatrixWorld(true)
 
@@ -801,15 +823,15 @@ export function createBasePersonRig(recipe = personRecipe()) {
         else if (seated) reach(limb, [sign * 0.21, 0.02, 0.30])
         else if (sleep) reach(limb, bundled ? [-sign * 0.035, 0.08, 0.23 + sign * 0.02] :
           female ? [sign * 0.055, 0.42, 0.25] : [sign * 0.09, 0.22, 0.24])
-        const handOffset = poseOffset(recipe.design.poseEdits, clip, limb.side === "left" ? "leftHand" : "rightHand", phase)
-        const elbowOffset = poseOffset(recipe.design.poseEdits, clip, limb.side === "left" ? "leftElbow" : "rightElbow", phase)
+        const handOffset = poseOffset(edits, clip, limb.side === "left" ? "leftHand" : "rightHand", phase)
+        const elbowOffset = poseOffset(edits, clip, limb.side === "left" ? "leftElbow" : "rightElbow", phase)
         if ([...handOffset, ...elbowOffset].some(v => v !== 0)) {
           root.updateMatrixWorld(true)
           const handSocket = limb.side === "left" ? sockets.leftHand : sockets.rightHand
           const hand = root.worldToLocal(handSocket.getWorldPosition(new THREE.Vector3())).add(new THREE.Vector3(...handOffset))
           const elbow = root.worldToLocal(limb.elbow.getWorldPosition(new THREE.Vector3())).add(new THREE.Vector3(...elbowOffset))
           const target = chest.worldToLocal(root.localToWorld(hand))
-          target.y += chest.position.y
+          target.add(chest.position)
           const pole = chest.worldToLocal(root.localToWorld(elbow))
           reach(limb, target.toArray() as Point3, true, pole)
         }
@@ -824,12 +846,12 @@ export function createBasePersonRig(recipe = personRecipe()) {
         }
       }
       root.updateMatrixWorld(true)
-      const headOffset = new THREE.Vector3(...poseOffset(recipe.design.poseEdits, clip, "head", phase))
+      const headOffset = new THREE.Vector3(...poseOffset(edits, clip, "head", phase))
       const parent = headPivot.parent!
       const zero = parent.worldToLocal(root.localToWorld(new THREE.Vector3()))
       headPivot.position.add(parent.worldToLocal(root.localToWorld(headOffset)).sub(zero))
       root.updateMatrixWorld(true)
-      roadAccessories.pose(clip, phase)
+      roadAccessories.pose(clip, phase, edits)
       if (building) {
         const desired = root.getWorldQuaternion(new THREE.Quaternion()).multiply(
           new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(1, 0, 0), hammer.pitch))

--- a/lib/game/base-person/road-accessories.ts
+++ b/lib/game/base-person/road-accessories.ts
@@ -3,6 +3,7 @@ import { uncoverHead } from "./head-covering"
 import type { PersonRecipe } from "./design"
 import type { BaseClip, SocketName } from "./pose"
 import { staffDimensions, staffMotion } from "./staff-motion"
+import type { PoseEdits } from "./pose-edits"
 
 /** Socket-mounted equipment is baked with the person for all eight views. */
 export function createRoadAccessories(recipe: PersonRecipe, sockets: Record<SocketName, THREE.Object3D>, root: THREE.Object3D) {
@@ -91,14 +92,14 @@ export function createRoadAccessories(recipe: PersonRecipe, sockets: Record<Sock
     staff.children.forEach(part => { part.userData.inkPart = 11 })
   }
   return {
-    pose(clip: BaseClip, phase: number) {
+    pose(clip: BaseClip, phase: number, edits: PoseEdits | undefined = design.poseEdits) {
       const road = clip === "walk" || clip === "idle"
       hat.visible = clip !== "sleeping" && !uncoverHead(design.bodyType, clip)
       satchel.visible = road && design.satchel
       lute.visible = road && design.lute
       staff.visible = road && design.walkingStick
       if (staff.visible) {
-        const { tip, planted } = staffMotion(phase, b, clip === "walk", design.poseEdits)
+        const { tip, planted } = staffMotion(phase, b, clip === "walk", edits)
         const grip = root.worldToLocal(sockets.rightHand.getWorldPosition(new THREE.Vector3()))
         const axis = grip.clone().sub(new THREE.Vector3(...tip))
         const gripDistance = axis.length()

--- a/lib/game/wildlife/rig-edits.test.ts
+++ b/lib/game/wildlife/rig-edits.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { animalOffset, animalPoseKey, EMPTY_ANIMAL_EDITS, validateAnimalEdits } from "./rig-edits"
+import { animalClearFrame, animalOffset, animalPoseKey, EMPTY_ANIMAL_EDITS, validateAnimalEdits } from "./rig-edits"
 import { gaitRecipe, gaitSpeed, gaitStride } from "./gait"
 import { createWildlifeRig } from "./rig"
 import { createAnimalRig } from "../transport/animal-rig"
@@ -13,6 +13,17 @@ describe("editable animal rigs", () => {
     expect(animalOffset(edits, "hop", "head", 1)).toEqual([0.1, 0.1, 0])
     expect(animalOffset(edits, "hop", "head", 0.5)).toEqual([0, 0, 0])
     expect(gaitSpeed("rabbit", "hop", 1.5, edits)).toBeCloseTo(gaitStride("rabbit", "hop", 1.5) * gaitRecipe("rabbit", "hop").cadence * 1.5)
+  })
+  it("returns one frame to the generated pose for every joint", () => {
+    let edits = animalPoseKey(EMPTY_ANIMAL_EDITS, "walk", "head", { frame: 3, radius: 2, offset: [0.1, 0, 0] }, 3)
+    edits = animalPoseKey(edits, "walk", "tail", { frame: 3, radius: 2, offset: [0, 0.1, 0] }, 3)
+    edits = animalPoseKey(edits, "walk", "tail", { frame: 8, radius: 2, offset: [0, 0.2, 0] }, 8)
+    edits = animalPoseKey(edits, "hop", "head", { frame: 3, radius: 2, offset: [0.3, 0, 0] }, 3)
+    const cleared = animalClearFrame(edits, "walk", 3)
+    expect(cleared.clips.walk?.keys?.head).toEqual([])
+    expect(cleared.clips.walk?.keys?.tail).toEqual([{ frame: 8, radius: 2, offset: [0, 0.2, 0] }])
+    expect(cleared.clips.hop).toEqual(edits.clips.hop)
+    expect(animalOffset(cleared, "walk", "head", 3 / 20)).toEqual([0, 0, 0])
   })
   it("rejects corrupt and out-of-range imports", () => {
     for (const value of [null, {}, { version: 1, clips: { walk: { cadence: NaN } } }, { version: 1, clips: { walk: { contacts: [0, 0, 0, 0.9] } } }, { version: 1, clips: { fly: { keys: { leftWing: [{ frame: 21, offset: [0, 0, 0], radius: 2 }] } } } }]) expect(() => validateAnimalEdits(value)).toThrow()

--- a/lib/game/wildlife/rig-edits.ts
+++ b/lib/game/wildlife/rig-edits.ts
@@ -32,6 +32,11 @@ export function animalPoseKey(edits: AnimalRigEdits, clip: AnimalClip, joint: An
   const keys = setPoseKey({ walk: { head: edits.clips[clip]?.keys?.[joint] ?? [] } }, "walk", "head", key, frame).walk!.head!
   return { version: 1, clips: { ...edits.clips, [clip]: { ...edits.clips[clip], keys: { ...edits.clips[clip]?.keys, [joint]: keys } } } }
 }
+export function animalClearFrame(edits: AnimalRigEdits, clip: AnimalClip, frame: number): AnimalRigEdits {
+  let result = edits
+  for (const joint of Object.keys(edits.clips[clip]?.keys ?? {}) as AnimalJoint[]) result = animalPoseKey(result, clip, joint, null, frame)
+  return result
+}
 export function validateAnimalEdits(input: unknown): AnimalRigEdits {
   if (!input || typeof input !== "object" || (input as AnimalRigEdits).version !== 1) throw new Error("Use an animal rig settings file (version 1).")
   const source = (input as AnimalRigEdits).clips


### PR DESCRIPTION
The rig editor rebaked every sprite sheet on each pose change with no indication, drew leg handles on the wrong joints, and lagged behind the pointer. Sheets now bake one row per task with a progress badge, each clip's sheet is cached against its own pose keys, and drags coalesce per frame through a shared render session, taking a pointer move from 74–110 ms to about 20 ms and sheet readiness after release from 7–11 s to about 1 s. The joint helper now reads bone ends geometrically (it previously reported the hip at the knee and the foot at the knee), and handles pick the nearest joint or bone under the pointer. Pelvis, chest, shoulders and hips accept pose offsets with planted feet kept within reach, and dragging a bone moves both of its joints. The inspector gains Reset key and Reset frame for people and animals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)