### PR TITLE
Keep the earth floor under the building, not in front of the door

### DIFF
--- a/lib/game/building-art/dirt-floor.test.ts
+++ b/lib/game/building-art/dirt-floor.test.ts
@@ -17,20 +17,21 @@ describe("shared path dirt for building floors", () => {
     expect(structureParts({...hut,buildType:"enclosure"}).find(p=>p.name === "floor")?.surface).toBeUndefined()
   })
 
-  it.each([0,1,2,3] as BuildingRotation[])("covers the rotated footprint, its entrance tile and their worn borders (%i)", rotation => {
+  it.each([0,1,2,3] as BuildingRotation[])("covers the rotated footprint and its worn border, but not the entrance tile (%i)", rotation => {
     const building={...hut,...rotatedFootprint(hut,rotation),rotation}, map=mapWith([building])
     const {data,tiles}=dirtFloorMask(map), entry=buildingApproach(map,building)!
     for (let z=0;z<map.depth;z++) for (let x=0;x<map.width;x++) {
       const inside=x>=building.x && x<building.x+building.w && z>=building.z && z<building.z+building.d
-      expect(data[(z*map.width+x)*4+1] === 255).toBe(inside || x===entry.x && z===entry.z)
+      expect(data[(z*map.width+x)*4+1] === 255).toBe(inside)
       if (tiles.has(z*map.width+x)) {
-        expect(x).toBeGreaterThanOrEqual(Math.min(building.x,entry.x)-1)
-        expect(x).toBeLessThanOrEqual(Math.max(building.x+building.w,entry.x+1))
-        expect(z).toBeGreaterThanOrEqual(Math.min(building.z,entry.z)-1)
-        expect(z).toBeLessThanOrEqual(Math.max(building.z+building.d,entry.z+1))
+        expect(x).toBeGreaterThanOrEqual(building.x-1)
+        expect(x).toBeLessThanOrEqual(building.x+building.w)
+        expect(z).toBeGreaterThanOrEqual(building.z-1)
+        expect(z).toBeLessThanOrEqual(building.z+building.d)
       }
     }
-    const west=(building.z*map.width+Math.min(building.x,entry.x)-1)*4
+    expect(data[(entry.z*map.width+entry.x)*4+1]).toBe(0)
+    const west=(building.z*map.width+building.x-1)*4
     expect(data[west] & 1<<FLOOR_NEIGHBOURS.findIndex(([x,z])=>x===1 && z===0)).not.toBe(0)
   })
 
@@ -47,7 +48,7 @@ describe("shared path dirt for building floors", () => {
     for(const b of map.buildings) {
       expect(mask.data[(b.z*map.width+b.x)*4+1]).toBe(0)
       const entry=buildingApproach(map,b)!
-      expect(mask.data[(entry.z*map.width+entry.x)*4+2]).toBe(255)
+      expect(mask.data[(entry.z*map.width+entry.x)*4+1]).toBe(0)
     }
     map.buildings.push({...hut,z:7})
     map.tiles[6*map.width+3]="water"
@@ -55,11 +56,8 @@ describe("shared path dirt for building floors", () => {
   })
 })
 
-it.each([0,1,2,3] as BuildingRotation[])("paints both tavern approaches at rotation %i",rotation=>{
+it.each([0,1,2,3] as BuildingRotation[])("keeps both tavern approaches clear of dirt at rotation %i",rotation=>{
   const tavern={...hut,buildType:"tavern",...rotatedFootprint({w:3,d:4},rotation),rotation}
   const map=mapWith([tavern]),mask=dirtFloorMask(map)
-  for(const entry of buildingApproaches(map,tavern)) {
-    expect(mask.data[(entry.z*map.width+entry.x)*4+1]).toBe(255)
-    expect(mask.data[(entry.z*map.width+entry.x)*4+2]).toBe(255)
-  }
+  for(const entry of buildingApproaches(map,tavern)) expect(mask.data[(entry.z*map.width+entry.x)*4+1]).toBe(0)
 })

--- a/lib/game/building-art/dirt-floor.ts
+++ b/lib/game/building-art/dirt-floor.ts
@@ -1,4 +1,3 @@
-import { buildingApproaches } from "../building-rotation"
 import type { GameMap } from "../map/types"
 import { TILE_HEIGHT } from "../map/terrain"
 
@@ -14,12 +13,8 @@ export const FLOOR_NEIGHBOURS = [[1,0],[-1,0],[0,1],[0,-1],[1,1],[1,-1],[-1,1],[
 /** One texture lookup identifies the union of adjacent dirt plots, without internal seams. */
 export function dirtFloorMask(map: GameMap) {
   const occupied = new Uint8Array(map.width * map.depth)
-  const entries = new Set<number>()
   for (const building of map.buildings) {
-    for(const entry of buildingApproaches(map,building)) if(entry.x>=0 && entry.z>=0 && entry.x<map.width && entry.z<map.depth) {
-      occupied[entry.z*map.width+entry.x]=1
-      entries.add(entry.z*map.width+entry.x)
-    }
+    // The floor stops at the walls: no worn approach in front of the door.
     if (building.id === map.site?.hovelId || !hasDirtFloor(building.buildType)) continue
     for (let z=building.z;z<building.z+building.d;z++) for (let x=building.x;x<building.x+building.w;x++) {
       if (x>=0 && z>=0 && x<map.width && z<map.depth) occupied[z*map.width+x]=1
@@ -39,7 +34,6 @@ export function dirtFloorMask(map: GameMap) {
     })
     data[index*4]=neighbours
     data[index*4+1]=occupied[index] ? 255 : 0
-    data[index*4+2]=entries.has(index) ? 255 : 0
     if (occupied[index] || neighbours) tiles.add(index)
   }
   return { data, tiles }


### PR DESCRIPTION
The dirt floor mask painted each building's approach tile as well as its footprint, so every doorway grew a square patch of dirt on the tile in front of it. `dirtFloorMask` now fills only the rotated footprint, leaving the entrance tile as ordinary ground — the small worn apron still frays the footprint edge, and storehouses, enclosures and the shrine hovel are unaffected as before. The mask texture's blue entrance channel goes with it, since the terrain shader only ever sampled red and green. Tests that asserted the approach tile was painted now assert it stays clear, including both tavern approaches at all four rotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)