### PR TITLE
Add a World panel toggle to swap the forest to pixel foliage sprites

### DIFF
--- a/app/play/page.tsx
+++ b/app/play/page.tsx
@@ -2,6 +2,7 @@ import { DEFAULT_ELEVATION, ELEVATION_CONTROLS, elevationSettings, type Elevatio
 import type { Metadata } from "next"
 
 import { GameShell, type MapSettings } from "@/components/game/game-shell"
+import { isTreeModel } from "@/lib/game/trees/render-model"
 
 export const metadata: Metadata = {
   title: "Pilgrimage — Prototype",
@@ -31,6 +32,7 @@ export default async function PlayPage({
   if (params.characters === "base" || params.characters === "callings") {
     initialSettings.characterModel = params.characters
   }
+  if (isTreeModel(params.trees)) initialSettings.treeModel = params.trees
   for (const key of ["baseSize", "draftSize"] as const) {
     const scale = parseFloatParam(params[key])
     if (scale !== undefined) initialSettings[key] = Math.min(4, Math.max(0.5, scale))

--- a/components/game/foliage-field.tsx
+++ b/components/game/foliage-field.tsx
@@ -11,13 +11,20 @@ import type { TreePlacement } from "@/lib/game/trees/placement"
 import { configureSpriteDepthTexture } from "@/lib/game/render/sprite-depth"
 import { encodeObjectId, OUTLINE_ID_LAYER_MASK, treeObjectId } from "@/lib/game/render/outline"
 import { makeRng } from "@/lib/game/rng"
+import { useBuildStore } from "@/lib/game/build-store"
 
 export interface FoliagePlacement extends TreePlacement { foliageVariant?: number }
 
-/** Prototype forest: two draws for any tree count, sharing one color/depth atlas. */
-export function FoliageField({ atlas, placements, seed = 1, onSelect }: {
-  atlas: FoliageAtlas; placements: FoliagePlacement[]; seed?: number
-  onSelect?: (index: number) => void
+/**
+ * Baked pixel foliage: two draws for any tree count, sharing one color/depth
+ * atlas. The game and the tree playground both draw through here; `idBase` is
+ * how many outline IDs the buildings already took, and `hidden` lists felled
+ * trees whose remains are drawn separately.
+ */
+export function FoliageField({ atlas, placements, seed = 1, idBase = 0, hidden, onSelect }: {
+  atlas: FoliageAtlas; placements: FoliagePlacement[]; seed?: number; idBase?: number
+  hidden?: ReadonlySet<number>
+  onSelect?: (index: number, event: { delta: number; stopPropagation: () => void }) => void
 }) {
   const sources = useLoader(THREE.TextureLoader, [atlas.color, atlas.depth])
   const color = useMemo(() => {
@@ -29,12 +36,15 @@ export function FoliageField({ atlas, placements, seed = 1, onSelect }: {
   const depth = useMemo(() => configureSpriteDepthTexture(sources[1].clone()), [sources])
   const worldTexel = usePixelWorldTexel(), view = useMemo(() => ({ value: 0 }), [])
   const materials = useMemo(() => [false, true].map(ids => foliageMaterial(color, depth, view, worldTexel, ids)), [color, depth, view, worldTexel])
-  const entries = useMemo(() => placements.flatMap((tree, index) => isFoliageSpecies(tree.species) ? [{ tree, index }] : []), [placements])
+  const entries = useMemo(() => placements.flatMap((tree, index) =>
+    isFoliageSpecies(tree.species) && !hidden?.has(index) ? [{ tree, index }] : []), [placements, hidden])
   const data = useMemo(() => {
+    // Frames draw from the placement order, so felling a tree never reshuffles its neighbours.
     const rng = makeRng(seed), frames: number[] = [], ids: number[] = [], matrices: THREE.Matrix4[] = []
+    const rolls = placements.map(() => [Math.floor(rng() * FOLIAGE_FRAME.directions), Math.floor(rng() * FOLIAGE_FRAME.variants)])
     entries.forEach(({ tree, index }) => {
-      frames.push(Math.floor(rng() * FOLIAGE_FRAME.directions), FOLIAGE_SPECIES.indexOf(tree.species as typeof FOLIAGE_SPECIES[number]) * FOLIAGE_FRAME.variants + (tree.foliageVariant ?? Math.floor(rng() * FOLIAGE_FRAME.variants)))
-      ids.push(...encodeObjectId(treeObjectId(0, index)))
+      frames.push(rolls[index][0], FOLIAGE_SPECIES.indexOf(tree.species as typeof FOLIAGE_SPECIES[number]) * FOLIAGE_FRAME.variants + (tree.foliageVariant ?? rolls[index][1]))
+      ids.push(...encodeObjectId(treeObjectId(idBase, index)))
       // Variation is baked at native density; don't stretch individual texels.
       matrices.push(new THREE.Matrix4().makeTranslation(tree.x, tree.y, tree.z))
     })
@@ -43,7 +53,7 @@ export function FoliageField({ atlas, placements, seed = 1, onSelect }: {
     geometry.setAttribute("foliageFrame", new THREE.InstancedBufferAttribute(new Float32Array(frames), 2))
     geometry.setAttribute("foliageId", new THREE.InstancedBufferAttribute(new Float32Array(ids), 3))
     return { geometry, matrices }
-  }, [entries, seed])
+  }, [placements, entries, seed, idBase])
   const body = useRef<THREE.InstancedMesh>(null), idMesh = useRef<THREE.InstancedMesh>(null)
   const camera = useRef<THREE.Camera>(undefined)
   const raycast = useMemo(() => foliageRaycast(data.geometry, color, depth, view, () => camera.current), [data, color, depth, view])
@@ -72,7 +82,10 @@ export function FoliageField({ atlas, placements, seed = 1, onSelect }: {
   if (!entries.length) return null
   return <group name="foliage-prototype">
     <instancedMesh key={`body-${entries.length}`} ref={body} args={[data.geometry, materials[0], entries.length]} frustumCulled={false} raycast={raycast}
-      onClick={event => { if (event.delta <= 6 && event.instanceId !== undefined) { event.stopPropagation(); onSelect?.(entries[event.instanceId].index) } }} />
+      onClick={event => {
+        if (!onSelect || event.delta > 6 || event.instanceId === undefined || useBuildStore.getState().tool) return
+        event.stopPropagation(); onSelect(entries[event.instanceId].index, event)
+      }} />
     <instancedMesh key={`ids-${entries.length}`} ref={idMesh} args={[data.geometry, materials[1], entries.length]} frustumCulled={false} layers-mask={OUTLINE_ID_LAYER_MASK} />
   </group>
 }

--- a/components/game/game-canvas.tsx
+++ b/components/game/game-canvas.tsx
@@ -18,6 +18,8 @@ import type { TilePos } from "@/lib/game/map/types"
 import { deriveSeed, SEED_STREAM } from "@/lib/game/rng"
 import { growTreePlacements } from "@/lib/game/trees/dimensions"
 import { placeTrees } from "@/lib/game/trees/placement"
+import { foliageSpacing } from "@/lib/game/trees/foliage/spacing"
+import { DEFAULT_TREE_MODEL, type TreeModel } from "@/lib/game/trees/render-model"
 import { useTreeTuningStore } from "@/lib/game/trees/tree-tuning-store"
 import type { GameMap } from "@/lib/game/map/types"
 import type { Monk } from "@/lib/game/monks"
@@ -58,6 +60,7 @@ export function GameCanvas({
   walkSpeed,
   characterModel = "callings",
   characterScale = 1,
+  treeModel = DEFAULT_TREE_MODEL,
   characterFps,
   walkTuning,
   movement = LINEAR_MOVEMENT,
@@ -88,6 +91,8 @@ export function GameCanvas({
   characterModel?: CharacterModel
   /** Uniform size multiplier; leaves the sprite's foot anchor fixed. */
   characterScale?: number
+  /** Parametric trees or the baked foliage sprites; sprites stand one to a tile. */
+  treeModel?: TreeModel
   /** Animation frames per second, independent of movement pace. */
   characterFps?: number
   walkTuning?: WalkTuning
@@ -116,8 +121,8 @@ export function GameCanvas({
   useEffect(() => { void usePopulationStore.getState().prepare(foundation) }, [foundation])
   const species = useTreeTuningStore((s) => s.species)
   const variance = useTreeTuningStore((s) => s.variance)
-  const trees = useMemo(() => growTreePlacements(placeTrees(map, species),
-    deriveSeed(map.seed ?? 0, SEED_STREAM.treeShapes), species, variance), [map.tiles, species, variance])
+  const trees = useMemo(() => growTreePlacements(placeTrees(map, treeModel === "sprites" ? foliageSpacing(species) : species),
+    deriveSeed(map.seed ?? 0, SEED_STREAM.treeShapes), species, variance), [map.tiles, species, variance, treeModel])
   return (
     <PixelCanvas
       {...pixelation}
@@ -150,7 +155,7 @@ export function GameCanvas({
           showGrid={showGrid}
         />
         <Bridges map={map} roadTier={roadTier} />
-        <Trees map={map} placements={trees} ents={lastMarch} characterScale={characterScale} />
+        <Trees map={map} placements={trees} ents={lastMarch} characterScale={characterScale} model={treeModel} />
         <Environment map={map} />
         <Wildlife map={map} trees={trees} characterScale={characterScale} />
         <Buildings map={map} characterScale={characterScale} />

--- a/components/game/game-hud.tsx
+++ b/components/game/game-hud.tsx
@@ -787,6 +787,15 @@ export function GameHud({
           <HudButton id="bug-report-button" onClick={openBugReport}>Report a bug</HudButton>
         </div>
         {reportError && <p role="alert" className="mb-4 text-sm text-red">{reportError}</p>}
+        <div className="mb-4">
+          <Chooser
+            label="Trees"
+            value={settings.treeModel === "sprites" ? 1 : 0}
+            options={["Procedural", "Pixel foliage"]}
+            onChange={(index) => set({ treeModel: index === 1 ? "sprites" : "procedural" })}
+          />
+          <p className="pt-1 text-[11px] italic text-ink-light">Pixel foliage draws the baked tree sprites from the playground; trees stand one to a tile.</p>
+        </div>
         {SHOW_PROPERTY_PANELS && <>
         <Section {...section("Seed")}>
           <SeedField seed={seed} onSeedChange={onSeedChange} />

--- a/components/game/game-shell.tsx
+++ b/components/game/game-shell.tsx
@@ -12,6 +12,7 @@ import { BASE_CHARACTER_SCALE, DEFAULT_WALK_SPEED, DEFAULT_WALK_STRIDE } from "@
 import { BASE_PERSON } from "@/lib/game/base-person/pose"
 import { DEFAULT_MOVEMENT } from "@/lib/game/motion"
 import type { CharacterModel } from "@/lib/game/character-assets"
+import { DEFAULT_TREE_MODEL, type TreeModel } from "@/lib/game/trees/render-model"
 import { DEFAULT_ROAD_LOOK, DEFAULT_ROAD_TIER, ROAD_TIERS } from "@/lib/game/map/road"
 import { loadSavedSeed } from "@/lib/game/seed-storage"
 import { generateMonks } from "@/lib/game/monks"
@@ -77,6 +78,8 @@ export interface MapSettings {
   pathEase: number
   acceleration: number
   characterModel: CharacterModel
+  /** Parametric trees, or the baked pixel foliage sprites from the tree playground. */
+  treeModel: TreeModel
   /** Uniform sprite-size multipliers, independently tuned for each model. */
   baseSize: number
   draftSize: number
@@ -118,6 +121,7 @@ export const DEFAULT_SETTINGS: MapSettings = {
   pathEase: DEFAULT_MOVEMENT.pathEase,
   acceleration: DEFAULT_MOVEMENT.acceleration,
   characterModel: "base",
+  treeModel: DEFAULT_TREE_MODEL,
   baseSize: BASE_CHARACTER_SCALE,
   draftSize: 1,
   road: DEFAULT_ROAD_TIER,
@@ -191,6 +195,7 @@ export function GameShell({
       easing: String(settings.pathEase),
       acceleration: String(settings.acceleration),
       characters: settings.characterModel,
+      trees: settings.treeModel,
       baseSize: String(settings.baseSize),
       draftSize: String(settings.draftSize),
       road: String(settings.road),
@@ -322,6 +327,7 @@ export function GameShell({
           movement={movement}
           walkTuning={walkTuning}
           characterModel={settings.characterModel}
+          treeModel={settings.treeModel}
           characterScale={settings.characterModel === "base" ? settings.baseSize : settings.draftSize}
           roadTier={settings.road}
           relicTraffic={relicTraffic}

--- a/components/game/trees.tsx
+++ b/components/game/trees.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useLayoutEffect, useMemo, useRef } from "react"
+import { Suspense, useEffect, useLayoutEffect, useMemo, useRef } from "react"
 import { useSimulationStore } from "@/lib/game/simulation-store"
 import { BASE_CHARACTER_SCALE } from "@/lib/game/base-person/gait"
 import { useFrame } from "@react-three/fiber"
@@ -10,6 +10,9 @@ import { softenTreeLighting } from "@/lib/game/trees/lighting"
 import { useCameraStore } from "@/lib/game/camera-store"
 import { selectElement } from "@/lib/game/selection"
 import { TreeRemains } from "./tree-remains"
+import { FoliageField } from "./foliage-field"
+import { DEFAULT_FOLIAGE_ATLAS } from "@/lib/game/trees/foliage/assets"
+import { DEFAULT_TREE_MODEL, type TreeModel } from "@/lib/game/trees/render-model"
 import { useBuildStore } from "@/lib/game/build-store"
 import { simRegistry } from "@/lib/game/sim"
 import { deriveSeed, makeRng, SEED_STREAM } from "@/lib/game/rng"
@@ -73,8 +76,10 @@ function makeCrownGeometry(shape: TreeSpeciesDef["crown"]["shape"]): THREE.Buffe
     : new THREE.IcosahedronGeometry(1, BLOB_DETAIL)
 }
 
-export function Trees({ map, placements: supplied, ents = false, characterScale = BASE_CHARACTER_SCALE }: {
+export function Trees({ map, placements: supplied, ents = false, characterScale = BASE_CHARACTER_SCALE, model = DEFAULT_TREE_MODEL }: {
   map: GameMap; placements?: TreePlacement[]; ents?: boolean; characterScale?: number
+  /** Sprites draw the baked pixel foliage in place of the parametric trees; Ents stay rooted. */
+  model?: TreeModel
 }) {
   const selection = useCameraStore((s) => s.selection)
   const resources = useBuildStore((s) => s.treeResources)
@@ -90,10 +95,14 @@ export function Trees({ map, placements: supplied, ents = false, characterScale 
     if (selection?.kind === "tree" && (!selected || !visible)) useCameraStore.getState().select(null)
   }, [selection, selected, visible])
   const selectTree = (id: number, event: { delta: number; stopPropagation: () => void }) => selectElement({ kind: "tree", id }, event)
+  const seed = deriveSeed(map.seed ?? 0, SEED_STREAM.treeShapes)
   return (
     <group>
-      <TreeField placements={placements} hidden={felled} onSelect={selectTree} entMap={ents ? map : undefined}
-        seed={deriveSeed(map.seed ?? 0, SEED_STREAM.treeShapes)} idBase={map.buildings.length} />
+      {model === "sprites"
+        ? <Suspense fallback={null}>
+            <FoliageField atlas={DEFAULT_FOLIAGE_ATLAS} placements={placements} hidden={felled} onSelect={selectTree} seed={seed} idBase={map.buildings.length} />
+          </Suspense>
+        : <TreeField placements={placements} hidden={felled} onSelect={selectTree} entMap={ents ? map : undefined} seed={seed} idBase={map.buildings.length} />}
       {Array.from(resources, ([id, resource]) => resource.health <= 0 && placements[id]
         ? <TreeRemains key={id} id={id} objectId={treeObjectId(map.buildings.length, id)} tree={placements[id]} resource={resource} time={time} characterScale={characterScale} /> : null)}
     </group>

--- a/components/tree-lab/tree-lineup.tsx
+++ b/components/tree-lab/tree-lineup.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense, useMemo } from "react"
 
-import { FoliageField, type FoliagePlacement } from "./foliage-field"
+import { FoliageField, type FoliagePlacement } from "@/components/game/foliage-field"
 import { FOLIAGE_SPECIES, isFoliageSpecies, type FoliageAtlas } from "@/lib/game/trees/foliage/design"
 import { PixelCharacters } from "@/components/pixel-canvas"
 import { CharacterSprite } from "@/components/game/character-sprite"

--- a/components/tree-lab/tree-map-preview.tsx
+++ b/components/tree-lab/tree-map-preview.tsx
@@ -10,8 +10,9 @@ import { CameraRig } from "@/components/game/camera-rig"
 import { Environment } from "@/components/game/environment"
 import { OutlinePass } from "@/components/game/outline-pass"
 import { TerrainTiles } from "@/components/game/terrain-tiles"
-import { FoliageField } from "./foliage-field"
+import { FoliageField } from "@/components/game/foliage-field"
 import type { FoliageAtlas } from "@/lib/game/trees/foliage/design"
+import { foliageSpacing } from "@/lib/game/trees/foliage/spacing"
 import { TREE_SPECIES } from "@/lib/game/trees/species"
 import { placeTrees } from "@/lib/game/trees/placement"
 import { Trees } from "@/components/game/trees"
@@ -30,10 +31,7 @@ export function TreeMapPreview({ seed, size, atlas, ...pixelation }: { seed: num
   const map = useMemo(() => generateMap({ seed, width: size, depth: size }), [seed, size])
 
   const prototype = !!atlas
-  const placements = useMemo(() => placeTrees(map, prototype ? Object.fromEntries(Object.entries(TREE_SPECIES).map(([id, def]) => [id, {
-    ...def, habitat: { ...def.habitat, weight: def.habitat.weight,
-      footprint: id === "oak" || id === "beech" ? 0.85 : id === "hawthorn" || id === "holly" ? 0.45 : 0.6, perTile: 1 },
-  }])) as typeof TREE_SPECIES : TREE_SPECIES), [map, prototype])
+  const placements = useMemo(() => placeTrees(map, prototype ? foliageSpacing(TREE_SPECIES) : TREE_SPECIES), [map, prototype])
   useEffect(() => {
     if (!prototype) return
     const { outlineMode, selection } = useCameraStore.getState()

--- a/lib/game/trees/foliage/spacing.test.ts
+++ b/lib/game/trees/foliage/spacing.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest"
+import { generateMap } from "../../map/generate-map"
+import { placeTrees } from "../placement"
+import { TREE_SPECIES, TREE_SPECIES_ORDER } from "../species"
+import { FOLIAGE_FOOTPRINT, foliageSpacing } from "./spacing"
+
+describe("foliage sprite spacing", () => {
+  it("gives every species one tree per tile with a crown-sized footprint, leaving the rest of the habitat alone", () => {
+    const spaced = foliageSpacing(TREE_SPECIES)
+    for (const id of TREE_SPECIES_ORDER) {
+      expect(spaced[id].habitat).toEqual({ ...TREE_SPECIES[id].habitat, footprint: FOLIAGE_FOOTPRINT[id], perTile: 1 })
+      expect(spaced[id].crown).toBe(TREE_SPECIES[id].crown)
+    }
+    expect(TREE_SPECIES.birch.habitat.perTile).toBeGreaterThan(1)
+  })
+
+  it("thins the stand so the unstretched sprites have room", () => {
+    const map = generateMap({ seed: 42, width: 64, depth: 64 })
+    const dense = placeTrees(map, TREE_SPECIES), sparse = placeTrees(map, foliageSpacing(TREE_SPECIES))
+    expect(sparse.length).toBeGreaterThan(0)
+    expect(sparse.length).toBeLessThan(dense.length)
+  })
+})

--- a/lib/game/trees/foliage/spacing.ts
+++ b/lib/game/trees/foliage/spacing.ts
@@ -1,0 +1,17 @@
+import type { TreeSpeciesDef, TreeSpeciesId } from "../species"
+
+/**
+ * Sprite crowns are baked at full size and never stretched, so a stand drawn
+ * with foliage sprites needs more room per trunk than the parametric trees:
+ * one tree of a species per tile, with footprints sized to the baked crowns.
+ * Big broadleaves hold the most ground; hawthorn and holly stand closest.
+ */
+export const FOLIAGE_FOOTPRINT: Record<TreeSpeciesId, number> = {
+  oak: 0.85, beech: 0.85, birch: 0.6, scotsPine: 0.6, hawthorn: 0.45, holly: 0.45,
+}
+
+export function foliageSpacing(species: Record<TreeSpeciesId, TreeSpeciesDef>): Record<TreeSpeciesId, TreeSpeciesDef> {
+  return Object.fromEntries(Object.entries(species).map(([id, def]) => [id, {
+    ...def, habitat: { ...def.habitat, footprint: FOLIAGE_FOOTPRINT[id as TreeSpeciesId], perTile: 1 },
+  }])) as Record<TreeSpeciesId, TreeSpeciesDef>
+}

--- a/lib/game/trees/render-model.ts
+++ b/lib/game/trees/render-model.ts
@@ -1,0 +1,11 @@
+/**
+ * How the forest is drawn. The parametric low-poly trees are the shipped
+ * default; the baked pixel foliage sprites are the prototype from the tree
+ * playground, switchable from the World panel so both can be judged in play.
+ */
+export const TREE_MODELS = ["procedural", "sprites"] as const
+export type TreeModel = typeof TREE_MODELS[number]
+export const DEFAULT_TREE_MODEL: TreeModel = "procedural"
+export function isTreeModel(value: unknown): value is TreeModel {
+  return (TREE_MODELS as readonly unknown[]).includes(value)
+}


### PR DESCRIPTION
The World settings panel gains a **Trees** chooser (Procedural / Pixel foliage) beside New Map and Report a bug, outside the tuning-sidebar gate so it is available without `NEXT_PUBLIC_PROPERTY_PANELS`, with the choice stored in `MapSettings` and mirrored to the `?trees=` URL parameter. In sprite mode the game draws the published foliage atlas through `FoliageField`, moved from `components/tree-lab` to `components/game` so the playground and the game share one renderer, now taking the buildings' outline ID base, hiding felled trees so their remains draw as before, and routing clicks through the existing tree inspector while ignoring clicks made with a build tool active. Sprite stands use the playground's one-per-tile spacing, extracted into `foliageSpacing` so the lab and the game agree on footprints, and Ents stay rooted in sprite mode. Validation: 1,102 tests pass (one hospitality test timed out only under parallel load and passes on its own) and `tsc --noEmit` is clean.