### PR TITLE
House replaces the shepherd's hut; tavern, market and a new sheep pen hire

### DIFF
--- a/app/docs/game-specs/page.tsx
+++ b/app/docs/game-specs/page.tsx
@@ -51,9 +51,12 @@ export default function GameSpecsPage() {
         </p>
         <p className="mt-3">
           Scheduled income models offerings and gathered timber without debiting travelers or requiring
-          jobs. Lumber camps also hire up to three jobless visitors each; their workers fell nearby
-          trees and carry logs home. Each delivered unit enters the shared treasury once, in addition
-          to scheduled income. Construction uses available stacked timber first, then other treasury wood. There are no wages, upkeep, refunds or demolition yet.
+          jobs. Woodcutter’s huts hire up to three jobless visitors each; their workers fell nearby
+          trees and carry logs home. A tavern hires two behind its counter and a sheep pen two in its
+          fold; both work at a fixed post inside the building. A market stall takes no settler — a
+          passing vendor settles into it and keeps it for good. Each delivered unit enters the shared
+          treasury once, in addition to scheduled income, as do the counters’ takings.
+          Construction uses available stacked timber first, then other treasury wood. There are no wages, upkeep, refunds or demolition yet.
         </p>
 
         <h2 className={heading}>Construction</h2>
@@ -195,9 +198,11 @@ export default function GameSpecsPage() {
           piety before willingness is calculated.
         </p>
         <p className="mt-3">
-          Hospitality requires fullness or hydration below {r.hospitalityNeedThreshold} + (60 −{" "}
+          Hospitality requires an open counter — a tavern with someone serving, or a market stall a
+          vendor has settled into — and fullness or hydration below {r.hospitalityNeedThreshold} + (60 −{" "}
           {r.hospitalityNeedThreshold}) × q. Its chance grows from zero at that threshold to a maximum
           of {r.hospitalityBaseChance} + {r.hospitalityRenownBonus} × q at an empty meter, capped at 100%.
+          With no counter open, hunger and thirst draw nobody in: the shrine itself keeps no table.
           Tiredness and job vacancies alone do not attract visitors. Travelers roll the higher of faith
           and hospitality chances when crossing the junction; they do not turn back to seek the shrine.
           If that roll fails, a completed carved cross grants one independent 5% Evangelism roll.
@@ -209,6 +214,18 @@ export default function GameSpecsPage() {
         <p className="mt-3">
           Passing travelers start with 80–100 fullness and hydration. These lose {r.hungerDecay} and{" "}
           {r.thirstDecay} points per game hour respectively; camping halves both rates.
+        </p>
+        <p className="mt-3">
+          Food and drink are bought, never given. A counter charges 2 gold for a meal and 3 for a
+          cup, and only serves what the customer can pay for; the takings go to the treasury.
+          Tavern customers pay at the counter and then take a table. Kneeling at the relic restores
+          stamina alone.
+        </p>
+        <p className="mt-3">
+          Settlers who take work move into a house, two to a house. They come home to sleep, and the
+          household’s own hearth restores them slowly and for nothing; the counter is the quick
+          answer and the only one open to a traveler off the road. A settler with no house camps
+          beside their work once their legs give out.
         </p>
 
         <h2 className={heading}>Tuning while playing</h2>

--- a/components/building-lab/procedural-workshop.tsx
+++ b/components/building-lab/procedural-workshop.tsx
@@ -67,7 +67,7 @@ export function ProceduralWorkshop({ mode, onModeChange, active = true }: AssetE
       const data = JSON.parse(await file.text()), value = data.recipe ?? data
       const legacy = ["gable", "hipped", "porch"].includes(value.variant)
       if (legacy) {
-        const preset = earlyBuildingRecipe(value.variant === "porch" ? "monk-shelter" : "shepherd-hut")
+        const preset = earlyBuildingRecipe(value.variant === "porch" ? "monk-shelter" : "house")
         Object.assign(value, { variant: preset.variant, width: Math.max(1, Math.min(5, value.width)), depth: Math.max(1, Math.min(5, value.depth)), wallHeight: preset.wallHeight, roofRise: preset.roofRise })
       }
       const parsed = recipeSchema.parse(value)

--- a/components/game/debug-handle.tsx
+++ b/components/game/debug-handle.tsx
@@ -140,6 +140,12 @@ export function DebugHandle({ map, travelers, speed, movement, speedScales, char
         for (let i = 0; i < ticks; i++) stepSim(sim, travelers, map, speed, 0.1, movement, speedScales, characterScale)
         useBuildStore.getState().syncResources(sim, travelers)
       },
+      /** Live settlement loop: who works where, who lives where, and the takings. */
+      travelers: () => [...(simRegistry.current?.travelers.values() ?? [])].map(s => ({
+        id: s.id, activity: s.activity, employer: s.employer, home: s.home, jobSlot: s.jobSlot,
+        gold: s.gold, hunger: Math.round(s.hunger), thirst: Math.round(s.thirst), stamina: Math.round(s.stamina),
+      })),
+      takings: () => ({ shrineGold: simRegistry.current?.shrineGold ?? 0, tradeGold: simRegistry.current?.tradeGold ?? 0 }),
       settlement: () => ({
         buildings: map.buildings,
         felled: [...useBuildStore.getState().felled],

--- a/components/game/entrance-details.tsx
+++ b/components/game/entrance-details.tsx
@@ -13,7 +13,7 @@ import { selectElement } from "@/lib/game/selection"
 
 /** Props belong to the reserved approach square, outside the shell's occupied tiles. */
 export function EntranceDetails({map,idColors,onSelect}:{map:GameMap;idColors:Color[];onSelect:(building:BuildingDef,event:Parameters<typeof selectElement>[1])=>void}) {
-  const models=useMemo(()=>map.buildings.map(b=>entranceParts(b.id===map.site?.hovelId ? "shrine" : b.buildType ?? "shepherd-hut",b.height)),[map.buildings,map.site?.hovelId])
+  const models=useMemo(()=>map.buildings.map(b=>entranceParts(b.id===map.site?.hovelId ? "shrine" : b.buildType ?? "house",b.height)),[map.buildings,map.site?.hovelId])
   return <group name="entrance-details">
     {map.buildings.map((building,index)=>{
       const at=buildingApproach(map,building)

--- a/components/game/game-hud.tsx
+++ b/components/game/game-hud.tsx
@@ -1,6 +1,8 @@
 "use client"
 
-import { isComplete, isMonkShelter } from "@/lib/game/construction"
+import { isComplete, isHouse, isMonkShelter } from "@/lib/game/construction"
+import { BUILDING_KINDS, buildingKind } from "@/lib/game/buildings"
+import { HOUSE_BEDS } from "@/lib/game/building-art/early-geometry"
 import { FOOD_TYPES, FOOD_LABELS, STOREHOUSE_FOOD_CAPACITY, emptyFoodStock, storedFood } from "@/lib/game/storage"
 
 import { ELEVATION_CONTROLS, type ElevationSettings } from "@/lib/game/map/elevation"
@@ -288,9 +290,10 @@ function useLiveStats(travelerId: number): SimTraveler | null {
 }
 
 /** Who the player clicked on the road: name, calling, and what drives them. */
-function TravelerPanel({ traveler }: { traveler: Traveler }) {
+function TravelerPanel({ traveler, map }: { traveler: Traveler; map: GameMap | null }) {
   const a = traveler.attributes
   const live = useLiveStats(traveler.id)
+  const named = (id: string | null | undefined) => map?.buildings.find(b => b.id === id)?.label
   return (
     <Panel>
       <div className="flex items-baseline justify-between gap-4">
@@ -320,6 +323,12 @@ function TravelerPanel({ traveler }: { traveler: Traveler }) {
             {live.praying ? "Kneeling in prayer before the relic" : ACTIVITY_LABELS[live.activity]}
             {live.employer && " · Settler"}
             {live.track && " · on the dark track"}
+          </div>
+        )}
+        {live?.employer && (
+          <div className="text-[11px] text-ink-light">
+            Works at {named(live.employer) ?? "a settlement building"}
+            {live.home ? ` · lives at ${named(live.home) ?? "a house"}` : " · no house yet"}
           </div>
         )}
         {live && live.fled > 0 && (
@@ -734,6 +743,12 @@ export function GameHud({
   const foodStores = useBuildStore(s => s.foodStores)
   const foodStock = foodStores.get(selectedBuilding?.id ?? "") ?? emptyFoodStock()
   const storedWood = piles.reduce((sum, pile) => sum + (pile.campId === selectedBuilding?.id ? pile.wood : 0), 0)
+  // Live occupancy of the selected workplace or house, read from the running sim.
+  const selectedKind = buildingKind(selectedBuilding?.buildType)
+  const household = selectedBuilding && isHouse(selectedBuilding)
+    ? [...(simRegistry.current?.travelers.values() ?? [])].filter(s => s.home === selectedBuilding.id).length : 0
+  const staff = selectedBuilding && selectedKind
+    ? [...(simRegistry.current?.travelers.values() ?? [])].filter(s => s.employer === selectedBuilding.id).length : 0
   const selectedRelic = selection?.kind === "relic"
 
   return (
@@ -1069,6 +1084,13 @@ export function GameHud({
             <p className="mt-1 font-display text-xs text-ink">{selectedBuilding.label}</p>
             <ConstructionStatus building={selectedBuilding} />
             {isMonkShelter(selectedBuilding) && isComplete(selectedBuilding) && <p className="mt-1 text-[11px] text-ink-light">Tired monks sleep here until their stamina recovers.</p>}
+            {isHouse(selectedBuilding) && isComplete(selectedBuilding) && <p className="mt-1 text-[11px] text-ink-light">
+              Home to {household} of {HOUSE_BEDS} settlers. They come back here to sleep and eat.
+            </p>}
+            {selectedKind && isComplete(selectedBuilding) && <p className="mt-1 text-[11px] text-ink-light">
+              {staff} of {BUILDING_KINDS[selectedKind].jobs} {BUILDING_KINDS[selectedKind].vendorKept ? "kept by a settled vendor" : "jobs taken"}
+              {selectedBuilding.buildType === "tavern" && staff === 0 ? " · nobody is serving yet" : ""}
+            </p>}
             {selectedBuilding.id === map?.site?.hovelId && (
               <div className="mt-3 flex flex-col gap-1.5">
                 <label htmlFor="shrine-admission" className="text-[11px] text-ink-light">Admission · gold per visitor</label>
@@ -1096,7 +1118,7 @@ export function GameHud({
           </Panel>
           )}
           {selection?.kind === "animal" && <AnimalInspector id={selection.id} />}
-          {selectedTraveler && <TravelerPanel traveler={selectedTraveler} />}
+          {selectedTraveler && <TravelerPanel traveler={selectedTraveler} map={map} />}
           {selectedMonk && <MonkPanel monk={selectedMonk} />}
           {selectedRelic && relic && <RelicPanel relic={relic} />}
         </div>}

--- a/components/game/settlement-panel.tsx
+++ b/components/game/settlement-panel.tsx
@@ -3,14 +3,15 @@
 import Link from "next/link"
 import type { useSettlement } from "@/hooks/use-settlement"
 import { useCameraStore } from "@/lib/game/camera-store"
-import { isComplete } from "@/lib/game/construction"
 import type { Monk } from "@/lib/game/monks"
 import type { Relic } from "@/lib/game/relic"
 import { tileToWorldX, tileToWorldZ } from "@/lib/game/map/types"
 import {
+  jobBuildings,
   renownTiers,
   settlementIncome,
 } from "@/lib/game/settlement"
+import { BUILDING_KINDS } from "@/lib/game/buildings"
 
 /**
  * Treasury and establishment-wide progression inside the minimap details dock.
@@ -80,7 +81,8 @@ export function SettlementPanel({
         ))}
       </div>
       <p className="mb-2 text-[11px] text-ink-light">
-        {economy.visits} visits · {economy.residents.length - monks.length} settlers · {Math.max(0, map.buildings.filter((b) => b.buildType === "workshop" && isComplete(b)).length * 3 - (economy.residents.length - monks.length))} open jobs
+        {economy.visits} visits · {economy.residents.length - monks.length} settlers · {Math.max(0, jobBuildings(map)
+          .reduce((jobs, b) => jobs + BUILDING_KINDS[b.kind].jobs, 0) - (economy.residents.length - monks.length))} open jobs
       </p>
       <details>
         <summary className="cursor-pointer text-xs">

--- a/components/game/travelers.tsx
+++ b/components/game/travelers.tsx
@@ -13,7 +13,7 @@ import { useSimulationStore } from "@/lib/game/simulation-store"
 import { selectElement } from "@/lib/game/selection"
 import { CharacterHitTarget, CharacterSelectionShadow } from "./character-selection"
 import { useBalanceStore } from "@/lib/game/balance-store"
-import { woodcutterHuts } from "@/lib/game/settlement"
+import { jobBuildings } from "@/lib/game/settlement"
 import { useBuildStore } from "@/lib/game/build-store"
 import type { Relic } from "@/lib/game/relic"
 import type { TreePlacement } from "@/lib/game/trees/placement"
@@ -101,7 +101,7 @@ export function Travelers({
     }
   }, [sim, travelers, map, relic])
 
-  const camps = useMemo(() => woodcutterHuts(map), [map])
+  const camps = useMemo(() => jobBuildings(map), [map])
 
   // Publish the running sim so the HUD's traveler panel can poll live stats.
   useEffect(() => {

--- a/docs/art/building-workshop.md
+++ b/docs/art/building-workshop.md
@@ -12,7 +12,7 @@ The construction baseline is informed by [West Stow’s reconstructed Anglo-Saxo
 | --- | --- | --- |
 | Relic enclosure | 3×3 | Roofless; low rough timber walls, four open gates, rough flagstones, stone table, loose planks and scattered belongings |
 | Monks’ shelter | 3×2 | Open front, thatched gable, woven windbreaks, straw beds and rolled blankets |
-| Shepherd’s hut | 2×2 | Low earthen and wattle walls, plank door, steep thatched roof, bedding |
+| House | 2×2 | Low earthen and wattle walls, plank door, steep thatched roof, a hearth and two straw beds |
 | Raised store | 1×1 | Open timber posts, raised plank floor and entry ramp, grain sack, small thatched gable |
 | Wood shelter | 2×1 | Open lean-to, woven windbreaks, stacked firewood |
 
@@ -22,7 +22,9 @@ Every width and depth is an integer from **1 to 5 tiles**. Dimensions describe t
 
 The live starting shrine uses a **3×5 footprint**, one entrance facing the founding track, four kneelers beside a central aisle, and a stone altar towards the rear. Its rough stone lower courses rise to the window sills, with uneven plaster above and arched openings in the raised timber section. Two lower thatched slopes meet the raised central roof, with a front cross and a larger rear cross on a small steeple. Candle stands flank the rear altar. Selecting any building removes the roof and near walls while retaining the walls opposite the camera. The relic, visitor headings and monks’ procession pickup share the same altar position; all shrine traffic crosses the single entrance. The approach to this door and its connection to the founding monk shelter are paved. Visitors reserve separate kneelers, enter by the aisle, kneel facing the altar, and retrace their route when leaving. The workshop’s roofless enclosure remains a separate study.
 
-Live settlement buildings share geometry with construction previews and menu thumbnails. The woodcutter’s hut has a plain plank lean-to, floor straw beds, lumber, axes, chisels, a long saw, a hand-cranked sharpening stone, offcuts and sawdust. The pilgrim shelter has bedding, hanging clothes, a table, a chest and a corner hearth. `BuildingSmoke` is a reusable pixel-scale sprite emitter placed at the chimney mouth; the fire remains visible in cutaway. Storehouses have open sides and an entry ramp; their food and timber still reflect live inventories.
+The **sheep pen** is a settlement type rather than a playground preset: half a house — one tile of log walls with a plank door, a lintel and a hearth — beside an open railed fold with a water trough and spare hurdles. The fold carries no roof and none of the woodcutter’s timber bays or firewood. Its reserved approach is the hut door; the fold’s gate stands open beside it. The flock itself is still to come.
+
+Live settlement buildings share geometry with construction previews and menu thumbnails. The woodcutter’s hut has a plain plank lean-to, floor straw beds, lumber, axes, chisels, a long saw, a hand-cranked sharpening stone, offcuts and sawdust. Bench seats — the tavern’s tables, the hall bench, the pilgrim shelter’s bench and the guard post’s watch seat — carry a `sitting` contact, so a character standing on one is drawn seated on the artwork, exactly as bedding carries `sleeping`. The pilgrim shelter has bedding, hanging clothes, a table, a chest and a corner hearth. `BuildingSmoke` is a reusable pixel-scale sprite emitter placed at the chimney mouth; the fire remains visible in cutaway. Storehouses have open sides and an entry ramp; their food and timber still reflect live inventories.
 
 ## Recipes and inspection
 

--- a/docs/art/settlement-sprites-todo.md
+++ b/docs/art/settlement-sprites-todo.md
@@ -1,0 +1,44 @@
+# Sprites still needed for the settlement loop
+
+The house, tavern, market stall and sheep pen now drive real behaviour (see
+`lib/game/sim.ts` and `lib/game/tavern.ts`), but several of those states borrow
+an existing pose or quietly drop a prop. Each entry below is a piece of artwork
+that would replace a stand-in. Nothing here blocks the simulation; it is the
+list of what is currently being faked.
+
+Everything follows the shared rules: the same pixel size as the character at
+play zoom (see `CLAUDE.md`), the shared leg rig and ground contacts for anything
+that walks ([assets/WALKING.md](../../assets/WALKING.md)), an editable rig with
+**Show rig** in the asset playground, and late Dark Ages to early Middle Ages
+materials and silhouettes.
+
+## Characters
+
+| Need | Currently | Notes |
+| --- | --- | --- |
+| **Sitting at a table** — a seated eating/drinking pose, ideally with a cup | reuses the existing `sitting` idle clip | The tavern benches carry a `sitting` contact (`support.clips`), so the pose is placed on the artwork already; it just is not a *dining* pose. A cup or bowl attachment would carry the whole tavern scene. |
+| **Paying at a counter** — a short standing exchange | reuses the plain `idle` clip during the `buying` activity | Two seconds long; a coin-and-cup handover would read at play zoom. |
+| **Serving behind a counter** — the tavern's two posted staff | reuses `idle` | Pouring, carrying a jug, wiping the board. Two staff stand either side of the counter (`WORK_POSTS.tavern`). |
+| **Tending a fold** — the sheep pen's two posted herders | reuses `idle` | Leaning on a crook, forking hay into the trough. Posts are inside the fold (`WORK_POSTS["sheep-pen"]`). |
+| **Keeping a stall** — the settled market vendor | reuses `idle` | Distinct from the roadside `vending` pose, which belongs to a parked cart. |
+| **Sleeping in a bed** at home | reuses the monks' `sleeping` clip on the house's straw beds | Works, but the monk pose reads as a bedroll. |
+
+## Animals and objects
+
+| Need | Currently | Notes |
+| --- | --- | --- |
+| **Sheep** — standing, grazing, walking, and a lamb | nothing; the fold is empty | The whole point of the pen. Needs the shared animal rig and **Show rig** in the playground, like the existing birds. |
+| **A settled vendor's cart** — where the wagon and draught animal go once a vendor takes over a market stall | the cart and animal simply disappear (`s.convoy` is cleared) | Options: park the wagon beside the stall as scenery, or stable the animal in a nearby pen. Until then a stall keeper is drawn on foot with no trace of the journey that brought them. |
+| **Stall wares** — food and goods on the market counter that reflect what is actually sold | three static sacks | The stall now sells food and drink for coin, so its counter should show it. |
+| **Tavern table dressing** — bowls, trenchers, a jug on the counter | four cups on two tables | The tables fill up with customers now; the settings should vary. |
+
+## Not yet modelled at all
+
+- **Traders drawn by a kept market stall.** The design calls for a staffed
+  stall to raise the settlement's draw for trade over time. Nothing in the
+  renown or traveler-generation code does this yet, and no trader-specific
+  artwork exists.
+- **A wagon or convoy visiting the market.** Wagons and horses stay on the road
+  when their owner is drawn to a counter (`needsParking` is excluded from the
+  counter trip), because there is no parking layout for the settlement's
+  interior buildings the way there is for the shrine.

--- a/hooks/use-settlement.ts
+++ b/hooks/use-settlement.ts
@@ -6,7 +6,7 @@ import type { GameMap, TilePos } from "@/lib/game/map/types"
 import type { Monk } from "@/lib/game/monks"
 import type { Relic } from "@/lib/game/relic"
 import { useBuildStore } from "@/lib/game/build-store"
-import { collectIncome, createSettlement, purchaseStructure, creditTimber, creditAdmission, syncTimberSpending, settlementRenown } from "@/lib/game/settlement"
+import { collectIncome, createSettlement, purchaseStructure, creditTimber, creditAdmission, creditTrade, syncTimberSpending, settlementRenown } from "@/lib/game/settlement"
 
 import { useSimulationStore } from "@/lib/game/simulation-store"
 import { useBalanceStore } from "@/lib/game/balance-store"
@@ -23,6 +23,7 @@ export function useSettlement(baseMap: GameMap | null, monks: Monk[], relic: Rel
   const simulation = useBuildStore((s) => s.simulation)
   const wood = useBuildStore((s) => s.wood)
   const shrineGold = useBuildStore((s) => s.shrineGold)
+  const tradeGold = useBuildStore((s) => s.tradeGold)
   const visitCount = useBuildStore((s) => s.visits)
   const settlers = useBuildStore((s) => s.settlers)
   const sameWorld = !!world && simulation?.world.road === world.road
@@ -74,10 +75,10 @@ export function useSettlement(baseMap: GameMap | null, monks: Monk[], relic: Rel
     if (!sameWorld) return
     setSession((current) => {
       if (current.world !== world) return current
-      const settlement = creditAdmission(creditTimber(current.settlement, wood), shrineGold)
+      const settlement = creditTrade(creditAdmission(creditTimber(current.settlement, wood), shrineGold), tradeGold)
       return settlement === current.settlement ? current : { ...current, settlement }
     })
-  }, [sameWorld, wood, shrineGold, world])
+  }, [sameWorld, wood, shrineGold, tradeGold, world])
 
   useEffect(() => {
     if (sameWorld && simulation) syncTimberSpending(simulation, session.settlement.spentWood)

--- a/lib/game/balance.ts
+++ b/lib/game/balance.ts
@@ -2,7 +2,8 @@ import { STOREHOUSE_FOOD_CAPACITY } from "./storage"
 
 /** Pure balance data, shared by gameplay, the tuning page and the specification. */
 export type BuildId = "shelter" | "workshop" | "garden" | "cross" | "hall" | "storehouse"
-  | "monk-shelter" | "shepherd-hut" | "tavern" | "wood-shelter" | "market" | "guard-post" | "lumberCamp"
+  | "monk-shelter" | "house" | "tavern" | "wood-shelter" | "market" | "guard-post" | "lumberCamp"
+  | "sheep-pen"
 
 export interface Resources {
   gold: number
@@ -119,8 +120,8 @@ export const BUILD_CATALOG: readonly BuildDefinition[] = [
     color: "#8c7658", roofColor: "#a59164",
   },
   {
-    id: "shepherd-hut", label: "Shepherd’s hut", category: "buildings",
-    description: "A compact log hut with a low thatched roof and a hearth for a herder’s household.",
+    id: "house", label: "House", category: "buildings",
+    description: "A log hut with a hearth and two straw beds. Settlers who take work here move in, and come home to sleep when they tire.",
     cost: { gold: 40, wood: 30 }, renown: 1, requiredRenown: 0,
     income: { gold: 1, wood: 0 }, w: 2, d: 2, height: 0.70,
     color: "#8c7658", roofColor: "#a59164",
@@ -141,7 +142,7 @@ export const BUILD_CATALOG: readonly BuildDefinition[] = [
   },
   {
     id: "market", label: "Market stall", category: "buildings",
-    description: "A cloth-canopied stall that trades with passing merchants.",
+    description: "A cloth-canopied stall. A passing vendor will settle and keep it, selling food and wares to the settlement and to travelers.",
     cost: { gold: 50, wood: 30 }, renown: 3, requiredRenown: 10,
     income: { gold: 4, wood: 0 }, w: 2, d: 2, height: 0.65,
     color: "#8c7658", roofColor: "#a59164",
@@ -155,9 +156,16 @@ export const BUILD_CATALOG: readonly BuildDefinition[] = [
   },
   {
     id: "tavern", label: "Tavern", category: "buildings",
-    description: "A broad alehouse with a hearth, drinking tables and a hanging sign. Its front and back doors each keep a clear path tile.",
+    description: "Two jobs behind the counter. Travelers and settlers buy food and drink here for gold, then sit at the tables. Its front and back doors each keep a clear path tile.",
     cost: { gold: 150, wood: 110 }, renown: 12, requiredRenown: 25,
-    income: { gold: 10, wood: 0 }, w: 3, d: 4, height: 0.78,
+    income: { gold: 0, wood: 0 }, w: 3, d: 4, height: 0.78,
+    color: "#8c7658", roofColor: "#a59164",
+  },
+  {
+    id: "sheep-pen", label: "Sheep pen", category: "buildings",
+    description: "Two herding jobs. A half hut with a door and a hearth beside an open railed pen; the flock itself is still to come.",
+    cost: { gold: 55, wood: 45 }, renown: 2, requiredRenown: 5,
+    income: { gold: 0, wood: 0 }, w: 3, d: 2, height: 0.70,
     color: "#8c7658", roofColor: "#a59164",
   },
 ]
@@ -531,7 +539,12 @@ export function buildingIncomeLabel(def: BuildDefinition, balance: GameBalance):
   ].filter(Boolean)
   return parts.length
     ? `${parts.join(" · ")} / ${balance.rules.incomeSeconds}s`
-    : def.id === "workshop" ? "3 woodcutting jobs" : def.id === "storehouse" ? `Timber storage · ${STOREHOUSE_FOOD_CAPACITY} food capacity` : "No resource income"
+    : def.id === "workshop" ? "3 woodcutting jobs"
+    : def.id === "tavern" ? "2 jobs · food & drink for gold"
+    : def.id === "sheep-pen" ? "2 herding jobs"
+    : def.id === "house" ? "Homes 2 settlers"
+    : def.id === "market" ? "Draws a vendor to keep it"
+    : def.id === "storehouse" ? `Timber storage · ${STOREHOUSE_FOOD_CAPACITY} food capacity` : "No resource income"
 }
 
 function record(value: unknown): Record<string, unknown> | null {
@@ -593,17 +606,18 @@ export function validateBalance(
   }
   return { balance: clean, error: null }
 }
-export const BALANCE_VERSION = 3
+export const BALANCE_VERSION = 4
 export function exportBalance(balance: GameBalance): string {
   return JSON.stringify({ version: BALANCE_VERSION, balance }, null, 2)
 }
 export function importBalance(json: string): ReturnType<typeof validateBalance> {
   try {
     const preset = record(JSON.parse(json))
-    if (preset?.version !== 1 && preset?.version !== 2 && preset?.version !== BALANCE_VERSION)
-      return { balance: null, error: "Unsupported preset version. Expected version 1, 2 or 3." }
+    const version = preset?.version
+    if (version !== 1 && version !== 2 && version !== 3 && version !== BALANCE_VERSION)
+      return { balance: null, error: "Unsupported preset version. Expected version 1, 2, 3 or 4." }
     // Add defaults for new structures while retaining all authored settings.
-    const saved = record(preset.balance)
+    const saved = record(preset?.balance)
     const rules = record(saved?.rules)
     const buildings = record(saved?.buildings)
     return validateBalance(saved && rules && buildings ? {
@@ -619,18 +633,24 @@ export function importBalance(json: string): ReturnType<typeof validateBalance> 
         hospitalityRenownBonus: DEFAULT_BALANCE.rules.hospitalityRenownBonus,
         ...rules,
         // Adopt slower defaults in old saves without overwriting custom rates.
-        ...(preset.version !== BALANCE_VERSION && rules.hungerDecay === 12.5 ? { hungerDecay: DEFAULT_BALANCE.rules.hungerDecay } : {}),
-        ...(preset.version !== BALANCE_VERSION && rules.thirstDecay === 25 ? { thirstDecay: DEFAULT_BALANCE.rules.thirstDecay } : {}),
+        ...(version !== BALANCE_VERSION && rules.hungerDecay === 12.5 ? { hungerDecay: DEFAULT_BALANCE.rules.hungerDecay } : {}),
+        ...(version !== BALANCE_VERSION && rules.thirstDecay === 25 ? { thirstDecay: DEFAULT_BALANCE.rules.thirstDecay } : {}),
       },
       buildings: {
         ...DEFAULT_BALANCE.buildings,
+        // The shepherd’s hut became the house; keep its authored tuning.
+        ...(record(buildings["shepherd-hut"]) ? { house: buildings["shepherd-hut"] } : {}),
         ...buildings,
         // The hut now earns wood through deliveries; retire its old passive payment.
-        ...(preset.version === 1 && record(buildings.workshop) ? {
+        ...(version === 1 && record(buildings.workshop) ? {
           workshop: { ...record(buildings.workshop), woodIncome: 0 },
         } : {}),
+        // The tavern now earns at the counter; retire its old passive payment.
+        ...(version !== BALANCE_VERSION && record(buildings.tavern)?.goldIncome === 10 ? {
+          tavern: { ...record(buildings.tavern), goldIncome: 0 },
+        } : {}),
       },
-    } : preset.balance)
+    } : preset?.balance)
   } catch {
     return { balance: null, error: "This file is not valid JSON." }
   }

--- a/lib/game/base-person/activity.ts
+++ b/lib/game/base-person/activity.ts
@@ -17,6 +17,7 @@ export function activityClip(activity: Activity | MonkActivity | undefined, movi
     case "sleeping":
     case "camping": return "sleeping"
     case "idle":
+    case "sitting":
       return "sitting"
     case "visiting": return "praying"
     // Resident monks rest on open ground, so use their existing kneeling pose.

--- a/lib/game/build-store.ts
+++ b/lib/game/build-store.ts
@@ -25,6 +25,7 @@ interface BuildState {
   simulation: SimState | null
   wood: number
   shrineGold: number
+  tradeGold: number
   visits: number
   settlers: Monk[]
   syncResources: (sim: SimState, travelers?: readonly Traveler[]) => void
@@ -45,6 +46,7 @@ const emptyState = () => ({
   simulation: null,
   wood: 0,
   shrineGold: 0,
+  tradeGold: 0,
   visits: 0,
   settlers: [] as Monk[],
 })
@@ -65,6 +67,7 @@ export const useBuildStore = create<BuildState>((set) => ({
       simulation: sim,
       wood: sim.wood,
       shrineGold: sim.shrineGold,
+      tradeGold: sim.tradeGold,
       visits: sim.visits,
       settlers: JSON.stringify(s.settlers) === JSON.stringify(settlers) ? s.settlers : settlers,
       time: sim.time,

--- a/lib/game/building-art/early-geometry.test.ts
+++ b/lib/game/building-art/early-geometry.test.ts
@@ -71,7 +71,7 @@ describe("early medieval building kit", () => {
     expect(enclosure.filter(p=>p.name.startsWith("gate-cross-upright-"))).toHaveLength(4)
     const shelter=buildingParts(earlyBuildingRecipe("monk-shelter"))
     expect(shelter.filter(p=>p.name.startsWith("shelter-cross-upright-"))).toHaveLength(2)
-    for(const type of ["shepherd-hut","storehouse","wood-shelter","tavern"] as const) {
+    for(const type of ["house","storehouse","wood-shelter","tavern"] as const) {
       expect(buildingParts(earlyBuildingRecipe(type)).some(p=>p.name.includes("cross-"))).toBe(false)
     }
   })
@@ -91,7 +91,7 @@ describe("early medieval building kit", () => {
   })
 
   it("gives homes and the tavern a fireplace clear of beds and a chimney above the roof in every footprint", () => {
-    for(const variant of ["monk-shelter", "shepherd-hut", "tavern"] as const) {
+    for(const variant of ["monk-shelter", "house", "tavern"] as const) {
       for(let width=1;width<=5;width++) for(let depth=1;depth<=5;depth++) {
         const parts = buildingParts({...earlyBuildingRecipe(variant),width,depth})
         const hearth = bounds(parts.find(p => p.name === "hearth-slab")!)
@@ -115,7 +115,7 @@ describe("early medieval building kit", () => {
   })
 
   it("cuts away entire chimneys without floating rim stones, keeping the fireplace visible", () => {
-    for(const variant of ["monk-shelter", "shepherd-hut", "tavern"] as const) {
+    for(const variant of ["monk-shelter", "house", "tavern"] as const) {
       const parts = buildingParts(earlyBuildingRecipe(variant))
       const chimneyCount = parts.filter(p => p.name.startsWith("chimney-")).length
       for(const x of [-1,1]) for(const z of [-1,1]) {
@@ -128,7 +128,7 @@ describe("early medieval building kit", () => {
 })
 
 it("keeps the full door below its arched roof and opens side and rear windows", () => {
-  const parts=buildingParts(earlyBuildingRecipe("shepherd-hut"))
+  const parts=buildingParts(earlyBuildingRecipe("house"))
   const door=bounds(parts.find(p=>p.name==="doorway-shadow")!)
   const brows=parts.filter(p=>p.name.startsWith("door-arch-thatch-")).map(bounds)
   expect(brows.length).toBeGreaterThan(10)

--- a/lib/game/building-art/early-geometry.ts
+++ b/lib/game/building-art/early-geometry.ts
@@ -4,7 +4,7 @@ import type { BuildingRecipe } from "./style"
 import { furnishingParts, hearthParts, shelterHearth, hasDomesticHearth } from "./furnishings"
 import { hasDirtFloor } from "./dirt-floor"
 import { buildingDoorOffset } from "../building-rotation"
-import { workshopLayout } from "../workshop-layout"
+import { workshopLayout, sheepPenLayout } from "../workshop-layout"
 import { BUILDING_FLOOR_TOP, BUILDING_DOOR_HEIGHT, roofProfile, hasFrontAwning } from "./dimensions"
 import { thatchSurface } from "./thatch"
 import { marketCanopyParts } from "./cloth"
@@ -13,7 +13,10 @@ import { buildingWeathering } from "./weathering"
 /** The relic rests on the same slab in the game and in the workshop. */
 export const RELIC_TABLE_TOP = 0.44
 
-export type SettlementBuildingType = "shelter" | "workshop" | "hall" | "garden" | "cross" | "lumberCamp" | "market" | "guard-post"
+/** A house sleeps this many settlers; the beds themselves decide the residency. */
+export const HOUSE_BEDS = 2
+
+export type SettlementBuildingType = "shelter" | "workshop" | "hall" | "garden" | "cross" | "lumberCamp" | "market" | "guard-post" | "sheep-pen"
 type ConstructionRecipe = Omit<BuildingRecipe, "variant"> & {
   variant: BuildingRecipe["variant"] | SettlementBuildingType
   /** The shrine's raised nave retains its bespoke gabled construction. */
@@ -28,7 +31,7 @@ export function earlyBuildingParts(recipe: ConstructionRecipe): BuildingPart[] {
   const w = width / 2, d = depth / 2, rampStart = depth / 2 - Math.min(.65, depth * .43)
   const lean = recipe.roofForm !== "gable", eave = floor + h
   const awning = lean && hasFrontAwning(variant)
-  const closed = lean && (variant === "shepherd-hut" || variant === "hall" || variant === "tavern")
+  const closed = lean && (variant === "house" || variant === "hall" || variant === "tavern")
   const profile = roofProfile(depth,rise,awning)
   const roofY = (_x: number, z = 0) => eave + (variant === "market" ? .48 : profile.height(z))
   function roofRectangle(name: string, left: number, right: number, back: number, front: number) {
@@ -133,7 +136,7 @@ export function earlyBuildingParts(recipe: ConstructionRecipe): BuildingPart[] {
       for(const [i,point] of [left,right].entries()) pole(`window-${suffix}-jamb-${i}`,[point[0]+normal[0],sill,point[2]+normal[2]],[point[0]+normal[0],head,point[2]+normal[2]],.022)
       for(const y of [sill,head]) pole(`window-${suffix}-rail-${y}`,[left[0]+normal[0],y,left[2]+normal[2]],[right[0]+normal[0],y,right[2]+normal[2]],.024,"wall",palette.paleWood)
     }
-    if(variant === "shepherd-hut") {panel(name,a,b,false);return}
+    if(variant === "house") {panel(name,a,b,false);return}
     if(a[2]<0 && b[2]>0) {
       const middle:Vec3=[a[0],0,0]
       panel(`${name}-rear`,a,middle,false)
@@ -146,9 +149,11 @@ export function earlyBuildingParts(recipe: ConstructionRecipe): BuildingPart[] {
     parts[parts.length - 1].support = { clips: ["sleeping"], anchorOffset: [0, -.06], heading: 0 }
     box(`rolled-blanket-${index}`,"base",[x,floor+.1,z-length*.32],[.3,.11,.12],"#a3987a",undefined,false)
   }
-  function bench(name: string, x: number, z: number, length: number, top = .3) {
+  /** `facing` is the heading a seated person takes; omit it for a counter nobody sits on. */
+  function bench(name: string, x: number, z: number, length: number, top = .3, facing?: number) {
     for (const end of [-1, 1]) pole(`${name}-leg-${end}`, [x+end*length*.35,floor,z], [x+end*length*.35,floor+top,z], .035, "interior")
     box(`${name}-seat`, "interior", [x,floor+top,z], [length,.045,.18], palette.paleWood, undefined, false)
+    if (facing !== undefined) parts[parts.length-1].support = { clips: ["sitting"], heading: facing }
   }
   if (variant === "garden") {
     // Two herb beds leave a narrow flagstone walk between them.
@@ -262,6 +267,69 @@ export function earlyBuildingParts(recipe: ConstructionRecipe): BuildingPart[] {
     return parts
   }
 
+  if (variant === "sheep-pen") {
+    // Half a house — a door and a hearth — beside an open railed fold. No roof
+    // over the pen, and none of the woodcutter's timber bays or firewood.
+    const { coreWidth, coreX, penLeft } = sheepPenLayout(width)
+    const hearth = hearthParts(coreWidth,depth,h,rise)
+    for (const part of hearth) { part.position[0] += coreX; part.position[2] += depth*.06 }
+    parts.push(...hearth)
+    const cx=w-.13, cz=d-.13, coreRight=penLeft
+    logWall("hut-rear",[-cx,0,-cz],[coreRight,0,-cz],h)
+    logWall("hut-side",[-cx,0,-cz],[-cx,0,cz],h)
+    logWall("hut-divider",[coreRight,0,-cz],[coreRight,0,cz],h)
+    const door=Math.min(.44,coreWidth*.62), doorHeight=Math.max(BUILDING_DOOR_HEIGHT,h*.9)
+    logWall("hut-front-left",[-cx,0,cz],[doorX-door/2,0,cz],h)
+    logWall("hut-front-right",[doorX+door/2,0,cz],[coreRight,0,cz],h)
+    const first=parts.length
+    box("doorway-shadow","wall",[doorX,floor+doorHeight/2,cz-.035],[door,doorHeight,.025],"#3f392c",undefined,false)
+    for(let i=0;i<4;i++) box(`door-board-${i}`,"wall",[doorX-door*.38+i*door*.24,floor+doorHeight*.48,cz+.013],[door*.22,doorHeight*.96,.025],i%2?palette.wood:palette.paleWood,undefined,false)
+    for(const y of [.2,.7]) box(`door-rail-${y}`,"wall",[doorX,floor+doorHeight*y,cz+.04],[door,.04,.03],palette.darkWood,undefined,false)
+    pole("door-lintel",[doorX-door/2-.05,floor+doorHeight+.03,cz+.045],[doorX+door/2+.05,floor+doorHeight+.03,cz+.045],.04)
+    for(const part of parts.slice(first)) part.cutawaySide=[0,1]
+    // The hut keeps its own thatch; the fold stays open to the sky.
+    roofRectangle("hut",-w,penLeft,-d,d)
+    // Close the wedge between the low walls and the sloping roof above them.
+    face("hut-rear-infill","roof",[-cx,eave,-cz,coreRight,eave,-cz,coreRight,roofY(coreRight,-cz),-cz,
+      -cx,eave,-cz,coreRight,roofY(coreRight,-cz),-cz,-cx,roofY(-cx,-cz),-cz],palette.wood)
+    for(const px of [-cx,coreRight]) face(`hut-side-infill-${px}`,"roof",
+      [px,eave,-cz,px,eave,cz,px,roofY(px,cz),cz,px,eave,-cz,px,roofY(px,cz),cz,px,roofY(px,-cz),-cz],"#b3aa8e")
+    for(const side of [-cx,coreRight]) {
+      const breaks=[-cz,...profile.breaks.filter(v=>v>-cz && v<cz),cz]
+      for(let i=0;i<breaks.length-1;i++) pole(`hut-eave-${side}-${i}`,[side,roofY(side,breaks[i]),breaks[i]],[side,roofY(side,breaks[i+1]),breaks[i+1]],.03,"roof")
+      for(const b of [-cz,cz]) pole(`hut-post-${side}-${b}`,[side,0,b],[side,roofY(side,b)+.21,b],.045)
+    }
+    for(const b of [-cz,cz]) pole(`hut-rafter-${b}`,[-w+.03,roofY(-w,b),b],[penLeft-.03,roofY(penLeft,b),b],.03,"roof")
+    // Hurdle fence: stakes and two rails around the fold, with a gate beside the door.
+    const railTop=Math.min(.62,h*.85), gate=Math.min(.62,depth*.42)
+    const runs: Array<[Vec3, Vec3, string]> = [
+      [[penLeft,0,-cz],[cx,0,-cz],"back"],
+      [[cx,0,-cz],[cx,0,cz],"far"],
+      [[cx,0,cz],[penLeft+gate,0,cz],"front"],
+    ]
+    for(const [a,b,name] of runs) {
+      const length=Math.hypot(b[0]-a[0],b[2]-a[2]), stakes=Math.max(2,Math.round(length/.45))
+      for(let i=0;i<=stakes;i++) {
+        const px=a[0]+(b[0]-a[0])*i/stakes, pz=a[2]+(b[2]-a[2])*i/stakes
+        pole(`pen-stake-${name}-${i}`,[px,0,pz],[px,railTop+.06,pz],i%stakes===0 ? .045 : .028)
+      }
+      for(const y of [railTop*.45,railTop]) pole(`pen-rail-${name}-${y}`,[a[0],y,a[2]],[b[0],y,b[2]],.026,"wall",palette.paleWood)
+    }
+    // A hung gate leaf, swung open into the fold.
+    const hinge=penLeft+gate
+    pole("pen-gatepost",[hinge,0,cz],[hinge,railTop+.12,cz],.048)
+    for(const y of [railTop*.45,railTop]) pole(`pen-gate-bar-${y}`,[hinge,y,cz],[hinge+.06,y,cz-gate*.8],.024,"wall",palette.paleWood)
+    pole("pen-gate-brace",[hinge,railTop*.35,cz],[hinge+.06,railTop,cz-gate*.8],.022,"wall",palette.wood)
+    // A water trough and a bundle of hurdle rods: the fold reads as ready for a flock.
+    const tx=(penLeft+cx)/2+.18, tz=-depth*.22
+    for(const end of [-1,1]) box(`trough-end-${end}`,"interior",[tx+end*.24,.11,tz],[.05,.22,.26],palette.wood,undefined,false)
+    box("trough-side","interior",[tx,.11,tz],[.48,.16,.26],palette.paleWood,undefined,false)
+    box("trough-water","interior",[tx,.185,tz],[.4,.02,.19],"#6d7a72",undefined,false)
+    for(let i=0;i<5;i++) pole(`spare-hurdle-${i}`,[cx-.12,.045+i*.05,cz-.55],[cx-.12+(i%2?.05:-.04),.05+i*.05,cz-.15],.03,"base",i%2?palette.paleWood:palette.wood)
+    parts.push(...buildingWeathering(width,depth,h,variant,recipe.seed))
+    return parts
+  }
+
   if (hasDomesticHearth(variant) && variant !== "shelter") parts.push(...hearthParts(width,depth,h,rise))
 
   const x=w-.13,z=d-.13
@@ -285,7 +353,7 @@ export function earlyBuildingParts(recipe: ConstructionRecipe): BuildingPart[] {
       const breaks=[-z,...(lean ? profile.breaks.filter(v=>v>-z && v<z) : []),z]
       for(let i=0;i<breaks.length-1;i++) pole(`store-side-beam-${side}-${i}`,[side*x,lean?roofY(side*x,breaks[i]):eave,breaks[i]],[side*x,lean?roofY(side*x,breaks[i+1]):eave,breaks[i+1]],.04)
     }
-  } else if(variant === "shepherd-hut" || variant === "hall" || variant === "tavern") {
+  } else if(variant === "house" || variant === "hall" || variant === "tavern") {
     const door=Math.min(.44,width*.5), left=(width-.26-door)/2
     if(variant === "tavern") {
       closedWall("rear-left",[-x,0,-z],[doorX-door/2,0,-z])
@@ -308,7 +376,7 @@ export function earlyBuildingParts(recipe: ConstructionRecipe): BuildingPart[] {
         const tx=-width*.23,tz=side*depth*.22,tableW=width*.32,tableD=depth*.15
         for(const a of [-1,1]) for(const b of [-1,1]) pole(`tavern-table-${side}-leg-${a}-${b}`,[tx+a*tableW*.35,0,tz+b*tableD*.32],[tx+a*tableW*.35,.37,tz+b*tableD*.32],.025,"interior")
         box(`tavern-table-${side}-top`,"interior",[tx,.39,tz],[tableW,.045,tableD],palette.paleWood,undefined,false)
-        for(const b of [-1,1]) bench(`tavern-bench-${side}-${b}`,tx,tz+b*depth*.11,tableW,.23)
+        for(const b of [-1,1]) bench(`tavern-bench-${side}-${b}`,tx,tz+b*depth*.11,tableW,.23,b>0 ? Math.PI : 0)
         for(const a of [-1,1]) {
           const mx=tx+a*tableW*.23
           box(`tavern-cup-${side}-${a}`,"interior",[mx,.445,tz],[.045,.065,.045],"#ad9166",undefined,false)
@@ -319,9 +387,15 @@ export function earlyBuildingParts(recipe: ConstructionRecipe): BuildingPart[] {
       box("tavern-serving-counter", "interior",[counterX,.23,counterZ],[counterW,.46,depth*.14],palette.wood,undefined,false)
       box("tavern-counter-top", "interior",[counterX,.475,counterZ],[counterW+.035,.035,depth*.15],palette.paleWood,undefined,false)
     }
-    if(variant === "shepherd-hut") bedding(-width*.2,-depth*.15,0,Math.min(.7,depth*.6))
+    if(variant === "house") {
+      // One bed per resident, laid left of the hearth and clear of the door.
+      const hearth = shelterHearth(width,depth,h,rise)
+      const bedLeft = -w+.24, bedRight = hearth.x-.285*hearth.scale-.24
+      const beds = Math.max(1,Math.min(HOUSE_BEDS,Math.floor((bedRight-bedLeft)/.42)+1))
+      for(let i=0;i<beds;i++) bedding(beds === 1 ? (bedLeft+bedRight)/2 : bedLeft+(bedRight-bedLeft)*i/(beds-1),-depth*.15,i,Math.min(.7,depth*.6))
+    }
     if(variant === "hall") {
-      bench("hall-bench",0,-depth*.25,width*.65)
+      bench("hall-bench",0,-depth*.25,width*.65,.3,0)
       // A pegged lintel and sheltered threshold distinguish the gathering hall.
       pole("hall-lintel",[doorX-.30,floor+doorHeight+.03,z+.045],[doorX+.30,floor+doorHeight+.03,z+.045],.045)
       flag("hall-threshold",doorX,z-.04,Math.min(.62,width*.6),.2,-.023,.025,palette.stone)
@@ -338,7 +412,7 @@ export function earlyBuildingParts(recipe: ConstructionRecipe): BuildingPart[] {
       if (variant === "shelter") {
         // Leave the rear-right hearth and front table clear of bedding.
         for(let i=0;i<2;i++) bedding(-width*.3,-depth*.18+i*depth*.35,i,Math.min(.58,depth*.28))
-        bench("pilgrim-bench",width*.1,depth*.43,width*.4,.23)
+        bench("pilgrim-bench",width*.1,depth*.43,width*.4,.23,Math.PI)
         parts.push(...furnishingParts("shelter",width,depth,h,rise))
       } else {
         const beds=Math.max(1,Math.floor((width-.3)/.55))
@@ -351,7 +425,7 @@ export function earlyBuildingParts(recipe: ConstructionRecipe): BuildingPart[] {
       bench("stall-counter",0,depth*.23,width*.72,.38)
       for (let i=0;i<3;i++) box(`market-sack-${i}`,"base",[(i-1)*width*.2,floor+.15,-depth*.16],[width*.16,.3,depth*.25],[palette.strawDark,"#8b8067",palette.earth][i],undefined,false)
     } else if (variant === "guard-post") {
-      bench("watch-seat",0,-depth*.16,width*.6,.24)
+      bench("watch-seat",0,-depth*.16,width*.6,.24,0)
       pole("watch-staff",[x-.08,floor,-z+.06],[x-.08,eave+.1,-z+.06],.02)
     } else {
       for(let row=0;row<3;row++) for(let i=0;i<Math.max(2,Math.floor(width/.14)-3-row);i++) {
@@ -429,7 +503,7 @@ export function earlyBuildingParts(recipe: ConstructionRecipe): BuildingPart[] {
       rearInfill()
     } else {
     rearInfill()
-    for(const side of [-1,1]) face(`roof-side-infill-${side}`,"roof",[side*x,eave,-z,side*x,eave,z,side*x,roofY(side*x,z),z,side*x,eave,-z,side*x,roofY(side*x,z),z,side*x,roofY(side*x,-z),-z],variant !== "shepherd-hut" ? "#b3aa8e" : palette.wood)
+    for(const side of [-1,1]) face(`roof-side-infill-${side}`,"roof",[side*x,eave,-z,side*x,eave,z,side*x,roofY(side*x,z),z,side*x,eave,-z,side*x,roofY(side*x,z),z,side*x,roofY(side*x,-z),-z],variant !== "house" ? "#b3aa8e" : palette.wood)
     const rows=Math.floor((roofY(0,-z)-eave)/.11)
     for(let row=0;row<rows;row++) {
       if(row%3!==1 || variant === "tavern") continue
@@ -466,7 +540,7 @@ export function earlyBuildingParts(recipe: ConstructionRecipe): BuildingPart[] {
       const points=[...new Set([left,doorX-door/2,doorX+door/2,right,...Array.from({length:9},(_,i)=>left+(i+1)*2*browHalf/10)])].sort((a,b)=>a-b)
       for(let i=0;i<points.length-1;i++) {
         const a=points[i],b=points[i+1],base=a>=doorX-door/2 && b<=doorX+door/2 ? head : eave
-        face(`door-arch-infill-${i}`,"roof",[a,base,z,b,base,z,b,endBrowY(b,z)-.065,z,a,base,z,b,endBrowY(b,z)-.065,z,a,endBrowY(a,z)-.065,z],variant !== "shepherd-hut" ? "#b3aa8e" : palette.wood)
+        face(`door-arch-infill-${i}`,"roof",[a,base,z,b,base,z,b,endBrowY(b,z)-.065,z,a,base,z,b,endBrowY(b,z)-.065,z,a,endBrowY(a,z)-.065,z],variant !== "house" ? "#b3aa8e" : palette.wood)
       }
       if(end===-1) for(const part of parts.slice(first)) {
         part.name=`back-${part.name}`
@@ -487,7 +561,7 @@ export function earlyBuildingParts(recipe: ConstructionRecipe): BuildingPart[] {
       }
     }
     pole("ridge-pole",[0,eave+rise+.045,-roofZ+.04],[0,eave+rise+.045,roofZ-.04],.045,"roof",palette.darkWood)
-    if(variant === "shepherd-hut" || variant === "hall" || variant === "tavern") for(const s of [-1,1]) {
+    if(variant === "house" || variant === "hall" || variant === "tavern") for(const s of [-1,1]) {
       face(`woven-gable-${s}`,"roof",[-x,eave,s*z,x,eave,s*z,0,eave+rise-.045,s*z],palette.wattle)
       pole(`gable-post-${s}`,[0,eave,s*z],[0,eave+rise,s*z],.029,"roof")
     }

--- a/lib/game/building-art/entrance.test.ts
+++ b/lib/game/building-art/entrance.test.ts
@@ -14,7 +14,7 @@ describe("door and approach proportions",()=>{
     expect(parts.find(p=>p.name==="doorway-shadow")!.position[0]).toBe(-.5)
     expect(parts.find(p=>p.name==="doorway-shadow")!.size![1]).toBeGreaterThanOrEqual(BUILDING_DOOR_HEIGHT)
   })
-  it.each(["shepherd-hut","hall","market","workshop","storehouse","shrine","tavern"])("keeps %s approach props against the building and leaves the walking lane open",type=>{
+  it.each(["house","hall","market","workshop","storehouse","shrine","tavern"])("keeps %s approach props against the building and leaves the walking lane open",type=>{
     const parts=entranceParts(type)
     expect(parts.length).toBeGreaterThan(3)
     for(const part of parts) {
@@ -38,7 +38,7 @@ describe("door and approach proportions",()=>{
   })
   it("turns roofs downhill within two tiles without imposing a height cap",()=>{
     for(const depth of [1,2,3,4,5,8]) expect(roofRun(depth)).toBeLessThanOrEqual(2)
-    const parts=structureParts({buildType:"shepherd-hut",w:2,d:4,height:2.1,color:"tan",roofColor:"tan"})
+    const parts=structureParts({buildType:"house",w:2,d:4,height:2.1,color:"tan",roofColor:"tan"})
     expect(parts.filter(p=>p.name.startsWith("thatch-bundle-")).some(p=>p.vertices!.some((v,i)=>i%3===1&&v>2.1))).toBe(true)
   })
 })

--- a/lib/game/building-art/entrance.ts
+++ b/lib/game/building-art/entrance.ts
@@ -6,7 +6,7 @@ export function entranceParts(type: string, wallHeight = .78): BuildingPart[] {
   const parts:BuildingPart[]=[]
   const box=(name:string,position:Vec3,size:Vec3,color:string,rotation?:Vec3)=>parts.push({name:`entry-${name}`,layer:"interior",position,size,color,rotation,outline:false})
   const x=-.38,z=-.38
-  if(["tavern","shelter","shepherd-hut","monk-shelter","hall","shrine"].includes(type)) {
+  if(["tavern","shelter","house","monk-shelter","hall","shrine"].includes(type)) {
     for(const a of [-1,1]) for(const b of [-1,1]) box(`chair-leg-${a}-${b}`,[x+a*.08,.12,z+b*.08],[.026,.24,.026],"#806b4c")
     box("chair-seat",[x,.25,z],[.22,.035,.22],"#9f875e")
     for(const side of [-1,1]) box(`chair-back-post-${side}`,[x+side*.085,.36,z-.085],[.028,.27,.028],"#806b4c")
@@ -14,6 +14,10 @@ export function entranceParts(type: string, wallHeight = .78): BuildingPart[] {
   } else if(type==="market" || type==="storehouse") {
     box("basket",[x,.10,z],[.20,.20,.22],"#967e58")
     for(let i=0;i<3;i++) box(`produce-${i}`,[x+(i-1)*.05,.215,z],[.055,.055,.09],type==="market" ? ["#98634f","#899157","#ac8657"][i] : "#b29a6e")
+  } else if(type==="sheep-pen") {
+    box("feed-basket",[x,.11,z],[.22,.22,.22],"#8c7250")
+    box("feed-hay",[x,.225,z],[.2,.05,.2],"#b7a367")
+    box("crook-staff",[x+.05,.36,z],[.026,.62,.026],"#7d6644")
   } else if(type==="workshop" || type==="wood-shelter") {
     box("wood-block",[x,.115,z],[.21,.23,.21],"#92744e")
     box("block-top",[x,.233,z],[.19,.012,.19],"#ad9165")
@@ -45,6 +49,9 @@ export function entranceParts(type: string, wallHeight = .78): BuildingPart[] {
   if(["shrine","hall","monk-shelter","enclosure"].includes(type)) {
     box("sign-cross-upright",[sx,.57,sz+.018],[.02,.14,.008],"#5d513c")
     box("sign-cross-arm",[sx,.595,sz+.018],[.105,.018,.008],"#5d513c")
+  } else if(type==="sheep-pen") {
+    box("sign-fleece",[sx,.57,sz+.018],[.11,.085,.008],"#7f7358")
+    box("sign-fleece-head",[sx+.055,.545,sz+.018],[.04,.04,.008],"#5d513c")
   } else if(type==="workshop" || type==="wood-shelter") {
     box("sign-axe-haft",[sx,.57,sz+.018],[.018,.13,.008],"#66523b")
     box("sign-axe-head",[sx+.025,.60,sz+.018],[.065,.045,.008],"#66523b")

--- a/lib/game/building-art/furnishings.ts
+++ b/lib/game/building-art/furnishings.ts
@@ -10,7 +10,7 @@ export function shelterHearth(width: number, depth: number, height: number, rise
 
 /** Chimneys identify domestic hearths and the tavern’s cooking fire. */
 export function hasDomesticHearth(variant: string | undefined): boolean {
-  return variant === "shelter" || variant === "monk-shelter" || variant === "shepherd-hut" || variant === "tavern"
+  return variant === "shelter" || variant === "monk-shelter" || variant === "house" || variant === "tavern"
 }
 
 /** One fireplace kit for homes and shelters, with a compact footprint in small huts. */

--- a/lib/game/building-art/structure.ts
+++ b/lib/game/building-art/structure.ts
@@ -8,7 +8,7 @@ import { singlePlaneRoofRise } from "./dimensions"
 export type StructureAppearance = Pick<BuildingDef, "buildType" | "w" | "d" | "height" | "color" | "roofColor">
 
 const SETTLEMENT_TYPES: readonly SettlementBuildingType[] = [
-  "shelter", "workshop", "hall", "garden", "cross", "lumberCamp", "market", "guard-post",
+  "shelter", "workshop", "hall", "garden", "cross", "lumberCamp", "market", "guard-post", "sheep-pen",
 ]
 
 function isSettlementType(type: string | undefined): type is SettlementBuildingType {
@@ -40,7 +40,7 @@ export function structureParts(building: StructureAppearance): BuildingPart[] {
   }
 
   if (isSettlementType(building.buildType)) return earlyBuildingParts({
-    ...earlyBuildingRecipe("shepherd-hut"),
+    ...earlyBuildingRecipe("house"),
     variant: building.buildType,
     width: building.w,
     depth: building.d,
@@ -50,7 +50,7 @@ export function structureParts(building: StructureAppearance): BuildingPart[] {
 
   // Untyped, older map structures also receive real construction at their footprint.
   return buildingParts({
-    ...earlyBuildingRecipe("shepherd-hut"),
+    ...earlyBuildingRecipe("house"),
     width: building.w,
     depth: building.d,
     wallHeight: Math.max(0.25, Math.min(1.4, building.height)),

--- a/lib/game/building-art/style.ts
+++ b/lib/game/building-art/style.ts
@@ -28,7 +28,7 @@ export const VARIANTS = [
 
 export const recipeSchema = z.object({
   subject: z.string().trim().min(1).max(160),
-  variant: z.enum(["enclosure", "monk-shelter", "shepherd-hut", "storehouse", "wood-shelter", "tavern", "gable", "hipped", "porch"]),
+  variant: z.enum(["enclosure", "monk-shelter", "house", "storehouse", "wood-shelter", "tavern", "gable", "hipped", "porch"]),
   width: z.number().int().min(1).max(5),
   depth: z.number().int().min(1).max(5),
   wallHeight: z.number().min(0.25).max(1.4),
@@ -48,7 +48,7 @@ export const LEGACY_RECIPE: BuildingRecipe = {
 export const EARLY_BUILDINGS = [
   { id: "enclosure", name: "Relic enclosure", description: "Four open timber gates with plain crosses, low paling walls and a glowing relic on a rough stone table under the sky.", width: 3, depth: 3, wallHeight: 0.42, roofRise: 0 },
   { id: "monk-shelter", name: "Monks’ shelter", description: "An open-front thatched sleeping shelter with a rear-sloping awning, plain crosses, a stone chimney and fireplace, horizontal log windbreaks and straw bedrolls.", width: 3, depth: 2, wallHeight: 0.62, roofRise: singlePlaneRoofRise(2) },
-  { id: "shepherd-hut", name: "Shepherd’s hut", description: "A compact log-built hut with a low single-plane thatched roof, a deep arched brow over the low-eave doorway, and a stone chimney and fireplace.", width: 2, depth: 2, wallHeight: 0.70, roofRise: singlePlaneRoofRise(2) },
+  { id: "house", name: "House", description: "A compact log-built home with a low single-plane thatched roof, a deep arched brow over the low-eave doorway, a stone chimney and fireplace, and straw beds for its household.", width: 2, depth: 2, wallHeight: 0.70, roofRise: singlePlaneRoofRise(2) },
   { id: "tavern", name: "Tavern", description: "A broad timber-and-rubble alehouse with a back-to-back thatched roof, an arched entrance, stone hearth and chimney, wooden drinking tables, benches and an ale-cup sign.", width: 3, depth: 4, wallHeight: 0.78, roofRise: singlePlaneRoofRise(4) },
   { id: "storehouse", name: "Raised store", description: "An open-sided store on timber legs, with a plank entry ramp and sacks beneath a thatched roof held by two plain timber battens.", width: 1, depth: 1, wallHeight: 0.55, roofRise: singlePlaneRoofRise(1) },
   { id: "wood-shelter", name: "Wood shelter", description: "An open lean-to with a low thatched roof over split wood and spare poles.", width: 2, depth: 1, wallHeight: 0.62, roofRise: singlePlaneRoofRise(1) },

--- a/lib/game/building-art/weathering.ts
+++ b/lib/game/building-art/weathering.ts
@@ -16,7 +16,7 @@ export function buildingWeathering(width: number,depth: number,height: number,va
     }
     box(`moss-${patch}`,[side*(w-.10),.006,cz],[.13,.009,.10],patch%2 ? "#777b4c" : "#898359")
   }
-  if(["tavern","shepherd-hut","hall","monk-shelter"].includes(variant)) {
+  if(["tavern","house","hall","monk-shelter","sheep-pen"].includes(variant)) {
     // An uneven spray up one side, with a few reddish leaves rather than a green blanket.
     for(let leaf=0;leaf<15;leaf++) {
       const t=leaf/15,y=.06+t*Math.min(.75,height*.95),z=-d+.19+Math.sin(t*8)*.065+(random()-.5)*.08,x=-w+.045
@@ -25,7 +25,7 @@ export function buildingWeathering(width: number,depth: number,height: number,va
       parts[parts.length-1].cutawaySide=[-1,0]
     }
   }
-  if(["tavern","shepherd-hut","hall","market"].includes(variant) && width>=2 && depth>=2) {
+  if(["tavern","house","hall","market"].includes(variant) && width>=2 && depth>=2) {
     const x=w-.29,z=d-.35
     // Eight broad staves, a swollen middle and wooden hoops.
     const rings=[[.02,.115],[.08,.14],[.27,.14],[.34,.115]]

--- a/lib/game/building-navigation.ts
+++ b/lib/game/building-navigation.ts
@@ -1,5 +1,5 @@
 import { buildingEntry } from "./building-rotation"
-import { isComplete, isMonkShelter } from "./construction"
+import { isComplete, isEnterable } from "./construction"
 import { shrineLayout, shrineKneelers } from "./shrine-layout"
 import type { BuildingDef, GameMap, TilePos } from "./map/types"
 
@@ -56,11 +56,15 @@ export function buildingStepAllowed(map: GameMap, buildings: readonly BuildingDe
   for (const building of buildings) {
     const a = containsTile(building, from), b = containsTile(building, to)
     if (!a && !b) continue
-    if (enterShrine && isMonkShelter(building) && isComplete(building)) {
+    if (enterShrine && isEnterable(building) && isComplete(building)) {
       if (a && b) continue
       const inside = a ? from : to, outside = a ? to : from
-      const entry = buildingEntry(building), inward = buildingEntry(building, true)
-      if (inside.x === inward.x && inside.z === inward.z && outside.x === entry.x && outside.z === entry.z) continue
+      // Cross the wall only in a doorway; the tavern also keeps a back door.
+      const doors = building.buildType === "tavern" ? ([1, -1] as const) : ([1] as const)
+      if (doors.some(end => {
+        const entry = buildingEntry(building, false, end), inward = buildingEntry(building, true, end)
+        return inside.x === inward.x && inside.z === inward.z && outside.x === entry.x && outside.z === entry.z
+      })) continue
       return false
     }
     if (!enterShrine || building.id !== map.site?.hovelId) return false

--- a/lib/game/building-preview.ts
+++ b/lib/game/building-preview.ts
@@ -53,7 +53,7 @@ export function buildingPreviewSettlement(world: GameMap, balance: GameBalance) 
   const at = candidates.find(at => !map.buildings.some(b => at.x < b.x+b.w+1 && at.x+pair.w+1 > b.x
     && at.z < b.z+b.d+1 && at.z+pair.d+1 > b.z) && placementError(map,pair,at,balance) === null)
   if(at) {
-    const module = { buildType: "shepherd-hut", w: 2, d: 2, height: .70, color: "#8c7658", roofColor: "#a59164" }
+    const module = { buildType: "house", w: 2, d: 2, height: .70, color: "#8c7658", roofColor: "#a59164" }
     settlement = { ...settlement, elevation: levelBuildingGround(map,{...at,w:4,d:2}),
       structures: [...settlement.structures,
         { ...module,...at,id:"preview-roofline-left",label:"Joined roof · left module",rotation:0 },

--- a/lib/game/building-rotation.ts
+++ b/lib/game/building-rotation.ts
@@ -27,7 +27,8 @@ export function rotateBuildingPoint(x: number, z: number, rotation = 0): TilePos
 
 /** Centre a doorway on a whole tile, including even-width building fronts. */
 export function buildingDoorOffset(width: number, type?: string): number {
-  return (type === "workshop" ? 0 : Math.floor((width-1)/2))-(width-1)/2
+  // The woodcutter opens onto its left-hand court; the sheep pen onto its hut door.
+  return (type === "workshop" || type === "sheep-pen" ? 0 : Math.floor((width-1)/2))-(width-1)/2
 }
 
 /** Keep an integer arrival tile aligned with the door or the workshop's open court. */

--- a/lib/game/buildings.ts
+++ b/lib/game/buildings.ts
@@ -2,6 +2,7 @@ import { rotatedFootprint, buildingEntry, buildingApproaches, type BuildingRotat
 import { settlementRoute } from "./settlement-route"
 import { isWoods, TERRAIN } from "./map/terrain"
 import { tileAt, tileToWorldX, tileToWorldZ, type BuildingDef, type GameMap } from "./map/types"
+import { WORK_POSTS } from "./work-posts"
 
 /**
  * What the player can build, and where. Pure data — no three.js, no React —
@@ -14,7 +15,7 @@ import { tileAt, tileToWorldX, tileToWorldZ, type BuildingDef, type GameMap } fr
  * places the shrine and monk shelter; lumber camps are the player's doing.
  */
 
-export type BuildingKind = "workshop"
+export type BuildingKind = "workshop" | "tavern" | "sheep-pen" | "market"
 
 export interface BuildingKindDef {
   id: BuildingKind
@@ -34,6 +35,8 @@ export interface BuildingKindDef {
   workRadius: number
   /** Trades that take to the work eagerly; anyone jobless will still take it. */
   trades: readonly string[]
+  /** Only a passing vendor keeps this place; settlers cannot take the job. */
+  vendorKept?: boolean
 }
 
 export const BUILDING_KINDS: Record<BuildingKind, BuildingKindDef> = {
@@ -50,6 +53,59 @@ export const BUILDING_KINDS: Record<BuildingKind, BuildingKindDef> = {
     workRadius: 8,
     trades: ["woodcutting", "labour"],
   },
+  tavern: {
+    id: "tavern",
+    label: "Tavern",
+    blurb: "Two jobs behind the counter, serving food and drink for gold.",
+    w: 3,
+    d: 4,
+    height: 0.78,
+    color: "#8c7658",
+    roofColor: "#a59164",
+    jobs: 2,
+    workRadius: 0,
+    trades: ["brewing", "cooking", "haggling"],
+  },
+  "sheep-pen": {
+    id: "sheep-pen",
+    label: "Sheep pen",
+    blurb: "Two herding jobs tending the fold.",
+    w: 3,
+    d: 2,
+    height: 0.70,
+    color: "#8c7658",
+    roofColor: "#a59164",
+    jobs: 2,
+    workRadius: 0,
+    trades: ["herding", "farming", "labour"],
+  },
+  market: {
+    id: "market",
+    label: "Market stall",
+    blurb: "A stall for one keeper, selling food and wares.",
+    w: 2,
+    d: 2,
+    height: 0.65,
+    color: "#8c7658",
+    roofColor: "#a59164",
+    jobs: 1,
+    workRadius: 0,
+    trades: ["haggling", "appraisal", "cart driving"],
+    vendorKept: true,
+  },
+}
+
+/** Work kept at a stand inside the building rather than ranging outside it. */
+export function isPostedWork(kind: BuildingKind): boolean {
+  return !!WORK_POSTS[kind]?.length
+}
+
+/** Places the player can build that hire, in the order the sim considers them. */
+export const JOB_KINDS: readonly BuildingKind[] = ["workshop", "tavern", "sheep-pen", "market"]
+
+/** The kind of work a placed structure offers, if any. */
+export function buildingKind(buildType: string | undefined): BuildingKind | null {
+  return JOB_KINDS.find(kind => kind === buildType) ?? null
 }
 
 /** A building the player put down: a BuildingDef that also knows its kind. */

--- a/lib/game/character-support.test.ts
+++ b/lib/game/character-support.test.ts
@@ -24,7 +24,8 @@ describe("authored character supports", () => {
     it.each([0, 1, 2, 3] as BuildingRotation[])(`${type} routes every rest slot onto its rendered bed at rotation %s`, rotation => {
       const map = fixture(type), building = map.buildings[0]
       Object.assign(building, { rotation, ...rotatedFootprint({ w: 3, d: 2 }, rotation) })
-      const beds = buildingSupports(building)
+      // A pilgrim shelter also has a sittable bench; only bedding takes rest slots.
+      const beds = buildingSupports(building).filter(support => support.clips.includes("sleeping"))
       expect(beds).toHaveLength(type === "shelter" ? 2 : 4)
       for (let slot = 0; slot < beds.length * 2; slot++) {
         const actor: Worker = { x: 0, y: 0, z: 2, workSlot: slot }
@@ -59,7 +60,7 @@ describe("authored character supports", () => {
     building.w = 2
     expect(buildingSupports(building)).toHaveLength(3)
     building.buildType = "shelter"
-    expect(buildingSupports(building)).toHaveLength(2)
+    expect(buildingSupports(building)).toHaveLength(3)
   })
 
   it.each([{ x: 6, z: 8 }, { x: 4, z: 6 }, { x: 8, z: 6 }, { x: 6, z: 4 }])("supports prayer using shrine geometry with door %j", door => {

--- a/lib/game/construction.ts
+++ b/lib/game/construction.ts
@@ -8,6 +8,7 @@ import { tileToWorldX, tileToWorldZ, worldToTileX, worldToTileZ, type BuildingDe
 import { settlementRoute } from "./settlement-route"
 import type { WanderSpot } from "./monk-wander"
 import { buildingSupports } from "./character-support"
+import { workPost } from "./work-posts"
 
 export interface Construction { work: number; required: number; cost?: { gold: number; wood: number } }
 /** Worker-seconds: small sites finish quickly; doubling the area quadruples the work. */
@@ -21,11 +22,21 @@ export function constructionStage(building: BuildingDef): number {
   return isComplete(building) ? 3 : Math.min(2, Math.floor(building.construction!.work / building.construction!.required * 3))
 }
 export function isMonkShelter(b: BuildingDef): boolean { return b.buildType === "shelter" || b.buildType === "monk-shelter" }
+/** Where a settled villager sleeps; monks keep to their own shelters. */
+export function isHouse(b: BuildingDef): boolean { return b.buildType === "house" }
+/**
+ * Buildings people walk into: sleeping places, the tavern's common room, and
+ * the open workplaces whose posts stand inside the footprint. Crossing the wall
+ * is still only allowed in a doorway, so none of these becomes a through-route.
+ */
+export function isEnterable(b: BuildingDef): boolean {
+  return isMonkShelter(b) || isHouse(b) || ["tavern", "market", "sheep-pen"].includes(b.buildType ?? "")
+}
 export function buildingEntrance(b: BuildingDef): TilePos { return buildingEntry(b) }
 
 export interface BuildingTask {
   buildingId: string
-  purpose: "build" | "rest"
+  purpose: "build" | "rest" | "work"
   slot: number
   heading: number
   route: WanderSpot[]
@@ -60,27 +71,39 @@ export function constructionStandOff(characterScale = BASE_CHARACTER_SCALE): num
   return MALLET_CONTACT_REACH * PERSON_SPRITE_SCALE * characterScale / BASE_PERSON.camera.viewSize
 }
 
+/** The stand a posted worker keeps, in the building's authored local frame. */
+function buildingWorkPost(building: BuildingDef, slot: number) {
+  const local = rotatedFootprint(building, building.rotation)
+  return workPost(building.buildType, slot, local.w, local.d)
+}
+
 /** Place work and rest positions in the same rotated local space as the building. */
 function taskPosition(map: GameMap, building: BuildingDef, purpose: BuildingTask["purpose"], slot: number, scale?: number) {
   const local = rotatedFootprint(building, building.rotation)
   const beds = purpose === "rest" ? buildingSupports(building).filter(s => s.clips.includes("sleeping")) : []
   const bed = beds[slot % beds.length]
   if (purpose === "rest" && !bed) return null
+  const post = purpose === "work" ? buildingWorkPost(building, slot) : null
+  if (purpose === "work" && !post) return null
   const x = purpose === "build" ? (slot % 4 - 1.5) * Math.min(0.45, (local.w - 0.5) / 3)
-    : bed.anchor.x
-  const z = purpose === "build" ? local.d / 2 - 0.055 + constructionStandOff(scale) : bed.anchor.z
+    : purpose === "work" ? post!.x : bed.anchor.x
+  const z = purpose === "build" ? local.d / 2 - 0.055 + constructionStandOff(scale)
+    : purpose === "work" ? post!.z : bed.anchor.z
   const offset = rotateBuildingPoint(x, z, building.rotation)
   const approach = rotateBuildingPoint(x, (local.d + 1) / 2, building.rotation)
   const cx = tileToWorldX(map, building.x) + (building.w - 1) / 2
   const cz = tileToWorldZ(map, building.z) + (building.d - 1) / 2
   const frontage = { x: worldToTileX(map, cx + approach.x), z: worldToTileZ(map, cz + approach.z) }
   return { destination: { x: cx + offset.x, z: cz + offset.z, y: surfaceHeight(map, frontage.x, frontage.z) }, frontage,
-    heading: (bed?.heading ?? Math.PI) + buildingYaw(building.rotation) }
+    heading: (bed?.heading ?? (purpose === "work" ? 0 : Math.PI)) + buildingYaw(building.rotation) }
 }
 
 /** Reserve a place before walking so en-route builders count toward the site's crew. */
 export function assignBuildingTask(actor: Worker, map: GameMap, purpose: BuildingTask["purpose"], focusedBuildingId?: string): boolean {
-  const candidates = map.buildings.filter(b => purpose === "build" ? !isComplete(b) : isMonkShelter(b) && isComplete(b))
+  // Only a named building can be rested or worked in: a settler's own house,
+  // or their employer. Unfocused rest is a brother looking for any shelter.
+  const candidates = map.buildings.filter(b => purpose === "build" ? !isComplete(b)
+    : isComplete(b) && (focusedBuildingId ? purpose === "work" || isEnterable(b) : isMonkShelter(b)))
     .filter(b => !focusedBuildingId || b.id === focusedBuildingId)
     .sort((a, b) => Math.hypot(tileToWorldX(map, a.x) - actor.x, tileToWorldZ(map, a.z) - actor.z) -
       Math.hypot(tileToWorldX(map, b.x) - actor.x, tileToWorldZ(map, b.z) - actor.z))
@@ -129,11 +152,11 @@ export function walkWorker(actor: WanderSpot, route: WanderSpot[], speed: number
 }
 
 /** Progress is paid in worker-seconds, only while standing at the site's entrance. */
-export function stepBuildingTask(actor: Worker, map: GameMap, speed: number, dt: number): "walking" | "building" | "sleeping" | null {
+export function stepBuildingTask(actor: Worker, map: GameMap, speed: number, dt: number): "walking" | "building" | "sleeping" | "posted" | null {
   const task = actor.buildingTask
   if (!task || dt <= 0) return null
   const building = map.buildings.find(b => b.id === task.buildingId)
-  if (!building || (task.purpose === "build" && isComplete(building)) || (task.purpose === "rest" && !isComplete(building))) {
+  if (!building || (task.purpose === "build" && isComplete(building)) || (task.purpose !== "build" && !isComplete(building))) {
     actor.buildingTask = undefined
     return null
   }
@@ -167,6 +190,7 @@ export function stepBuildingTask(actor: Worker, map: GameMap, speed: number, dt:
     return "walking"
   }
   if (task.purpose === "rest") return "sleeping"
+  if (task.purpose === "work") return "posted"
   const construction = building.construction!
   construction.work = Math.min(construction.required, construction.work + dt)
   return "building"

--- a/lib/game/hospitality.test.ts
+++ b/lib/game/hospitality.test.ts
@@ -1,7 +1,10 @@
 import { shrineSeats } from "./shrine-layout"
 import { afterEach, describe, expect, it } from "vitest"
 import { BUILD_CATALOG, DEFAULT_BALANCE } from "./balance"
-import { createSettlement, purchaseStructure, woodcutterHuts, creditTimber, creditAdmission, syncTimberSpending, settlementRenown } from "./settlement"
+import { createSettlement, purchaseStructure, woodcutterHuts, jobBuildings, creditTimber, creditAdmission, syncTimberSpending, settlementRenown } from "./settlement"
+import { characterSupport } from "./character-support"
+import { HOUSE_BEDS } from "./building-art/early-geometry"
+import { MEAL_PRICE, servingHouses, tavernSeats } from "./tavern"
 import { buildingStepAllowed, containsTile, shrineGates } from "./building-navigation"
 import { relicHeading, shrineVisitRoute, shrineVisitPlan } from "./shrine-visit"
 import { BUILDING_KINDS, placementProblem, planBuilding } from "./buildings"
@@ -51,6 +54,14 @@ function run(sim: SimState, travelers: Traveler[], map: GameMap, seconds: number
 }
 
 const obscure = { sanctity: 0, spectacle: 0, doubt: 100 }
+/** The shrine no longer feeds anyone, so faith is what reliably draws a visitor. */
+const holy = { sanctity: 100, spectacle: 0, doubt: 0 }
+function devout(t: Traveler): Traveler {
+  // Just short of complete devotion, so a visit can still raise it.
+  t.attributes.piety = 99
+  t.attributes.status = 0
+  return t
+}
 
 function addCross(map: GameMap) {
   map.buildings.push({ ...BUILD_CATALOG.find(b => b.id === "cross")!, id: "cross-0", buildType: "cross", x: 13, z: 6 })
@@ -85,9 +96,8 @@ describe("cross evangelism", () => {
   it("does not roll evangelism when the ordinary visit roll succeeds", () => {
     const { map, traveler } = fixture()
     addCross(map)
-    const t = traveler(0)
-    t.attributes.hunger = 0
-    const sim = createEstablishedShrine([t], map)
+    const t = devout(traveler(0))
+    const sim = createEstablishedShrine([t], map, holy)
     stepSim(sim, [t], map, 1.5, 0.2)
     expect(sim.travelers.get(0)!.activity).toBe("toRelic")
     expect(sim.travelers.get(0)!.rolls).toBe(1)
@@ -171,12 +181,34 @@ describe("monk evangelism at the junction", () => {
 })
 
 /** Guaranteed hospitality isolates the visit lifecycle from attraction rolls. */
-function createEstablishedShrine(travelers: Traveler[], map: GameMap) {
-  const sim = createSim(travelers, map, [], obscure)
+function createEstablishedShrine(travelers: Traveler[], map: GameMap, stats = obscure) {
+  const sim = createSim(travelers, map, [], stats)
   sim.balance = structuredClone(DEFAULT_BALANCE)
   sim.balance.rules.hospitalityBaseChance = 1
   sim.shrineRenown = sim.balance.rules.drawCap
   return sim
+}
+
+/**
+ * A completed tavern with a keeper already at their post, so its counter can
+ * serve. The keeper has no identity on the road, so `stepSim` never moves them.
+ */
+/** A completed house: where settlers sleep, and where their own hearth feeds them. */
+function addHouse(map: GameMap, at = { x: 6, z: 9 }) {
+  const def = BUILD_CATALOG.find(b => b.id === "house")!
+  const house = { ...def, id: `house-${at.x}-${at.z}`, buildType: "house", label: def.label, ...at, rotation: 0 as const }
+  map.buildings.push(house)
+  return house
+}
+
+function staffTavern(sim: SimState, map: GameMap, at = { x: 13, z: 9 }) {
+  const def = BUILD_CATALOG.find(b => b.id === "tavern")!
+  const tavern = { ...def, id: "tavern-0", buildType: "tavern", label: def.label, ...at, rotation: 0 as const }
+  map.buildings.push(tavern)
+  sim.travelers.set(-1, { ...[...sim.travelers.values()][0], id: -1, employer: tavern.id,
+    activity: "posted", tavernVisit: undefined, home: null,
+    x: tileToWorldX(map, at.x + 1), z: tileToWorldZ(map, at.z + 1) })
+  return tavern
 }
 
 describe("shrine hospitality", () => {
@@ -187,11 +219,13 @@ describe("shrine hospitality", () => {
         const { map, traveler } = fixture()
         const t = traveler(id, id % 2 === 0 ? 1 : -1)
         t.attributes.hunger = 0
+        t.attributes.gold = 10
         const sim = createSim([t], map, [], obscure)
+        staffTavern(sim, map)
         sim.shrineRenown = renown
         sim.visits = visits
         run(sim, [t], map, 1)
-        if (sim.travelers.get(id)!.activity === "toRelic") count++
+        if (sim.travelers.get(id)!.activity === "toTavern") count++
       }
       return count
     }
@@ -208,10 +242,9 @@ describe("shrine hospitality", () => {
     const { map, traveler } = fixture()
     const shrine = map.buildings[0]
     shrine.admissionFee = 3
-    const t = traveler(id)
+    const t = devout(traveler(id))
     t.attributes.gold = 10
-    t.attributes.hunger = 0
-    const sim = createEstablishedShrine([t], map)
+    const sim = createEstablishedShrine([t], map, holy)
     const s = sim.travelers.get(id)!
     const route = shrineVisitRoute(map, id, 0)!
     expect(route.at(-1)).toEqual(shrineSeats(shrine,map.site!.door)[id % 2].tile)
@@ -245,10 +278,9 @@ describe("shrine hospitality", () => {
   it("passes an unaffordable shrine and returns unpaid if the fee rises during the approach", () => {
     const { map, traveler } = fixture()
     map.buildings[0].admissionFee = 3
-    const t = traveler(0)
+    const t = devout(traveler(0))
     t.attributes.gold = 2
-    t.attributes.hunger = 30
-    const sim = createEstablishedShrine([t], map)
+    const sim = createEstablishedShrine([t], map, holy)
     const s = sim.travelers.get(0)!
     run(sim, [t], map, 1)
     expect(s.activity).toBe("walking")
@@ -256,7 +288,6 @@ describe("shrine hospitality", () => {
     s.gold = 3
     s.progress = map.site!.junction - 0.1
     s.visitCooldown = 0
-    s.hunger = 0
     run(sim, [t], map, 1, () => s.activity === "toRelic")
     expect(s.activity).toBe("toRelic")
     map.buildings[0].admissionFee = 4
@@ -288,11 +319,10 @@ describe("shrine hospitality", () => {
 
   it("never carries a paid visit's piety entitlement into a later free visit", () => {
     const { map, traveler } = fixture()
-    const t = traveler(0)
+    const t = devout(traveler(0))
     t.attributes.gold = 10
-    t.attributes.hunger = 0
     map.buildings[0].admissionFee = 3
-    const sim = createEstablishedShrine([t], map), s = sim.travelers.get(0)!
+    const sim = createEstablishedShrine([t], map, holy), s = sim.travelers.get(0)!
     run(sim, [t], map, 60, () => s.activity === "fromRelic")
     const paidPiety = s.piety
     expect(paidPiety).toBeGreaterThan(0)
@@ -328,9 +358,8 @@ describe("shrine hospitality", () => {
 
   it.each([1, -1] as const)("keeps lane changes continuous through a complete shrine visit (road direction %i)", (direction) => {
     const { map, traveler } = fixture()
-    const t = traveler(0, direction)
-    t.attributes.hunger = 0
-    const sim = createEstablishedShrine([t], map)
+    const t = devout(traveler(0, direction))
+    const sim = createEstablishedShrine([t], map, holy)
     const s = sim.travelers.get(0)!
     let returning = false
     let rejoined = false
@@ -353,29 +382,33 @@ describe("shrine hospitality", () => {
 
   for (const need of ["hunger", "thirst"] as const) {
     for (const direction of [1, -1] as const) {
-      it(`draws a traveler with empty ${need} from direction ${direction}, restores needs and returns them`, () => {
+      it(`draws a traveler with empty ${need} from direction ${direction} to the counter, fills them for coin and returns them`, () => {
         const { map, traveler } = fixture()
         const t = traveler(0, direction)
         t.attributes[need] = 0
+        t.attributes.gold = 10
         const sim = createEstablishedShrine([t], map)
+        const tavern = staffTavern(sim, map)
         const s = sim.travelers.get(t.id)!
         const identity = structuredClone(t)
         run(sim, [t], map, 1)
-        expect(s.activity).toBe("toRelic")
-        run(sim, [t], map, 60, () => s.activity === "fromRelic")
-        expect(s.visits).toBe(1)
-        expect(Math.min(s.hunger, s.thirst, s.stamina)).toBeGreaterThanOrEqual(95)
-        expect(s.piety).toBe(t.attributes.piety)
-        expect(sim.admissionPayments).toHaveLength(0)
-        expect(s.gold).toBe(0)
-        expect(sim.visits * sim.balance.rules.visitRenown).toBe(0.5)
-        expect(sim.relic).toEqual(obscure)
-        run(sim, [t], map, 20, () => s.activity === "walking")
+        expect(s.activity).toBe("toTavern")
+        expect(s.tavernVisit!.plan.buildingId).toBe(tavern.id)
+        run(sim, [t], map, 120, () => s.activity === "sitting")
+        expect(s.activity).toBe("sitting")
+        // Paid for at the counter, then carried to an authored bench place.
+        expect(s[need]).toBeGreaterThan(95)
+        expect(s.gold).toBeLessThan(10)
+        expect(sim.tradeGold).toBe(10 - s.gold)
+        expect(sim.tradeGold).toBeGreaterThan(0)
+        expect(containsTile(tavern, { x: worldToTileX(map, s.x), z: worldToTileZ(map, s.z) })).toBe(true)
+        // The shrine itself neither feeds nor takes any of this.
+        expect(sim.visits).toBe(0)
+        expect(sim.shrineGold).toBe(0)
+        run(sim, [t], map, 240, () => s.activity === "walking")
         expect(s.activity).toBe("walking")
-        expect(s.progress).toBe(map.site!.junction)
+        expect(s.tavernVisit).toBeUndefined()
         expect(s.direction).toBe(direction)
-        run(sim, [t], map, 0.5)
-        expect(s.activity).toBe("walking")
         expect(t).toEqual(identity)
       })
     }
@@ -383,10 +416,9 @@ describe("shrine hospitality", () => {
 
   it("notices a junction even when a fast step skips its tile", () => {
     const { map, traveler } = fixture()
-    const t = traveler(0)
+    const t = devout(traveler(0))
     t.offset = 8.5 / 29
-    t.attributes.hunger = 0
-    const sim = createEstablishedShrine([t], map)
+    const sim = createEstablishedShrine([t], map, holy)
     stepSim(sim, [t], map, 5, 1)
     expect(sim.travelers.get(0)!.activity).toBe("toRelic")
   })
@@ -447,7 +479,8 @@ describe("shrine hospitality", () => {
     }
     expect(established).toBeGreaterThan(early)
     expect(early).toBeLessThan(9) // Under one visit per ten initial passersby across these worlds.
-  })
+    // Three generated worlds, twice over: slow, but the only end-to-end check.
+  }, 30000)
 })
 
 describe("woodcutter huts", () => {
@@ -457,6 +490,7 @@ describe("woodcutter huts", () => {
       const t = traveler(0), sim = createSim([t], map), actor = sim.travelers.get(0)!
       const site = { ...camp, id: "construction-site", x: 5, z: 6, construction: { work: 0, required: 96 } }
       map.buildings.push(camp, site)
+      addHouse(map)
       sim.buildings = [camp]
       actor.employer = camp.id
       actor.activity = "idle"
@@ -478,8 +512,11 @@ describe("woodcutter huts", () => {
       run(sim, [t], map, 60, () => actor.activity === "idle")
       expect(actor.activity).toBe("idle")
       expect(actor.buildingTask).toBeUndefined()
+      // Only once the site is finished do they go home, where the household's
+      // own hearth restores them. The shrine keeps no table any more.
       const depleted = actor[need]
-      stepSim(sim, [t], map, 1.5, 0.1)
+      run(sim, [t], map, 600, () => actor[need] > depleted)
+      expect(["toHome", "sleeping"]).toContain(actor.activity)
       expect(actor[need]).toBeGreaterThan(depleted)
     }
   })
@@ -509,6 +546,8 @@ describe("woodcutter huts", () => {
       const { map, trees, camp, traveler } = fixture()
       const t = traveler(0)
       const sim = createSim([t], map)
+      map.buildings.push(camp)
+      addHouse(map)
       sim.buildings = [camp]
       sim.trees = [trees[0]]
       const resource = treeResource(trees[0], 0, map.seed)
@@ -537,7 +576,8 @@ describe("woodcutter huts", () => {
       } else {
         expect(s.activity).toBe("idle")
         expect(s.tree).toBeNull()
-        run(sim, [t], map, 30, () => s.activity === "toWork")
+        // They go home to sleep and eat before taking on another tree.
+        run(sim, [t], map, 600, () => s.activity === "toWork")
         expect(s.activity).toBe("toWork")
         expect(Math.min(s.hunger, s.thirst, s.stamina)).toBeGreaterThanOrEqual(80)
       }
@@ -600,10 +640,9 @@ describe("woodcutter huts", () => {
     expect(blocked.settlement).toBe(before)
     bought.settlement.structures[0].construction!.work = bought.settlement.structures[0].construction!.required
     const builtMap = { ...map, buildings: [...map.buildings, ...bought.settlement.structures] }
-    const t = traveler(0)
-    t.attributes.hunger = 0
+    const t = devout(traveler(0))
     t.attributes.jobless = true
-    const sim = createEstablishedShrine([t], builtMap)
+    const sim = createEstablishedShrine([t], builtMap, holy)
     sim.buildings = woodcutterHuts(builtMap)
     sim.trees = trees
     syncTimberSpending(sim, bought.settlement.spentWood)
@@ -654,12 +693,14 @@ describe("woodcutter huts", () => {
     expect(camp).not.toBeNull()
     map.tiles[10 * map.width + 15] = "water"
     const travelers = Array.from({ length: 12 }, (_, id) => {
-      const t = traveler(id)
-      t.attributes.hunger = 0
+      const t = devout(traveler(id))
       t.attributes.jobless = true
       return t
     })
-    const sim = createEstablishedShrine(travelers, map)
+    // Three hires need beds; a house sleeps two.
+    addHouse(map)
+    addHouse(map, { x: 6, z: 12 })
+    const sim = createEstablishedShrine(travelers, map, holy)
     sim.buildings = [camp]
     sim.trees = trees
     let maxWorkers = 0
@@ -688,7 +729,8 @@ describe("woodcutter huts", () => {
     expect(sim.wood).toBe(expectedWood)
     expect(Array.from(sim.piles.values()).reduce((sum, pile) => sum + pile.wood, 0)).toBe(sim.wood)
     expect(Array.from(sim.travelers.values()).filter((s) => s.employer)).toHaveLength(3)
-  })
+    // Ten game days of felling, hauling and nights at home.
+  }, 30000)
 
   it("delivers harvested wood to a storehouse without moving the worker’s job", () => {
     const { map, camp, trees, traveler } = fixture()
@@ -712,9 +754,8 @@ describe("woodcutter huts", () => {
 
   it("does not recruit employed travelers", () => {
     const { map, trees, camp, traveler } = fixture()
-    const t = traveler(0)
-    t.attributes.hunger = 0
-    const sim = createEstablishedShrine([t], map)
+    const t = devout(traveler(0))
+    const sim = createEstablishedShrine([t], map, holy)
     sim.buildings = [camp]
     sim.trees = trees
     run(sim, [t], map, 120)
@@ -760,6 +801,131 @@ describe("woodcutter huts", () => {
 })
 
 
+describe("houses, counters and posts", () => {
+  it("seats a customer on an authored bench and pays the settlement, not the shrine", () => {
+    const { map, traveler } = fixture()
+    const t = traveler(0)
+    t.attributes.hunger = 0
+    t.attributes.gold = 10
+    const sim = createEstablishedShrine([t], map)
+    const tavern = staffTavern(sim, map)
+    const s = sim.travelers.get(0)!
+    run(sim, [t], map, 200, () => s.activity === "sitting")
+    expect(s.activity).toBe("sitting")
+    const bench = characterSupport(map, s.x, s.z, "sitting")
+    expect(bench?.id).toBe(s.tavernVisit!.plan.seat!.id)
+    expect(tavernSeats(map, tavern).map(seat => seat.id)).toContain(bench!.id)
+    expect(sim.tradeGold).toBe(MEAL_PRICE)
+    expect(s.gold).toBe(10 - MEAL_PRICE)
+    expect(sim.shrineGold).toBe(0)
+  })
+
+  it("keeps one table per customer and leaves the penniless on the road", () => {
+    const { map, traveler } = fixture()
+    const people = Array.from({ length: 6 }, (_, id) => {
+      const t = traveler(id, id % 2 === 0 ? 1 : -1)
+      t.attributes.hunger = 0
+      t.attributes.gold = id === 5 ? 0 : 10
+      return t
+    })
+    const sim = createEstablishedShrine(people, map)
+    const tavern = staffTavern(sim, map)
+    run(sim, people, map, 200, () => [...sim.travelers.values()].filter(s => s.activity === "sitting").length === 4)
+    const seated = [...sim.travelers.values()].filter(s => s.activity === "sitting")
+    expect(seated).toHaveLength(tavernSeats(map, tavern).length)
+    expect(new Set(seated.map(s => s.tavernVisit!.plan.seat!.id)).size).toBe(seated.length)
+    // Nobody without the price of a meal turns off the road for one.
+    expect(sim.travelers.get(5)!.tavernVisit).toBeUndefined()
+  })
+
+  it("does not draw anyone to a tavern with nobody behind the counter", () => {
+    const { map, traveler } = fixture()
+    const t = traveler(0)
+    t.attributes.hunger = 0
+    t.attributes.gold = 10
+    const sim = createEstablishedShrine([t], map)
+    const def = BUILD_CATALOG.find(b => b.id === "tavern")!
+    map.buildings.push({ ...def, id: "tavern-0", buildType: "tavern", label: def.label, x: 13, z: 9, rotation: 0 })
+    const s = sim.travelers.get(0)!
+    run(sim, [t], map, 30)
+    // They stay on the road, hunting a vendor as they would with no tavern at all.
+    expect(["walking", "seeking"]).toContain(s.activity)
+    expect(s.tavernVisit).toBeUndefined()
+    expect(sim.tradeGold).toBe(0)
+  })
+
+  it("takes both tavern posts and both places in the fold, one settler each", () => {
+    for (const type of ["tavern", "sheep-pen"] as const) {
+      const { map, traveler } = fixture()
+      const def = BUILD_CATALOG.find(b => b.id === type)!
+      const place = { ...def, id: `${type}-0`, buildType: type, label: def.label, x: 13, z: 9, rotation: 0 as const }
+      map.buildings.push(place)
+      addHouse(map)
+      const people = Array.from({ length: 4 }, (_, id) => {
+        const t = devout(traveler(id))
+        t.attributes.jobless = true
+        return t
+      })
+      const sim = createEstablishedShrine(people, map, holy)
+      sim.buildings = jobBuildings(map)
+      run(sim, people, map, 400, () => [...sim.travelers.values()].filter(s => s.activity === "posted").length === 2)
+      const staff = [...sim.travelers.values()].filter(s => s.employer === place.id)
+      expect(staff).toHaveLength(2)
+      expect(new Set(staff.map(s => s.jobSlot))).toEqual(new Set([0, 1]))
+      for (const worker of staff) {
+        expect(worker.jobless).toBe(false)
+        // Every post stands inside its own building, not on the doorstep.
+        expect(containsTile(place, { x: worldToTileX(map, worker.x), z: worldToTileZ(map, worker.z) })).toBe(true)
+      }
+    }
+  }, 20000)
+
+  it("gives each settler their own bed and moves the next one into the next house", () => {
+    const { map, camp, trees, traveler } = fixture()
+    map.buildings.push(camp)
+    addHouse(map)
+    addHouse(map, { x: 6, z: 12 })
+    const people = Array.from({ length: 4 }, (_, id) => {
+      const t = devout(traveler(id))
+      t.attributes.jobless = true
+      return t
+    })
+    const sim = createEstablishedShrine(people, map, holy)
+    sim.buildings = jobBuildings(map)
+    sim.trees = trees
+    run(sim, people, map, 400, () => [...sim.travelers.values()].filter(s => s.home).length === 3)
+    const settled = [...sim.travelers.values()].filter(s => s.home)
+    expect(settled.length).toBe(3)
+    // Two beds to a house, so the third settler goes to the second house.
+    const byHouse = new Map<string, number>()
+    for (const s of settled) byHouse.set(s.home!, (byHouse.get(s.home!) ?? 0) + 1)
+    expect([...byHouse.values()].every(count => count <= HOUSE_BEDS)).toBe(true)
+    expect(byHouse.size).toBe(2)
+  }, 20000)
+
+  it("draws a passing vendor to keep an empty market stall for good", () => {
+    const { map } = fixture()
+    const def = BUILD_CATALOG.find(b => b.id === "market")!
+    const stall = { ...def, id: "market-0", buildType: "market", label: def.label, x: 13, z: 9, rotation: 0 as const }
+    map.buildings.push(stall)
+    const vendor: Traveler = {
+      id: 0, name: "Vendor", type: TRAVELER_TYPES.vendor, direction: 1, pace: 1, offset: 8 / 29,
+      attributes: { age: 30, gold: 60, piety: 0, status: 20, hunger: 100, thirst: 100, stamina: 100, jobless: false, skills: ["haggling"] },
+    }
+    const sim = createSim([vendor], map, [], obscure)
+    sim.buildings = jobBuildings(map)
+    const s = sim.travelers.get(0)!
+    run(sim, [vendor], map, 300, () => s.activity === "posted")
+    expect(s.employer).toBe(stall.id)
+    expect(s.activity).toBe("posted")
+    expect(s.convoy).toBe(false)
+    expect(containsTile(stall, { x: worldToTileX(map, s.x), z: worldToTileZ(map, s.z) })).toBe(true)
+    // A kept stall is a counter: it serves food and drink like the tavern.
+    expect(servingHouses(map, b => [...sim.travelers.values()].some(w => w.employer === b.id && w.activity === "posted")))
+      .toEqual([stall])
+  }, 20000)
+})
+
 describe("tree resources and timber storage", () => {
   it("gives larger and harder species more durability and wood", () => {
     const { trees } = fixture()
@@ -777,6 +943,8 @@ describe("tree resources and timber storage", () => {
     const { map, trees, camp, traveler } = fixture()
     const t = traveler(0)
     const sim = createSim([t], map)
+    map.buildings.push(camp)
+    addHouse(map)
     sim.buildings = [camp]
     sim.trees = [trees[0]]
     const s = sim.travelers.get(0)!
@@ -904,8 +1072,8 @@ describe("settlement route heights", () => {
 it("reserves separate kneelers, walks down the aisle, and frees seats after departures", () => {
   const {map,traveler}=fixture()
   map.buildings[0].d=5
-  const people=Array.from({length:5},(_,id)=>{const t=traveler(id);t.attributes.hunger=20;return t})
-  const sim=createEstablishedShrine(people,map)
+  const people=Array.from({length:5},(_,id)=>devout(traveler(id)))
+  const sim=createEstablishedShrine(people,map,holy)
   run(sim,people,map,20,()=>[...sim.travelers.values()].filter(s=>s.activity === "visiting").length===4)
   const seated=[...sim.travelers.values()].filter(s=>s.activity === "visiting")
   expect(seated).toHaveLength(4)

--- a/lib/game/monk-work.ts
+++ b/lib/game/monk-work.ts
@@ -25,7 +25,9 @@ export function stepMonkWork(s: MonkRoutine & MonkNeeds, map: GameMap, speed: nu
   if (s.buildingTask) {
     const state = stepBuildingTask(s, map, speed, dt)
     if (state) {
-      s.activity = state === "walking" ? s.buildingTask!.purpose === "rest" ? "toShelter" : "toBuild" : state
+      // Brothers only build and sleep; a posted work state cannot reach them.
+      s.activity = state === "walking" ? s.buildingTask!.purpose === "rest" ? "toShelter" : "toBuild"
+        : state === "posted" ? "resting" : state
       if (state === "sleeping") {
         s.stamina = Math.min(100, s.stamina + dt * 4)
         if (s.stamina >= MONK_WAKE_AT) { s.buildingTask = undefined; s.activity = "resting"; s.pause = 1; s.destination = "home" }

--- a/lib/game/settlement.test.ts
+++ b/lib/game/settlement.test.ts
@@ -122,7 +122,7 @@ describe("build and buy", () => {
 
   it("offers the whole building kit except the relic enclosure", () => {
     expect(BUILD_CATALOG.filter(b => b.category === "buildings").map(b => b.id))
-      .toEqual(["shelter", "workshop", "hall", "storehouse", "monk-shelter", "shepherd-hut", "wood-shelter", "lumberCamp", "market", "guard-post", "tavern"])
+      .toEqual(["shelter", "workshop", "hall", "storehouse", "monk-shelter", "house", "wood-shelter", "lumberCamp", "market", "guard-post", "tavern", "sheep-pen"])
     for (const type of ["enclosure", "gable", "hovel"])
       expect(purchaseStructure(createSettlement(), testMap(), monks, [relic], type, { x: 10, z: 14 }).error).toBe("Unknown structure.")
   })

--- a/lib/game/settlement.ts
+++ b/lib/game/settlement.ts
@@ -1,7 +1,7 @@
 import { buildingEntrance, constructionWork, isComplete } from "./construction"
 import { rotatedFootprint, buildingEntry, buildingApproaches, type BuildingRotation } from "./building-rotation"
 import { groundHeight, levelBuildingGround } from "./map/elevation"
-import { placementProblem, PLACEMENT_PROBLEM_LABELS, type PlacedBuilding } from "./buildings"
+import { buildingKind, placementProblem, PLACEMENT_PROBLEM_LABELS, type PlacedBuilding } from "./buildings"
 import { settlementRoute } from "./settlement-route"
 import { getBuildInfluence, type BuildInfluence } from "./build-influence"
 import type { SimState } from "./sim"
@@ -32,6 +32,8 @@ export interface Settlement {
   spentWood: number
   shrineAdmission: number
   collectedAdmission: number
+  /** Counter takings already credited; sales never credit the same coin twice. */
+  collectedTrade: number
   /** Only player-built additions. The founding hovel stays on the base map. */
   structures: BuildingDef[]
 }
@@ -44,6 +46,17 @@ export function createSettlement(balance: GameBalance = DEFAULT_BALANCE): Settle
     spentWood: 0,
     shrineAdmission: DEFAULT_ADMISSION_FEE,
     collectedAdmission: 0,
+    collectedTrade: 0,
+  }
+}
+
+/** Tavern and stall takings are earned in the simulation and credited once. */
+export function creditTrade(settlement: Settlement, receipts: number): Settlement {
+  if (receipts <= settlement.collectedTrade) return settlement
+  return {
+    ...settlement,
+    collectedTrade: receipts,
+    resources: { ...settlement.resources, gold: settlement.resources.gold + receipts - settlement.collectedTrade },
   }
 }
 
@@ -243,6 +256,14 @@ export function placementError(
 export function woodcutterHuts(map: GameMap): PlacedBuilding[] {
   return map.buildings.filter((b) => b.buildType === "workshop" && isComplete(b))
     .map((b) => ({ ...b, kind: "workshop" }))
+}
+
+/** Every completed structure with work in it: huts, taverns, folds and stalls. */
+export function jobBuildings(map: GameMap): PlacedBuilding[] {
+  return map.buildings.flatMap((b) => {
+    const kind = isComplete(b) ? buildingKind(b.buildType) : null
+    return kind ? [{ ...b, kind }] : []
+  })
 }
 
 export function creditTimber(settlement: Settlement, deliveredWood: number): Settlement {

--- a/lib/game/sim.ts
+++ b/lib/game/sim.ts
@@ -23,8 +23,11 @@ import { LINEAR_MOVEMENT, easeSpeed, paceVariation, type MovementTuning } from "
 import { DEFAULT_BALANCE, type GameBalance } from "./balance"
 import { roadsideEvangelism } from "./monk-evangelism"
 import { buildingAt } from "./settlement"
+import { isComplete, isHouse } from "./construction"
+import { buildingSupports } from "./character-support"
 import { AXE_DAMAGE_PER_HOUR, STUMP_LIFETIME_DAYS, TIMBER_LOAD, stackWood, treeResource, type TreeResource, type WoodPile } from "./trees/timber"
-import { BUILDING_KINDS, buildingCentre, type PlacedBuilding } from "./buildings"
+import { BUILDING_KINDS, buildingCentre, isPostedWork, type PlacedBuilding } from "./buildings"
+import { DRINK_PRICE, MEAL_PRICE, SERVING_THRESHOLD, servingHouses, tavernVisitPlan, type TavernPlan } from "./tavern"
 import { generateRelic, hospitalityNeedThreshold, visitChance, type RelicStats } from "./relic"
 import { settlementRoute } from "./settlement-route"
 import { admissionFee, shrineVisitPlan } from "./shrine-visit"
@@ -83,6 +86,15 @@ export type Activity =
   | "visiting"
   | "fromRelic"
   | "toWork"
+  | "toPost"
+  | "posted"
+  | "toHome"
+  | "sleeping"
+  | "fromHome"
+  | "toTavern"
+  | "buying"
+  | "sitting"
+  | "fromTavern"
   | "working"
   | "gathering"
   | "hauling"
@@ -118,6 +130,15 @@ export const ACTIVITY_LABELS: Record<Activity, string> = {
   visiting: "Kneeling in the shrine",
   fromRelic: "Returning from the shrine",
   toWork: "Walking to work",
+  toPost: "Going to their post",
+  posted: "At work",
+  toHome: "Tired — going home",
+  sleeping: "Asleep at home",
+  fromHome: "Leaving home for work",
+  toTavern: "Going to buy food & drink",
+  buying: "Paying at the counter",
+  sitting: "Eating and drinking",
+  fromTavern: "Leaving the counter",
   working: "Felling a tree",
   gathering: "Cutting & gathering fallen timber",
   hauling: "Carrying logs to storage",
@@ -182,6 +203,20 @@ const BUY_THRESHOLD = 10
 /** Close enough to trade, in tiles; a parked stall serves a wider reach. */
 const TRADE_RANGE = 1.2
 const STALL_TRADE_RANGE = 2.6
+/** Settlers knock off to sleep below this stamina, and rise again above it. */
+const SETTLER_TIRED_AT = 25
+const SETTLER_WAKE_AT = 95
+/**
+ * A household keeps its own hearth, bread and small beer: sleeping at home
+ * restores a settler slowly and for nothing. The counter is the quick answer,
+ * and the only one open to a traveler off the road — for coin.
+ */
+const HOME_MEAL_PER_HOUR = 30
+const HOME_DRINK_PER_HOUR = 40
+/** Rested and fed enough to go back to work. */
+const SETTLER_FED_AT = 80
+/** How long a customer lingers over a meal at a tavern table, in game hours. */
+const TABLE_HOURS = 2
 /** An exhausted traveler anchors to a stall or camp within this many tiles. */
 const CAMP_JOIN_RADIUS = 10
 /** How far off the road anyone will look for a clearing. */
@@ -254,6 +289,17 @@ export interface SimTraveler {
   jobless: boolean
   deliveryBuilding?: string | null
   employer: string | null
+  /** Which of the employer's work slots is theirs; posts are one per slot. */
+  jobSlot: number
+  /** The house they sleep in. Settlers move in when they take work. */
+  home: string | null
+  /** A trip to a counter: where to pay, where to sit, and where to go after. */
+  tavernVisit?: {
+    plan: TavernPlan
+    served: boolean
+    /** Null returns them to their place on the road. */
+    returnTo: WorldPoint | null
+  }
   branchProgress: number
   shrineRoute: TilePos[] | null
   /** Reserved until the visitor has left the shrine approach. */
@@ -334,6 +380,8 @@ export interface SimState {
   wood: number
   /** Cumulative admission receipts; the economy credits each payment once. */
   shrineGold: number
+  /** Cumulative counter takings from the tavern and any kept market stall. */
+  tradeGold: number
   constructionWood: number
   felled: Set<number>
   treeResources: Map<number, TreeResource>
@@ -545,6 +593,7 @@ export function createSim(
     visits: 0,
     wood: 0,
     shrineGold: 0,
+    tradeGold: 0,
     constructionWood: 0,
     felled: new Set(),
     treeResources: new Map(),
@@ -577,6 +626,8 @@ export function createSim(
       piety: t.attributes.piety,
       jobless: t.attributes.jobless,
       employer: null,
+      jobSlot: 0,
+      home: null,
       branchProgress: 0,
       shrineRoute: null,
       branchEntryLane: lane,
@@ -659,6 +710,9 @@ function findNearbySpot(
 }
 
 const STALL_ACTIVITIES: readonly Activity[] = ["toShop", "openingShop", "vending", "packingShop"]
+/** Activities that hold someone in place; their speed stays at zero. */
+const STILL_ACTIVITIES: readonly Activity[] = ["working", "building", "browsing", "performing", "listening",
+  "openingShop", "packingShop", "vending", "idle", "posted", "sleeping", "buying", "sitting"]
 const CAMP_ACTIVITIES: readonly Activity[] = ["toCamp", "camping"]
 
 /** World-space pitch on the nearest clearing to `anchor`, or in place if none. */
@@ -826,15 +880,121 @@ function pay(buyer: SimTraveler, vendor: SimTraveler, price: number): void {
   vendor.gold += paid
 }
 
-/** Unskilled applicants can fill any open woodcutter hut slot. */
-function findJob(sim: SimState, s: SimTraveler, map: GameMap): PlacedBuilding | undefined {
+function staffOf(sim: SimState, buildingId: string): SimTraveler[] {
+  return [...sim.travelers.values()].filter(worker => worker.employer === buildingId)
+}
+
+/** The lowest work slot nobody holds, or null when the place is fully manned. */
+function openSlot(sim: SimState, building: PlacedBuilding): number | null {
+  const taken = new Set(staffOf(sim, building.id).map(worker => worker.jobSlot))
+  for (let slot = 0; slot < BUILDING_KINDS[building.kind].jobs; slot++) if (!taken.has(slot)) return slot
+  return null
+}
+
+/** Unskilled applicants can fill any open slot; only a vendor keeps a stall. */
+function findJob(sim: SimState, s: SimTraveler, map: GameMap): { building: PlacedBuilding; slot: number } | undefined {
   if (!s.jobless || s.employer) return undefined
-  return sim.buildings.find((b) => {
-    const centre = buildingCentre(map, b)
-    return Array.from(sim.travelers.values()).filter((worker) => worker.employer === b.id).length < BUILDING_KINDS[b.kind].jobs &&
-      sim.trees.some((tree, index) => (sim.treeResources.get(index)?.remainingWood ?? 1) > 0 &&
-        Math.hypot(tree.x - centre.x, tree.z - centre.z) <= BUILDING_KINDS[b.kind].workRadius)
-  })
+  for (const building of sim.buildings) {
+    const def = BUILDING_KINDS[building.kind]
+    if (def.vendorKept) continue
+    const slot = openSlot(sim, building)
+    if (slot === null) continue
+    if (def.workRadius > 0) {
+      const centre = buildingCentre(map, building)
+      if (!sim.trees.some((tree, index) => (sim.treeResources.get(index)?.remainingWood ?? 1) > 0 &&
+        Math.hypot(tree.x - centre.x, tree.z - centre.z) <= def.workRadius)) continue
+    }
+    return { building, slot }
+  }
+  return undefined
+}
+
+/** Sleeping places actually built into the house; the artwork sets the capacity. */
+function houseBeds(building: { id: string } & Parameters<typeof buildingSupports>[0]): number {
+  return buildingSupports(building).filter(support => support.clips.includes("sleeping")).length
+}
+
+/** A new settler moves into the nearest house that still has a bed to spare. */
+function findHome(sim: SimState, s: SimTraveler, map: GameMap): string | null {
+  const houses = map.buildings.filter(b => isHouse(b) && isComplete(b))
+    .sort((a, b) => Math.hypot(tileToWorldX(map, a.x) - s.x, tileToWorldZ(map, a.z) - s.z)
+      - Math.hypot(tileToWorldX(map, b.x) - s.x, tileToWorldZ(map, b.z) - s.z))
+  for (const house of houses) {
+    if ([...sim.travelers.values()].filter(other => other.home === house.id).length < houseBeds(house)) return house.id
+  }
+  return null
+}
+
+/** Housemates take the beds in a settled order, so two never share one. */
+function homeBedSlot(sim: SimState, s: SimTraveler): number {
+  const housemates = [...sim.travelers.values()].filter(other => other.home === s.home)
+    .map(other => other.id).sort((a, b) => a - b)
+  return Math.max(0, housemates.indexOf(s.id))
+}
+
+/** Counters able to serve right now: complete, and with a keeper at their post. */
+function openCounters(sim: SimState, map: GameMap) {
+  return servingHouses(map, building => staffOf(sim, building.id).some(worker => worker.activity === "posted"))
+}
+
+/** Walk a pre-planned tile route, keeping the off-road walker's tile alignment. */
+function routeWalk(s: SimTraveler, map: GameMap, route: readonly TilePos[], to: WorldPoint): void {
+  const points = route.map(p => ({ x: tileToWorldX(map, p.x), y: surfaceHeight(map, p.x, p.z), z: tileToWorldZ(map, p.z) }))
+  s.walkFrom = { x: s.x, y: s.y, z: s.z }
+  s.walkT = 0
+  s.targetId = null
+  s.offRoadRoute = [{ x: points[0].x, y: s.y, z: s.z }, ...points, { ...to }]
+}
+
+/**
+ * Set out for the nearest counter with a free table. `returnTo` is where they
+ * belong afterwards — a settler's workplace, or null for their place on the road.
+ */
+function startTavernTrip(sim: SimState, s: SimTraveler, map: GameMap,
+  counters: readonly { id: string; x: number; z: number; w: number; d: number }[], returnTo: WorldPoint | null): boolean {
+  if (!counters.length || s.gold < MEAL_PRICE) return false
+  const from = { x: worldToTileX(map, s.x), z: worldToTileZ(map, s.z) }
+  const occupied = new Set([...sim.travelers.values()].flatMap(other => other.tavernVisit?.plan.seat
+    ? [`${other.tavernVisit.plan.buildingId}:${other.tavernVisit.plan.seat.id}`] : []))
+  const nearest = [...counters].sort((a, b) => Math.hypot(tileToWorldX(map, a.x) - s.x, tileToWorldZ(map, a.z) - s.z)
+    - Math.hypot(tileToWorldX(map, b.x) - s.x, tileToWorldZ(map, b.z) - s.z))
+  for (const house of nearest) {
+    const building = map.buildings.find(b => b.id === house.id)
+    const plan = building && tavernVisitPlan(map, building, from, occupied)
+    if (!plan) continue
+    s.tavernVisit = { plan, served: false, returnTo }
+    routeWalk(s, map, plan.route, plan.counter.point)
+    s.activity = "toTavern"
+    return true
+  }
+  return false
+}
+
+/** Coin over the counter: the settlement takes it, not the server's own purse. */
+function buyRefreshment(sim: SimState, s: SimTraveler): void {
+  const take = (price: number) => {
+    s.gold -= price
+    sim.tradeGold += price
+  }
+  if (s.hunger < SERVING_THRESHOLD && s.gold >= MEAL_PRICE) { take(MEAL_PRICE); s.hunger = 100 }
+  if (s.thirst < SERVING_THRESHOLD && s.gold >= DRINK_PRICE) { take(DRINK_PRICE); s.thirst = 100 }
+}
+
+/** A settler's own doorstep: where they wait for work between errands. */
+function workplaceReturn(sim: SimState, s: SimTraveler, map: GameMap): WorldPoint | null {
+  const workplace = sim.buildings.find(b => b.id === s.employer)
+  if (!workplace) return null
+  const entry = buildingEntry(workplace)
+  return { x: tileToWorldX(map, entry.x), y: surfaceHeight(map, entry.x, entry.z), z: tileToWorldZ(map, entry.z) }
+}
+
+/** Head back out of the door to the road, or to the work they left. */
+function leaveTavern(s: SimTraveler, map: GameMap, back: WorldPoint): void {
+  const route = settlementRoute(map, map.buildings, { x: worldToTileX(map, s.x), z: worldToTileZ(map, s.z) },
+    { x: worldToTileX(map, back.x), z: worldToTileZ(map, back.z) }, false, true)
+  if (route) routeWalk(s, map, route, back)
+  else s.offRoadRoute = [{ ...back }]
+  s.activity = "fromTavern"
 }
 
 function startWorkRoute(s: SimTraveler, route: TilePos[], activity: Activity): void {
@@ -905,14 +1065,16 @@ function finishVisit(sim: SimState, s: SimTraveler, t: Traveler, map: GameMap): 
   if (s.admissionPaid > 0) s.piety = Math.min(100, s.piety + 4 + sim.relic.sanctity / 25)
   s.admissionPaid = 0
   const job = s.shrineParking ? undefined : findJob(sim, s, map)
-  if (job && nextRoll(s) < (t.attributes.skills.some((skill) => BUILDING_KINDS[job.kind].trades.includes(skill)) ? 0.9 : 0.65)) {
+  if (job && nextRoll(s) < (t.attributes.skills.some((skill) => BUILDING_KINDS[job.building.kind].trades.includes(skill)) ? 0.9 : 0.65)) {
     const route = settlementRoute(map, [...map.buildings, ...sim.buildings],
       { x: worldToTileX(map, s.x), z: worldToTileZ(map, s.z) },
-      buildingEntry(job), false, true, s.shrineSeat)
+      buildingEntry(job.building), false, true, s.shrineSeat)
     if (route) {
-      s.employer = job.id
+      s.employer = job.building.id
+      s.jobSlot = job.slot
       s.shrineSeat = undefined
       s.jobless = false
+      s.home = findHome(sim, s, map)
       startWorkRoute(s, route, "hauling")
       return
     }
@@ -937,6 +1099,8 @@ export function stepSim(
   const hours = dt / GAME_HOUR_SECONDS
   const previousPositions = dt > 0 ? new Map([...sim.travelers].map(([id, s]) => [id, { x: s.x, z: s.z, cycle: s.cycle }])) : null
   regrowFootpaths(sim.footpaths, dt / GAME_DAY_SECONDS)
+  // One reading of the settlement's open counters, shared by everyone this step.
+  const counters = openCounters(sim, map)
   const roadWalkers = travelers.filter(t => t.type.id !== "vendor" && t.type.id !== "knight")
   const explorerRanks = new Map(roadWalkers.map((t, index) => [t.id, index]))
 
@@ -945,8 +1109,9 @@ export function stepSim(
     if (!s) continue
     s.convoyScale = characterScale
     // Riders wait for a passing procession; prayer poses begin once on foot.
+    // A vendor who has taken over a stall has left the wagon for good.
     const riding = t.type.id === "knight" ? knightMounted(s.activity, s.horseRest) :
-      t.type.id === "vendor" && cartLoadout(s.id).puller !== "hand" && !s.shrineParking?.walking &&
+      t.type.id === "vendor" && !s.employer && cartLoadout(s.id).puller !== "hand" && !s.shrineParking?.walking &&
       !["openingShop", "vending", "packingShop"].includes(s.activity)
     const processionNearby = nearProcession(sim.procession, s, s.praying)
     s.praying = !riding && processionNearby
@@ -957,23 +1122,25 @@ export function stepSim(
     s.visitCooldown = Math.max(0, s.visitCooldown - dt)
     s.musicCooldown = Math.max(0, (s.musicCooldown ?? 0) - dt)
     const camping = s.activity === "camping"
-    const sheltered = s.activity === "visiting" || s.activity === "idle"
+    // Kneeling in the shrine is a rest, not a meal: the brothers keep no table.
+    const sheltered = s.activity === "visiting"
+    const abed = s.activity === "sleeping"
     const isVendor = t.type.id === "vendor", needsParking = isVendor || t.type.id === "knight"
 
     // --- Needs march on ------------------------------------------------------
-    const needFactor = camping ? CAMP_NEED_FACTOR : 1
+    const needFactor = camping || abed ? CAMP_NEED_FACTOR : 1
     s.hunger = Math.max(0, s.hunger - sim.balance.rules.hungerDecay * needFactor * hours)
     s.thirst = Math.max(0, s.thirst - sim.balance.rules.thirstDecay * needFactor * hours)
-    if (camping) s.stamina = Math.min(100, s.stamina + CAMP_STAMINA_REGEN * hours)
-    // Standing at a stall or performance neither drains nor restores the legs.
-    else if (!["vending", "performing", "listening"].includes(s.activity)) {
+    if (camping || abed) s.stamina = Math.min(100, s.stamina + CAMP_STAMINA_REGEN * hours)
+    // Standing at a stall, a post or a performance neither drains nor restores the legs.
+    else if (!["vending", "performing", "listening", "posted", "sitting", "buying"].includes(s.activity)) {
       s.stamina = Math.max(0, s.stamina - sim.balance.rules.staminaDecay * hours)
     }
 
-    if (sheltered) {
-      s.hunger = Math.min(100, s.hunger + 70 * hours)
-      s.thirst = Math.min(100, s.thirst + 90 * hours)
-      s.stamina = Math.min(100, s.stamina + 65 * hours)
+    if (sheltered) s.stamina = Math.min(100, s.stamina + 65 * hours)
+    if (abed) {
+      s.hunger = Math.min(100, s.hunger + HOME_MEAL_PER_HOUR * hours)
+      s.thirst = Math.min(100, s.thirst + HOME_DRINK_PER_HOUR * hours)
     }
 
     // Vendors eat and drink from their own stock, on the move.
@@ -988,7 +1155,7 @@ export function stepSim(
       ? knightTravelSpeed(characterScale, knightLoadout(t.id).squire)
       : personWalkStride(knightDesign(travelerAppearance(map.seed ?? 0, t.id).variant)) * characterScale * DEFAULT_WALK_CADENCE) / DEFAULT_WALK_SPEED : undefined
     const targetSpeed = t.pace * baseSpeed * (knightSpeed ?? speedScales?.get(t.id) ?? 1) * paceVariation(t.id, sim.time * GAME_DAY_SECONDS, movement.variation)
-    s.moveSpeed = camping || sheltered || s.activity === "working" || s.activity === "building" || s.activity === "browsing" || s.activity === "performing" || s.activity === "listening" || s.activity === "openingShop" || s.activity === "packingShop" || s.activity === "vending" ? 0 :
+    s.moveSpeed = camping || sheltered || STILL_ACTIVITIES.includes(s.activity) ? 0 :
       easeSpeed(s.moveSpeed, targetSpeed, dt, movement.acceleration)
     const worldSpeed = s.moveSpeed
     if (s.roadShortcut) {
@@ -1065,7 +1232,7 @@ export function stepSim(
       }
       case "visiting": {
         s.timer -= dt
-        if (s.timer <= 0 && Math.min(s.hunger, s.thirst, s.stamina) >= 95) finishVisit(sim, s, t, map)
+        if (s.timer <= 0 && s.stamina >= 95) finishVisit(sim, s, t, map)
         break
       }
       case "toWork": {
@@ -1140,14 +1307,107 @@ export function stepSim(
       }
       case "idle": {
         s.workScale = characterScale
+        // Standing behind a counter or in a fold asks little; a settler keeps
+        // that post until they are genuinely hungry or tired.
+        const hungry = Math.min(s.hunger, s.thirst) < SERVING_THRESHOLD
+        const workplace = sim.buildings.find(b => b.id === s.employer)
+        if (workplace && isPostedWork(workplace.kind) && !hungry && s.stamina > SETTLER_TIRED_AT) {
+          s.workSlot = s.jobSlot
+          if (assignBuildingTask(s, map, "work", workplace.id)) { s.activity = "toPost"; break }
+        }
+        // The counter is the quick answer to hunger and thirst; home is the
+        // slow one, and the only rest a settler gets. Work comes after both.
+        if (hungry && startTavernTrip(sim, s, map, counters, workplaceReturn(sim, s, map))) break
+        if (Math.min(s.hunger, s.thirst, s.stamina) < SETTLER_FED_AT) {
+          if (!s.home) s.home = findHome(sim, s, map)
+          s.workSlot = homeBedSlot(sim, s)
+          if (s.home && assignBuildingTask(s, map, "rest", s.home)) { s.activity = "toHome"; break }
+          // Nowhere of their own to sleep: bed down beside the work.
+          if (s.stamina <= 0) { startCamping(sim, s, t, map); break }
+        }
         s.workSlot = s.id
-        if (Math.min(s.hunger, s.thirst, s.stamina) >= 80 && assignBuildingTask(s, map, "build")) {
+        if (Math.min(s.hunger, s.thirst, s.stamina) >= SETTLER_FED_AT && assignBuildingTask(s, map, "build")) {
           s.activity = "toBuild"
           break
         }
         s.timer -= dt
-        if (s.timer <= 0 && Math.min(s.hunger, s.thirst, s.stamina) >= 80) {
+        if (s.timer <= 0 && Math.min(s.hunger, s.thirst, s.stamina) >= SETTLER_FED_AT) {
           if (!chooseTree(sim, s, map)) s.timer = GAME_HOUR_SECONDS
+        }
+        break
+      }
+      case "toHome":
+      case "sleeping": {
+        if (dt <= 0) break
+        const state = stepBuildingTask(s, map, targetSpeed, dt)
+        if (!state) { s.activity = "idle"; s.timer = GAME_HOUR_SECONDS; break }
+        s.activity = state === "walking" ? "toHome" : "sleeping"
+        // Rise fully rested and fed, so a night at home is worth the walk.
+        // Step outside before looking for work: routes to a tree or a site
+        // cannot cross the house wall.
+        if (state === "sleeping" && Math.min(s.stamina, s.hunger, s.thirst) >= SETTLER_WAKE_AT) {
+          const home = map.buildings.find(b => b.id === s.buildingTask!.buildingId)
+          s.buildingTask = undefined
+          s.constructionReturn = home ? workerRoute(map, s, buildingEntrance(home)) ?? [] : []
+          s.activity = "fromHome"
+        }
+        break
+      }
+      case "fromHome": {
+        if (walkWorker(s, s.constructionReturn ?? [], targetSpeed, dt)) {
+          s.activity = "idle"; s.timer = 0; s.constructionReturn = undefined
+        }
+        break
+      }
+      case "toPost":
+      case "posted": {
+        if (dt <= 0) break
+        const state = stepBuildingTask(s, map, targetSpeed, dt)
+        if (!state) { s.activity = "idle"; s.timer = GAME_HOUR_SECONDS; break }
+        s.activity = state === "walking" ? "toPost" : "posted"
+        // Step away to sleep or eat; the slot stays theirs while they are gone.
+        if (state === "posted" && (s.stamina <= SETTLER_TIRED_AT || Math.min(s.hunger, s.thirst) < SERVING_THRESHOLD)) {
+          s.buildingTask = undefined
+          s.activity = "idle"
+          s.timer = 0
+        }
+        break
+      }
+      case "toTavern": {
+        const visit = s.tavernVisit!
+        const goal = visit.served ? visit.plan.seat!.point : visit.plan.counter.point
+        if (stepOffRoadWalk(s, goal, worldSpeed, dt, map)) {
+          s.activity = visit.served ? "sitting" : "buying"
+          s.timer = visit.served ? TABLE_HOURS * GAME_HOUR_SECONDS : 2
+        }
+        break
+      }
+      case "buying": {
+        s.timer -= dt
+        if (s.timer > 0) break
+        const visit = s.tavernVisit!
+        buyRefreshment(sim, s)
+        visit.served = true
+        const seat = visit.plan.seat
+        const onward = seat && settlementRoute(map, map.buildings, visit.plan.counter.tile, seat.tile, false, true)
+        if (seat && onward) { routeWalk(s, map, onward, seat.point); s.activity = "toTavern" }
+        else leaveTavern(s, map, visit.returnTo ?? currentRoutePoint(map, s))
+        break
+      }
+      case "sitting": {
+        s.timer -= dt
+        if (s.timer <= 0) leaveTavern(s, map, s.tavernVisit!.returnTo ?? currentRoutePoint(map, s))
+        break
+      }
+      case "fromTavern": {
+        const back = s.tavernVisit?.returnTo ?? currentRoutePoint(map, s)
+        if (stepOffRoadWalk(s, back, worldSpeed, dt, map)) {
+          const settled = !!s.employer
+          s.tavernVisit = undefined
+          s.walkFrom = null
+          s.offRoadRoute = null
+          if (settled) { s.activity = "idle"; s.timer = GAME_HOUR_SECONDS }
+          else { s.activity = "walking"; s.visitCooldown = 30 }
         }
         break
       }
@@ -1167,6 +1427,25 @@ export function stepSim(
         if (s.activity === "fleeing") {
           s.fleeTimer -= dt
           if (s.fleeTimer <= 0) s.activity = "walking"
+        }
+        // An empty market stall on the shrine's ground draws a passing vendor
+        // to settle: they leave the road, take the stall, and keep it for good.
+        if (isVendor && !s.employer && !s.track && ahead >= 0 && ahead <= 6 && !s.shrineParking) {
+          const stall = sim.buildings.find(b => BUILDING_KINDS[b.kind].vendorKept && staffOf(sim, b.id).length === 0)
+          if (stall) {
+            s.workSlot = 0
+            if (assignBuildingTask(s, map, "work", stall.id)) {
+              s.employer = stall.id
+              s.jobSlot = 0
+              s.jobless = false
+              s.convoy = false
+              s.stallRoute = undefined
+              s.pasture = undefined
+              s.spot = null
+              s.activity = "toPost"
+              break
+            }
+          }
         }
         // A vendor whose walking stint is up pulls off to the side of the path.
         if (isVendor && !shelter && !s.track) {
@@ -1297,12 +1576,21 @@ export function stepSim(
           // on their approach, so the walking visitor can cover the last stretch.
           if (distance <= worldSpeed * haste * dt || (needsParking && distance <= 12 && crossingTile)) {
             const parkingProgress = needsParking ? s.progress : site.junction
+            // Hunger and thirst only draw anyone in while a counter is open:
+            // the shrine itself keeps no table (see the tavern and the stall).
+            const served = counters.length > 0
             const chance = visitChance({ ...t.attributes, piety: s.piety,
-              hunger: s.hunger, thirst: s.thirst, stamina: s.stamina }, sim.relic, renown, sim.balance)
+              hunger: served ? s.hunger : 100, thirst: served ? s.thirst : 100, stamina: s.stamina },
+              sim.relic, renown, sim.balance)
             s.visitCooldown = 5
             const ordinaryVisit = nextRoll(s) < chance
             const evangelism = ordinaryVisit ? 0 : roadsideEvangelism(map)
             const persuaded = evangelism > 0 && nextRoll(s) < evangelism
+            // A traveler drawn by need heads for the counter, not the relic.
+            // Wagons and horses stay on the road; only walkers turn aside for a meal.
+            if ((ordinaryVisit || persuaded) && served && !needsParking &&
+              Math.min(s.hunger, s.thirst) < hospitalityNeedThreshold(renown, sim.balance) &&
+              startTavernTrip(sim, s, map, counters, null)) break
             const wantsVisit = (ordinaryVisit || persuaded) && s.gold >= admissionFee(map)
             const occupiedSeats = new Set([...sim.travelers.values()].flatMap(other =>
               other.shrineSeat && ["toParking","toRelic","visiting","fromRelic"].includes(other.activity) ? [other.shrineSeat] : []))

--- a/lib/game/tavern.ts
+++ b/lib/game/tavern.ts
@@ -1,0 +1,103 @@
+import { rotateBuildingPoint, rotatedFootprint, buildingEntry } from "./building-rotation"
+import { buildingSupports, placedSupport } from "./character-support"
+import { isComplete } from "./construction"
+import { surfaceHeight } from "./map/bridges"
+import { settlementRoute } from "./settlement-route"
+import { tileToWorldX, tileToWorldZ, worldToTileX, worldToTileZ, type BuildingDef, type GameMap, type TilePos } from "./map/types"
+import { workPost } from "./work-posts"
+
+/**
+ * Where the settlement sells food and drink. The shrine no longer feeds anyone:
+ * a meal and a cup are bought with coin at a counter, and the takings belong to
+ * the settlement (see `SimState.tradeGold`).
+ *
+ * Two counters exist. The tavern serves inside, and its customers carry the
+ * cup to a table and sit down. A market stall kept by a settled vendor serves
+ * over its frontage, and its customers drink standing and walk on.
+ */
+
+export const MEAL_PRICE = 2
+export const DRINK_PRICE = 3
+/** A counter only tops up a meter this low; a cup is not also half a dinner. */
+export const SERVING_THRESHOLD = 60
+
+export interface TavernSeat {
+  id: string
+  tile: TilePos
+  point: { x: number; y: number; z: number }
+  heading: number
+}
+
+/** Completed places with a counter; a stall only counts once a keeper holds it. */
+export function servingHouses(map: GameMap, staffed: (building: BuildingDef) => boolean): BuildingDef[] {
+  return map.buildings.filter(b => isComplete(b)
+    && (b.buildType === "tavern" || b.buildType === "market") && staffed(b))
+}
+
+function localPoint(map: GameMap, building: BuildingDef, x: number, z: number) {
+  const offset = rotateBuildingPoint(x, z, building.rotation)
+  return {
+    x: tileToWorldX(map, building.x) + (building.w - 1) / 2 + offset.x,
+    z: tileToWorldZ(map, building.z) + (building.d - 1) / 2 + offset.z,
+  }
+}
+
+/**
+ * The customers' side of the counter: inside the tavern, facing the servers
+ * across it, or on the stall's own approach tile out in the open.
+ */
+export function servingCounter(map: GameMap, building: BuildingDef): { tile: TilePos; point: { x: number; y: number; z: number } } {
+  if (building.buildType !== "tavern") {
+    const tile = buildingEntry(building)
+    return { tile, point: { x: tileToWorldX(map, tile.x), y: surfaceHeight(map, tile.x, tile.z), z: tileToWorldZ(map, tile.z) } }
+  }
+  const local = rotatedFootprint(building, building.rotation)
+  const post = workPost("tavern", 0, local.w, local.d)!
+  const point = localPoint(map, building, post.x, post.z + local.d * 0.22)
+  const tile = { x: worldToTileX(map, point.x), z: worldToTileZ(map, point.z) }
+  return { tile, point: { ...point, y: surfaceHeight(map, tile.x, tile.z) } }
+}
+
+/** The authored bench places, in the order visitors take them. */
+export function tavernSeats(map: GameMap, building: BuildingDef): TavernSeat[] {
+  if (building.buildType !== "tavern") return []
+  return buildingSupports(building, map)
+    .filter(support => support.clips.includes("sitting"))
+    .map(support => {
+      const placed = placedSupport(map, building, support)
+      const tile = { x: worldToTileX(map, placed.anchor.x), z: worldToTileZ(map, placed.anchor.z) }
+      return { id: support.id, tile, heading: placed.heading,
+        point: { x: placed.anchor.x, y: surfaceHeight(map, tile.x, tile.z), z: placed.anchor.z } }
+    })
+}
+
+export interface TavernPlan {
+  buildingId: string
+  counter: { tile: TilePos; point: { x: number; y: number; z: number } }
+  seat: TavernSeat | null
+  /** Tiles from the customer's own position to the counter. */
+  route: TilePos[]
+}
+
+/**
+ * Reserve a table before setting out, and only promise a trip that can actually
+ * be walked: to the counter first, and on to the seat afterwards.
+ */
+export function tavernVisitPlan(
+  map: GameMap,
+  building: BuildingDef,
+  from: TilePos,
+  occupied: ReadonlySet<string> = new Set(),
+): TavernPlan | null {
+  const counter = servingCounter(map, building)
+  const route = settlementRoute(map, map.buildings, from, counter.tile, false, true)
+  if (!route) return null
+  const seats = tavernSeats(map, building).filter(seat => !occupied.has(`${building.id}:${seat.id}`))
+  if (building.buildType !== "tavern") return { buildingId: building.id, counter, seat: null, route }
+  for (const seat of seats) {
+    if (settlementRoute(map, map.buildings, counter.tile, seat.tile, false, true)) {
+      return { buildingId: building.id, counter, seat, route }
+    }
+  }
+  return null
+}

--- a/lib/game/work-posts.ts
+++ b/lib/game/work-posts.ts
@@ -1,0 +1,24 @@
+/**
+ * Where a posted worker stands inside their workplace. Leaf data with no
+ * imports, so both the building catalogue and the task planner can read it
+ * without pulling each other in.
+ *
+ * Offsets are fractions of the authored footprint, measured from its centre in
+ * the building's own local frame (+Z is the front, where the door is), so a
+ * resized or rotated building keeps its posts.
+ */
+export const WORK_POSTS: Record<string, readonly (readonly [number, number])[]> = {
+  // Either side of the serving counter, which stands at (width×.2, -depth×.14).
+  tavern: [[0.06, -0.30], [0.34, -0.30]],
+  // Out in the open fold, clear of the water trough and the gate.
+  "sheep-pen": [[0.14, -0.10], [0.32, 0.18]],
+  // Behind the stall counter at the front of the footprint.
+  market: [[0, 0.02]],
+}
+
+export function workPost(type: string | undefined, slot: number, w: number, d: number): { x: number; z: number } | null {
+  const posts = type ? WORK_POSTS[type] : undefined
+  if (!posts?.length) return null
+  const [x, z] = posts[((slot % posts.length) + posts.length) % posts.length]
+  return { x: x * w, z: z * d }
+}

--- a/lib/game/workshop-layout.ts
+++ b/lib/game/workshop-layout.ts
@@ -11,3 +11,9 @@ export function workshopPileOffset(slot: number, width: number, depth: number): 
   return [layout.storageX,
     (Math.floor(slot / 2) - .5) * layout.bayDepth + (slot % 2 - .5) * layout.bayDepth * .4]
 }
+
+/** The sheep pen: one tile of hut on the left, the open fold across the rest. */
+export function sheepPenLayout(width: number) {
+  const coreWidth = Math.min(width, Math.max(1, width / 3))
+  return { coreWidth, coreX: -width / 2 + coreWidth / 2, penLeft: -width / 2 + coreWidth }
+}

--- a/lib/path-lab/town.ts
+++ b/lib/path-lab/town.ts
@@ -9,10 +9,10 @@ export const TOWN_SETTINGS = { ...DEFAULT_PATH_SETTINGS, traffic: 0 }
 export interface TownSite extends BuildingDef { purpose: string; workplace?: boolean }
 const site = (id: string, label: string, x: number, z: number, buildType: string, purpose: string, workplace = false): TownSite => ({ id, label, x, z, w: 2, d: 2, height: .85, color: "#ad9672", roofColor: "#786140", rotation: 0, buildType, purpose, workplace })
 export const TOWN_SITES: TownSite[] = [
-  site("home-0", "Willow cottage", 5, 5, "shepherd-hut", "Home to Ada, Oswin and Edith"),
-  site("home-1", "Ash cottage", 5, 11, "shepherd-hut", "Home to Leof, Wulf and Alys"),
-  site("home-2", "Orchard cottage", 11, 3, "shepherd-hut", "Home to Eda, Cuth and Hild"),
-  site("home-3", "Roadside cottage", 11, 12, "shepherd-hut", "Home to Alden, Maud and Godric"),
+  site("home-0", "Willow cottage", 5, 5, "house", "Home to Ada, Oswin and Edith"),
+  site("home-1", "Ash cottage", 5, 11, "house", "Home to Leof, Wulf and Alys"),
+  site("home-2", "Orchard cottage", 11, 3, "house", "Home to Eda, Cuth and Hild"),
+  site("home-3", "Roadside cottage", 11, 12, "house", "Home to Alden, Maud and Godric"),
   site("timber", "Wood yard", 24, 4, "workshop", "Woodworkers carry fuel to the bakehouse", true),
   site("granary", "Granary", 26, 11, "storehouse", "Porters carry grain to the bakehouse and market", true),
   site("bakehouse", "Bakehouse", 20, 11, "hall", "Bakers collect grain, bake and carry bread to market", true),

--- a/public/assets/buildings/style-guide.md
+++ b/public/assets/buildings/style-guide.md
@@ -16,7 +16,7 @@ Construction context: [West Stow Anglo-Saxon village](https://www.weststow.org/a
 | --- | --- | --- |
 | Relic enclosure | 3×3 | No roof; low timber walls and an open gate on every side; rough flags, stone table, planks and scattered belongings |
 | Monks’ shelter | 3×2 | Open front, thatched gable, woven windbreaks, straw bedding and blankets |
-| Shepherd’s hut | 2×2 | Compact earthen/wattle hut with a plank door and steep thatch |
+| House | 2×2 | Compact earthen/wattle hut with a plank door, steep thatch, a hearth and two straw beds |
 | Raised store | 1×1 | Timber legs, plank floor and walls, grain sack, small thatched gable |
 | Wood shelter | 2×1 | Open lean-to with stacked wood and woven screens |
 


### PR DESCRIPTION
The shepherd's hut is now the **house**, and it is where settled villagers sleep: each settler moves into a specific house when they take a job, keeps their own bed (two to a house, as the artwork decides), and walks home to sleep and eat.

The shrine no longer feeds anyone — food and drink are bought at a counter for coin, credited to the treasury separately from admission. The **tavern** hires two behind its counter and its customers pay there before carrying the cup to an authored bench and sitting down; a passing vendor settles into an empty **market stall** and keeps it, which makes that stall a counter too, and hunger only draws a traveler off the road while some counter is actually open.

The new **sheep pen** (3×2, two herding jobs) is half a house — log walls, plank door, lintel and hearth — beside an open railed fold with a water trough and spare hurdles, with no roof and none of the woodcutter's timber bays or firewood; the flock is still to come, and the sprites currently being faked are listed in `docs/art/settlement-sprites-todo.md`.

One judgement call worth review: with free food removed, a settler with no tavern would have starved to a standstill, so sleeping at home restores hunger and thirst slowly and for nothing, leaving the counter as the fast option and the only one open to a traveler off the road. Full suite green (124 files, 1152 tests, including six new ones covering seating, staffing, bed allocation and the stall takeover); types and production build clean; verified live over six game days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)