### PR TITLE
Mark the shrine's fork with a wayside signpost

### DIFF
--- a/components/game/game-canvas.tsx
+++ b/components/game/game-canvas.tsx
@@ -41,6 +41,7 @@ import { OutlinePass } from "./outline-pass"
 import { RenownSaturation } from "./renown-saturation"
 import { vendorSpeedScale } from "@/lib/game/transport/assets"
 import { Shrine } from "./shrine"
+import { Signpost } from "./signpost"
 import type { RoadLook } from "@/lib/game/map/road"
 import { WalkingTerrain } from "./walking-terrain"
 import { TileCursor } from "./tile-cursor"
@@ -160,6 +161,7 @@ export function GameCanvas({
         <Wildlife map={map} trees={trees} characterScale={characterScale} />
         <Buildings map={map} characterScale={characterScale} />
         <Shrine map={map} relic={relic} />
+        <Signpost map={map} />
         <PixelCharacters>
           <Monks map={map} monks={monks} relic={relic} flying={blasterPastor} characterScale={characterScale} />
         </PixelCharacters>

--- a/components/game/signpost.tsx
+++ b/components/game/signpost.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import { useMemo } from "react"
+import * as THREE from "three"
+
+import { StructureModel } from "@/components/building-lab/building-model"
+import { signpostParts } from "@/lib/game/building-art/structure"
+import { groundHeight } from "@/lib/game/map/elevation"
+import { signpostPlacement } from "@/lib/game/map/signpost"
+import type { GameMap } from "@/lib/game/map/types"
+import { encodeObjectId, SIGNPOST_OBJECT_ID } from "@/lib/game/render/outline"
+
+/**
+ * The wayside marker where the shrine's track forks from the road: a riven
+ * post in the crook of the junction, a pointed board turned onto the shrine's
+ * bearing, and a small cross above it. Placement is decided on the map (see
+ * lib/game/map/signpost.ts); this only stands the timber up.
+ */
+export function Signpost({ map }: { map: GameMap }) {
+  const placement = useMemo(() => signpostPlacement(map), [map])
+  const parts = useMemo(() => signpostParts(map.seed ?? 0), [map.seed])
+  const idColor = useMemo(() => new THREE.Color(...encodeObjectId(SIGNPOST_OBJECT_ID)), [])
+  if (!placement) return null
+  const baseY = groundHeight(map, placement.x + map.width / 2 - 0.5, placement.z + map.depth / 2 - 0.5)
+  return (
+    <group name="signpost" position={[placement.x, baseY, placement.z]} rotation={[0, placement.yaw, 0]}>
+      <StructureModel parts={parts} idColor={idColor} ink={false} />
+    </group>
+  )
+}

--- a/lib/game/building-art/early-geometry.ts
+++ b/lib/game/building-art/early-geometry.ts
@@ -15,7 +15,8 @@ export const RELIC_TABLE_TOP = 0.44
 
 export type SettlementBuildingType = "shelter" | "workshop" | "hall" | "garden" | "cross" | "lumberCamp" | "market" | "guard-post"
 type ConstructionRecipe = Omit<BuildingRecipe, "variant"> & {
-  variant: BuildingRecipe["variant"] | SettlementBuildingType
+  /** "signpost" is scenery the generator places, not anything the player builds. */
+  variant: BuildingRecipe["variant"] | SettlementBuildingType | "signpost"
   /** The shrine's raised nave retains its bespoke gabled construction. */
   roofForm?: "single-plane" | "gable"
 }
@@ -68,6 +69,39 @@ export function earlyBuildingParts(recipe: ConstructionRecipe): BuildingPart[] {
     const vertices: number[] = []
     for(let i=0;i<8;i++) { const a=ring[i],b=ring[(i+1)%8]; vertices.push(x,y+thickness,z,x+a[0],y+thickness,z+a[1],x+b[0],y+thickness,z+b[1], x+a[0],y,z+a[1],x+b[0],y,z+b[1],x+b[0],y+thickness,z+b[1], x+a[0],y,z+a[1],x+b[0],y+thickness,z+b[1],x+a[0],y+thickness,z+a[1]) }
     face(name,"base",vertices,color)
+  }
+  // A wayside marker, not a building: no floor slab and no tile-square footing.
+  // The board points along local +X; the map turns it onto the shrine's bearing.
+  if (variant === "signpost") {
+    const board = { back: -.055, tip: .4, nose: .12, low: h - .31, high: h - .12, half: .024 }
+    const packing = [[-.085,-.055,.11,.1],[.075,.05,.1,.085],[.015,-.09,.085,.08],[-.06,.075,.08,.075]]
+    packing.forEach(([x,z,sx,sz],i) => flag(`signpost-stone-${i}`,x,z,sx,sz,-.012,.035+random()*.018,palette.stone))
+    pole("signpost-post",[0,0,0],[0,h,0],.056)
+    // Riven board: a five-sided profile in X/Y extruded through its thickness,
+    // so the far end comes to a real point rather than a sawn-off plank end.
+    const profile = [[board.back,board.low],[board.tip-board.nose,board.low],[board.tip,(board.low+board.high)/2],[board.tip-board.nose,board.high],[board.back,board.high]]
+    const vertices: number[] = []
+    for (let i=1;i<profile.length-1;i++) {
+      const a=profile[0],b=profile[i],c=profile[i+1]
+      vertices.push(a[0],a[1],board.half,b[0],b[1],board.half,c[0],c[1],board.half,
+        a[0],a[1],-board.half,c[0],c[1],-board.half,b[0],b[1],-board.half)
+    }
+    for (let i=0;i<profile.length;i++) {
+      const a=profile[i],b=profile[(i+1)%profile.length]
+      vertices.push(a[0],a[1],-board.half,b[0],b[1],-board.half,b[0],b[1],board.half,
+        a[0],a[1],-board.half,b[0],b[1],board.half,a[0],a[1],board.half)
+    }
+    face("signpost-board","wall",vertices,palette.paleWood,true)
+    box("signpost-peg","wall",[0,(board.low+board.high)/2,board.half+.013],[.03,.03,.026],palette.darkWood,undefined,false)
+    // The cross says whose road this is; the board says which way along it. Its
+    // arms lie across the board, so whichever of the two the camera foreshortens
+    // the other stands broadside and the marker never reads as a bare stake.
+    const head = "#a58c66"
+    box("signpost-cross-upright","wall",[0,h+.11,0],[.052,.24,.06],head)
+    box("signpost-cross-arm","wall",[0,h+.155,0],[.052,.058,.26],head)
+    box("signpost-cross-peg","wall",[.031,h+.155,0],[.022,.03,.03],palette.darkWood,undefined,false)
+    for (const side of [-1,1]) pole(`signpost-grain-${side}`,[side*.014,.1,.044],[side*.011,h-.05,.038],.004,"wall",palette.darkWood)
+    return parts
   }
   // Bury slab thickness below the walking plane; inset the store platform for its ramp.
   box("floor","base",[0,(variant === "storehouse" ? floor : BUILDING_FLOOR_TOP)-.025,variant === "storehouse" ? (rampStart-d+.02)/2 : 0],[width-.04,.05,variant === "storehouse" ? rampStart+d-.02 : depth-.04],variant === "enclosure" ? "#686857" : "#817052",undefined,false)

--- a/lib/game/building-art/structure.ts
+++ b/lib/game/building-art/structure.ts
@@ -68,4 +68,15 @@ export function visibleStructureParts(parts: BuildingPart[], cutaway: boolean, c
   }) : parts
 }
 
