### PR TITLE
Halve the stamina drain and have travelers seek lodging at 20%

### DIFF
--- a/lib/game/balance.ts
+++ b/lib/game/balance.ts
@@ -431,8 +431,8 @@ export const RULE_FIELDS = [
   },
   {
     key: "staminaDecay", group: "Traveler needs", label: "Stamina drain per game hour",
-    description: "Energy lost per game hour. Default: exhausted after about 24 hours. Camping restores stamina and tending a parked stall holds it steady; drinking does not restore energy.",
-    default: 4.2, min: 0, max: 50, step: 0.1,
+    description: "Energy lost per game hour. Default: a full bar lasts about 48 hours, with travelers looking for lodging once it falls below 20. Camping restores stamina and tending a parked stall holds it steady; drinking does not restore energy.",
+    default: 2.1, min: 0, max: 50, step: 0.1,
   },
 ] as const
 export type RuleKey = (typeof RULE_FIELDS)[number]["key"]

--- a/lib/game/sim.test.ts
+++ b/lib/game/sim.test.ts
@@ -179,11 +179,11 @@ describe("stepSim", () => {
     const s = sim.travelers.get(0)!
     const hour = GAME_DAY_SECONDS / 24
     stepSim(sim, travelers, map, 1, hour)
-    expect([s.hunger, s.thirst, s.stamina]).toEqual([77, 74, 75.8])
+    expect([s.hunger, s.thirst, s.stamina]).toEqual([77, 74, 77.9])
 
     Object.assign(sim.balance.rules, { hungerDecay: 2, thirstDecay: 6, staminaDecay: 0 })
     stepSim(sim, travelers, map, 1, hour)
-    expect([s.hunger, s.thirst, s.stamina]).toEqual([75, 68, 75.8])
+    expect([s.hunger, s.thirst, s.stamina]).toEqual([75, 68, 77.9])
 
     s.activity = "camping"
     s.stamina = 0
@@ -206,7 +206,8 @@ describe("stepSim", () => {
         s.activity = "walking"
       }
     }
-    expect(depleted).toEqual({ hunger: 0, thirst: 1, stamina: 1 })
+    // Legs never bottom out: walkers pitch camp once stamina falls below 20.
+    expect(depleted).toEqual({ hunger: 0, thirst: 1, stamina: 0 })
     expect(sim.time).toBeCloseTo(1.25)
   })
 
@@ -745,7 +746,8 @@ describe("tracks through the dark forest", () => {
     const map = makeTrackMap()
     let took = 0
     for (let id = 0; id < 12; id++) {
-      const travelers = [makeTraveler(id, "pilgrim", { stamina: 20, hunger: 100, thirst: 100 }, beforeMouth)]
+      // Weary but still above the stamina at which they would stop and camp.
+      const travelers = [makeTraveler(id, "pilgrim", { stamina: 24, hunger: 100, thirst: 100 }, beforeMouth)]
       const sim = createSim(travelers, map)
       const s = sim.travelers.get(id)!
       if (runUntil(sim, travelers, map, () => s.track !== null, 8)) took++

--- a/lib/game/sim.ts
+++ b/lib/game/sim.ts
@@ -58,7 +58,7 @@ import type { Traveler } from "./travelers"
  *    they return to the road; each visit spreads the shrine's renown.
  *  - Jobless visitors may settle into a woodcutter hut slot, walk to a reserved
  *    tree, fell it and haul logs home. Camps provide rest when needs run low.
- *  - Stamina at 0 → leave the road for the nearest open ground (grass, dirt,
+ *  - Stamina below 20 → leave the road for the nearest open ground (grass, dirt,
  *    or a forest-floor clearing — never solid woods or the road itself) and
  *    camp until rested. A roadside stall is
  *    the favourite pitch for anyone; pilgrims will otherwise join an existing
@@ -172,6 +172,8 @@ export function formatGameTime(time: number): string {
 // is a few hours' rest — watchable at the default day length.
 
 export const CAMP_STAMINA_REGEN = 60
+/** Tired travelers start looking for a pitch here, rather than walking to zero. */
+export const CAMP_STAMINA_THRESHOLD = 20
 /** Resting slows the need for food and drink but doesn't stop it. */
 const CAMP_NEED_FACTOR = 0.5
 
@@ -1160,7 +1162,7 @@ export function stepSim(
         const ahead = map.site ? s.direction * (map.site.junction - s.progress) : -1
         const shelter = !!map.site && s.gold >= admissionFee(map) && !s.track && s.activity !== "fleeing" && s.visitCooldown <= 0 &&
           Math.min(s.hunger, s.thirst) < hospitalityNeedThreshold(renown, sim.balance) && ahead >= 0 && ahead <= 12
-        if (s.stamina <= 0 && !shelter) {
+        if (s.stamina <= CAMP_STAMINA_THRESHOLD && !shelter) {
           startCamping(sim, s, t, map)
           break
         }


### PR DESCRIPTION
Stamina now drains at 2.1 per game hour instead of 4.2, so a full bar lasts about 48 game hours rather than 24; it remains a tunable World rule, with its description updated to match. Travelers also stop walking themselves to zero: the new `CAMP_STAMINA_THRESHOLD` (20) starts the existing lodging search — a roadside stall first, then an existing camp for pilgrims, otherwise a clearing off the road — while shrine hospitality still takes priority when the shrine is ahead. The net rest cycle is roughly 38 hours of walking followed by a ~1.3-hour camp, so travelers spend less of the day camped than before.

Three sim tests were updated for the new pacing: the per-hour stamina expectation, the active-day baseline (stamina no longer bottoms out, as walkers camp first), and the dark-track temptation test's pilgrim, raised from 20 to 24 so they stay inside the weary band instead of camping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)