+/** Head of the post, where the cross is stepped on above the pointing board. */
+export const SIGNPOST_HEIGHT = 0.78
+
+/** The wayside marker at the shrine's fork; its board points along local +X. */
+export function signpostParts(seed = 0): BuildingPart[] {
+  return earlyBuildingParts({
+    ...earlyBuildingRecipe("shepherd-hut"),
+    variant: "signpost", width: 1, depth: 1, wallHeight: SIGNPOST_HEIGHT, roofRise: 0, seed,
+  })
+}
+
 export { shrineStructureParts } from "./shrine-geometry"

--- a/lib/game/environment/placement.ts
+++ b/lib/game/environment/placement.ts
@@ -2,6 +2,7 @@ import { groundHeight } from "../map/elevation"
 import { bridgeLayout } from "../map/bridges"
 import { computeForestShade } from "../map/forest-field"
 import { type TerrainId } from "../map/terrain"
+import { signpostPlacement } from "../map/signpost"
 import { worldToTileX, worldToTileZ, type GameMap } from "../map/types"
 import { deriveSeed, makeRng, SEED_STREAM } from "../rng"
 import { ELEMENT_RADIUS, ENVIRONMENT_KINDS, type EnvironmentKind, type EnvironmentPlacement } from "./elements"
@@ -49,6 +50,9 @@ export function placeEnvironment(map: GameMap): EnvironmentPlacement[] {
     }
   }
   if (map.site) blocked.add(map.site.door.z * map.width + map.site.door.x)
+  // The signpost has the corner of its fork to itself; no boulder shares it.
+  const signpost = signpostPlacement(map)
+  if (signpost) blocked.add(signpost.tile.z * map.width + signpost.tile.x)
 
   const onLand = (px: number, pz: number, radius: number, kind: EnvironmentKind) => {
     const kindIndex = ENVIRONMENT_KINDS.indexOf(kind)

--- a/lib/game/map/signpost.test.ts
+++ b/lib/game/map/signpost.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest"
+
+import { generateMap, MIN_MAP_SIZE } from "./generate-map"
+import { signpostPlacement, SIGNPOST_CLEARANCE, SIGNPOST_INSET } from "./signpost"
+import { placeTrees } from "../trees/placement"
+import { TREE_SPECIES } from "../trees/species"
+import { tileAt, tileToWorldX, tileToWorldZ, type GameMap } from "./types"
+
+const SEEDS = Array.from({ length: 12 }, (_, i) => i * 7919 + 1)
+const mapFor = (seed: number) => generateMap({ width: MIN_MAP_SIZE, depth: MIN_MAP_SIZE, seed })
+
+/** The post's tile, plus the way its board is turned, on a real generated world. */
+describe("the shrine's wayside signpost", () => {
+  const maps = SEEDS.map(mapFor)
+
+  it("stands beside the branch on every generated world, never on the way itself", () => {
+    for (const map of maps) {
+      const post = signpostPlacement(map)
+      expect(post).not.toBeNull()
+      expect(tileAt(map, post!.tile.x, post!.tile.z)).not.toBe("water")
+      expect(map.site!.branch.some(p => p.x === post!.tile.x && p.z === post!.tile.z)).toBe(false)
+      expect(map.road!.some(p => p.x === post!.tile.x && p.z === post!.tile.z)).toBe(false)
+    }
+  })
+
+  it("stays within a couple of tiles of the fork it marks", () => {
+    for (const map of maps) {
+      const post = signpostPlacement(map)!
+      const junction = map.site!.branch[0]
+      expect(Math.abs(post.tile.x - junction.x) + Math.abs(post.tile.z - junction.z)).toBeLessThanOrEqual(4)
+    }
+  })
+
+  it("leaves the post standing room, however thick the woods around it", () => {
+    for (const map of maps) {
+      const post = signpostPlacement(map)!
+      for (const tree of placeTrees(map, TREE_SPECIES)) {
+        expect(Math.hypot(tree.x - post.x, tree.z - post.z)).toBeGreaterThanOrEqual(SIGNPOST_CLEARANCE)
+      }
+    }
+  })
+
+  it("keeps the post inside its tile but set in toward the corner it marks", () => {
+    for (const map of maps) {
+      const post = signpostPlacement(map)!
+      const offset = Math.hypot(post.x - tileToWorldX(map, post.tile.x), post.z - tileToWorldZ(map, post.tile.z))
+      expect(offset).toBeCloseTo(SIGNPOST_INSET, 6)
+    }
+  })
+
+  it("turns the pointing board onto the shrine's bearing", () => {
+    for (const map of maps) {
+      const post = signpostPlacement(map)!
+      const hovel = map.buildings.find(b => b.id === map.site!.hovelId)!
+      const shrineX = tileToWorldX(map, hovel.x) + (hovel.w - 1) / 2
+      const shrineZ = tileToWorldZ(map, hovel.z) + (hovel.d - 1) / 2
+      // Local +X after a yaw rotation about Y; it must lie along the shrine.
+      const armX = Math.cos(post.yaw), armZ = -Math.sin(post.yaw)
+      const span = Math.hypot(shrineX - post.x, shrineZ - post.z)
+      expect(armX * (shrineX - post.x) / span + armZ * (shrineZ - post.z) / span).toBeCloseTo(1, 6)
+    }
+  })
+
+  it("has nothing to mark on a map with no shrine branch", () => {
+    const bare: GameMap = { width: 4, depth: 4, tiles: new Array(16).fill("grass"), buildings: [] }
+    expect(signpostPlacement(bare)).toBeNull()
+  })
+})

--- a/lib/game/map/signpost.ts
+++ b/lib/game/map/signpost.ts
@@ -1,0 +1,102 @@
+import { type TerrainId } from "./terrain"
+import { tileToWorldX, tileToWorldZ, type GameMap, type TilePos } from "./types"
+
+/**
+ * The wayside marker at the fork for the shrine. Pure geometry — no three.js,
+ * no React — so where the post lands can be checked headlessly.
+ *
+ * A traveller on the road has no reason to guess which way the relic lies, so
+ * the way to it is marked where it leaves the road: a post at a corner of the
+ * junction, a board pointing along the branch, and a cross to say what stands
+ * at the end of it. The post never stands on the track itself — it takes the
+ * open ground in the crook of the fork, set in toward the corner so it reads
+ * as part of the junction rather than something dropped in the field.
+ */
+
+/** Ground a post can be driven into: open, dry and clear of the tree line. */
+const OPEN_GROUND: readonly TerrainId[] = ["grass", "dirt", "clearing", "sand"]
+
+/** Woods take the post too, rather than lose the marker: the trees stand off it. */
+const WOODED_GROUND: readonly TerrainId[] = [...OPEN_GROUND, "forest", "darkwood"]
+
+/** How far in from the corner tile's centre the post stands, in tiles. */
+export const SIGNPOST_INSET = 0.32
+
+/** No trunk stands inside this radius of the post, so nothing grows through the board. */
+export const SIGNPOST_CLEARANCE = 0.7
+
+/** Corners further along the branch than this are no longer part of the fork. */
+const MAX_BEND_SEARCH = 6
+
+/** A cliff between the post and the way it marks reads as two separate places. */
+const MAX_CORNER_RISE = 0.25
+
+export interface SignpostPlacement {
+  /** The corner tile the post stands on; never a road or track tile. */
+  tile: TilePos
+  /** World position of the post's foot. */
+  x: number
+  z: number
+  /** Y rotation that swings the pointing board onto the shrine's bearing. */
+  yaw: number
+}
+
+function usableCorner(map: GameMap, tile: TilePos, beside: TilePos, wooded: boolean): boolean {
+  if (tile.x < 0 || tile.z < 0 || tile.x >= map.width || tile.z >= map.depth) return false
+  const index = tile.z * map.width + tile.x
+  if (!(wooded ? WOODED_GROUND : OPEN_GROUND).includes(map.tiles[index])) return false
+  if (map.buildings.some(b => tile.x >= b.x && tile.x < b.x + b.w && tile.z >= b.z && tile.z < b.z + b.d)) return false
+  if (map.site && map.site.door.x === tile.x && map.site.door.z === tile.z) return false
+  const height = map.elevation?.height
+  return !height || Math.abs(height[index] - height[beside.z * map.width + beside.x]) <= MAX_CORNER_RISE
+}
+
+/**
+ * Where the signpost stands, or null on a map with no shrine branch to mark.
+ *
+ * The fork's own two corners come first — the tiles diagonally out from the
+ * junction, one either side of the road. Failing those, the search steps along
+ * to the outer corners of the branch's next few bends. Open ground wins at
+ * each corner in turn, but a corner in the trees is taken before the search
+ * moves further from the road: a marker at the mouth of a forest track is the
+ * point of the thing, and the stand grows around it (see SIGNPOST_CLEARANCE).
+ */
+export function signpostPlacement(map: GameMap): SignpostPlacement | null {
+  const site = map.site
+  if (!site || site.branch.length < 2) return null
+  const hovel = map.buildings.find(b => b.id === site.hovelId)
+  if (!hovel) return null
+
+  const corners: { tile: TilePos; beside: TilePos }[][] = []
+  const junction = site.branch[0], first = site.branch[1]
+  const step = { x: first.x - junction.x, z: first.z - junction.z }
+  corners.push([{ x: step.z, z: -step.x }, { x: -step.z, z: step.x }]
+    .map(side => ({ tile: { x: first.x + side.x, z: first.z + side.z }, beside: junction })))
+  // Both tiles adjacent to a bend but off the branch sit on the outside of it.
+  for (let i = 1; i < Math.min(MAX_BEND_SEARCH, site.branch.length - 1); i++) {
+    const at = site.branch[i]
+    const into = { x: at.x - site.branch[i - 1].x, z: at.z - site.branch[i - 1].z }
+    const out = { x: site.branch[i + 1].x - at.x, z: site.branch[i + 1].z - at.z }
+    if (into.x === out.x && into.z === out.z) continue
+    corners.push([{ x: at.x + into.x, z: at.z + into.z }, { x: at.x - out.x, z: at.z - out.z }]
+      .map(tile => ({ tile, beside: at })))
+  }
+
+  let corner: { tile: TilePos; beside: TilePos } | undefined
+  for (const pair of corners) {
+    corner = pair.find(c => usableCorner(map, c.tile, c.beside, false))
+      ?? pair.find(c => usableCorner(map, c.tile, c.beside, true))
+    if (corner) break
+  }
+  if (!corner) return null
+
+  // Hug the corner: step in from the tile's centre toward the ground it marks.
+  const toward = { x: corner.beside.x - corner.tile.x, z: corner.beside.z - corner.tile.z }
+  const span = Math.hypot(toward.x, toward.z) || 1
+  const x = tileToWorldX(map, corner.tile.x) + SIGNPOST_INSET * toward.x / span
+  const z = tileToWorldZ(map, corner.tile.z) + SIGNPOST_INSET * toward.z / span
+
+  const shrineX = tileToWorldX(map, hovel.x) + (hovel.w - 1) / 2
+  const shrineZ = tileToWorldZ(map, hovel.z) + (hovel.d - 1) / 2
+  return { tile: corner.tile, x, z, yaw: Math.atan2(-(shrineZ - z), shrineX - x) }
+}

--- a/lib/game/render/outline.ts
+++ b/lib/game/render/outline.ts
@@ -102,6 +102,9 @@ export function wildlifeObjectId(animalIndex: number): number {
   return MAX_OBJECT_ID - 0x4000 - animalIndex
 }
 
+/** The lone wayside signpost, below wildlife and clear of every growing block. */
+export const SIGNPOST_OBJECT_ID = MAX_OBJECT_ID - 0x5000
+
 /**
  * The relic sits alone in the middle of the ID space, so it outlines against
  * the shrine that houses it rather than merging into the walls.

--- a/lib/game/trees/placement.ts
+++ b/lib/game/trees/placement.ts
@@ -1,5 +1,6 @@
 import { groundHeight } from "../map/elevation"
 import { computeDarkShade, computeForestShade } from "../map/forest-field"
+import { signpostPlacement, SIGNPOST_CLEARANCE } from "../map/signpost"
 import { isWoods } from "../map/terrain"
 import { tileAt, tileToWorldX, tileToWorldZ, type GameMap } from "../map/types"
 import { deriveSeed, makeRng, SEED_STREAM } from "../rng"
@@ -116,6 +117,8 @@ export function placeTrees(
   const out: TreePlacement[] = []
   // Indices into `out` of the trees on each tile, for the cap and the room check.
   const byTile: (number[] | undefined)[] = new Array(map.width * map.depth)
+  // The wayside signpost may take a corner inside the woods; leave it standing room.
+  const signpost = signpostPlacement(map)
 
   const hasRoom = (px: number, pz: number, def: TreeSpeciesDef, scale: number, x: number, z: number) => {
     for (let dz = -1; dz <= 1; dz++) {
@@ -172,6 +175,7 @@ export function placeTrees(
           const px = cx + (rng() - 0.5) * SCATTER
           const pz = cz + (rng() - 0.5) * SCATTER
           if (!hasRoom(px, pz, def, scale, x, z)) continue
+          if (signpost && Math.hypot(px - signpost.x, pz - signpost.z) < SIGNPOST_CLEARANCE) continue
           if (!here) byTile[index] = here = []
           here.push(out.length)
           out.push({ x: px, y: groundHeight(map, px + map.width / 2 - 0.5, pz + map.depth / 2 - 0.5), z: pz, species: id, scale, brightness })


### PR DESCRIPTION
A traveller on the road had no way to tell which turning leads to the relic, so the shrine's branch now carries a marker where it leaves the road: a riven post at a corner of the junction, a pointed board turned onto the shrine's bearing, and a small cross on the head. Placement is pure map geometry (`lib/game/map/signpost.ts`) — the two corners of the fork come first, falling back to the outer corners of the branch's next few bends, preferring open ground at each corner before a wooded one, and the post is set in toward the corner so it hugs the junction without standing in anyone's walking lane. Tree and scenery placement now leave it standing room, so a marker at the mouth of a forest track never grows over. The timber reuses the existing early-building parts vocabulary as a `signpost` variant and renders through the shared `StructureModel`, so it matches the carved cross and the shrine in palette, pixel size and outline handling; the cross arms lie across the board so whichever the camera foreshortens, the other stands broadside in all four views. Covered by `lib/game/map/signpost.test.ts` (placement, bearing and tree clearance over 12 generated worlds) and checked in the running app at the closest player zoom.

Note: wayside crosses marking the road to a shrine are firmly in period, but a pointing fingerpost board is a later invention — this is built as a wayside cross with a shaped, unlettered directing board, which I flagged for you rather than treating as strictly accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)