### PR TITLE
Trace people and road verges through the trees that hide them

### DIFF
--- a/components/game/character-selection.tsx
+++ b/components/game/character-selection.tsx
@@ -1,14 +1,29 @@
 "use client"
 
-import { useLayoutEffect, useMemo, useRef } from "react"
+import { useEffect, useLayoutEffect, useMemo, useRef } from "react"
 import { createPortal, useFrame, useThree } from "@react-three/fiber"
 import * as THREE from "three"
 import { PixelCharacters } from "@/components/pixel-canvas"
 import { surfaceHeight } from "@/lib/game/map/bridges"
 import { worldToTileX, worldToTileZ, type GameMap } from "@/lib/game/map/types"
-import { SELECTION_COLOR } from "@/lib/game/selection"
+import { prioritizePeople, SELECTION_COLOR } from "@/lib/game/selection"
 import { SELECTED_CHARACTER_LAYER } from "@/lib/game/render/outline"
 import type { FigureClickHandler } from "./traveler-figure"
+
+/**
+ * Clicks pick the person under the pointer before the scenery in front of them,
+ * so a walker stays reachable through the crowns and walls that hide them.
+ * Mounted once per scene; every monk and traveler group marks itself with
+ * `markPerson`.
+ */
+export function PersonPicking() {
+  const setEvents = useThree((s) => s.setEvents)
+  useEffect(() => {
+    setEvents({ filter: prioritizePeople })
+    return () => setEvents({ filter: undefined })
+  }, [setEvents])
+  return null
+}
 
 /** A generous click volume shared by monks and travelers, without visible geometry. */
 export function CharacterHitTarget({ onClick }: { onClick: FigureClickHandler }) {

--- a/components/game/game-canvas.tsx
+++ b/components/game/game-canvas.tsx
@@ -34,6 +34,7 @@ import { Buildings } from "./buildings"
 import { BuildInfluenceOverlay } from "./build-influence-overlay"
 import { CameraLight } from "./camera-light"
 import { CameraRig } from "./camera-rig"
+import { PersonPicking } from "./character-selection"
 import { DebugHandle } from "./debug-handle"
 import { Environment } from "./environment"
 import { Monks } from "./monks"
@@ -170,6 +171,7 @@ export function GameCanvas({
       <BuildInfluenceOverlay map={map} buildMode={!!buildType} />
 
       <CameraRig map={map} onPlace={buildType ? onPlace : undefined} />
+      <PersonPicking />
       <OutlinePass objects={{ buildings: map.buildings, travelers, monks }} />
       <DebugHandle characterScale={characterScale} map={map} travelers={travelers} speed={walkSpeed} speedScales={speedScales} movement={movement} />
     </PixelCanvas>

--- a/components/game/monks.tsx
+++ b/components/game/monks.tsx
@@ -21,7 +21,7 @@ import * as THREE from "three"
 
 import { useSimulationStore } from "@/lib/game/simulation-store"
 import { isSelected, useCameraStore } from "@/lib/game/camera-store"
-import { selectElement } from "@/lib/game/selection"
+import { markPerson, selectElement } from "@/lib/game/selection"
 import { CharacterHitTarget, CharacterSelectionShadow } from "./character-selection"
 import type { GameMap } from "@/lib/game/map/types"
 import { monkStaminaRegistry, monkRegistry, monkPositionRegistry, type Monk, type MonkActivity } from "@/lib/game/monks"
@@ -283,6 +283,7 @@ export function Monks({ map, monks, relic, flying = false, characterScale = 1 }:
           <group
             key={monk.id}
             ref={(node) => {
+              markPerson(node)
               groupRefs.current[index] = node
             }}
           >

--- a/components/game/outline-pass.tsx
+++ b/components/game/outline-pass.tsx
@@ -3,21 +3,37 @@
 import { useEffect, useMemo } from "react"
 import { useThree } from "@react-three/fiber"
 import * as THREE from "three"
-import { usePixelScene } from "@/components/pixel-canvas"
-import { CHARACTER_ID_LAYER } from "@/lib/game/render/pixel-characters"
+import { usePixelCharacterRoots, usePixelScene } from "@/components/pixel-canvas"
+import { CHARACTER_COLOR_LAYER, CHARACTER_ID_LAYER } from "@/lib/game/render/pixel-characters"
 
 import { useCameraStore } from "@/lib/game/camera-store"
 import { useBuildStore } from "@/lib/game/build-store"
 import { SELECTION_OUTLINE_COLOR, SELECTION_OUTLINE_OPACITY, SELECTION_FILL, SELECTION_FILL_OPACITY, selectionObjectId } from "@/lib/game/selection"
 import {
   OUTLINE_ID_LAYER,
+  ROAD_EDGE_LAYER,
   SELECTED_CHARACTER_LAYER,
   MAX_OBJECT_ID,
+  RELIC_OBJECT_ID,
   type OutlineMode,
 } from "@/lib/game/render/outline"
 
 /** Warm near-black, so lines read as ink rather than dead pixels. */
 const OUTLINE_COLOR = "#120b05"
+
+/**
+ * How much of a person shows through the tree hiding them. Half strength keeps
+ * the trunk or crown in front readable while the walker behind stays followable
+ * — the same masking the selected character already gets behind any occluder.
+ */
+const CHARACTER_MASK_OPACITY = 0.5
+
+/**
+ * How strongly the road's edge line comes back through the canopy. Much
+ * fainter than the line on the open road — enough to follow where the road
+ * runs under the trees, never enough to read as a line drawn on them.
+ */
+const ROAD_EDGE_MASK_OPACITY = 0.5
 
 const MODE_INT: Record<OutlineMode, number> = { off: 0, overlap: 1, silhouette: 2 }
 
@@ -47,6 +63,15 @@ const FRAGMENT_SHADER = /* glsl */ `
   uniform sampler2D tDepth;
   uniform sampler2D tCharacter;
   uniform sampler2D tCharacterDepth;
+  uniform sampler2D tMasked;
+  uniform sampler2D tMaskedDepth;
+  uniform sampler2D tRoadEdge;
+  uniform bool uRoadEdges;
+  uniform float uRoadEdgeOpacity;
+  uniform bool uMaskCharacters;
+  uniform float uMaskOpacity;
+  uniform float uTreeIdMin;
+  uniform float uTreeIdMax;
   uniform bool uCharacterSelected;
   uniform bool uCharacterPass;
   uniform float uCharacterIdMin;
@@ -121,6 +146,27 @@ const FRAGMENT_SHADER = /* glsl */ `
         finishColor(); return;
       }
     }
+    // Trees give way to the people walking behind them: where an unoccluded
+    // character sits behind a trunk or a crown, the figure returns at half
+    // strength. Only trees relent — terrain writes ID 0 and buildings own
+    // their own ID block, so hills and walls still hide whoever is behind.
+    if (uMaskCharacters && idC >= uTreeIdMin && idC <= uTreeIdMax) {
+      vec4 masked = texture2D(tMasked, pixelUv);
+      if (masked.a > 0.5 && texture2D(tMaskedDepth, pixelUv).x > dC + 1.0e-5) {
+        gl_FragColor = vec4(masked.rgb, uMaskOpacity);
+        finishColor(); return;
+      }
+    }
+    // The road keeps its verge through the wood: the edge line, drawn over the
+    // terrain's own depth, comes back in ink wherever a tree stands in front of
+    // it, so a road's course still reads under the canopy.
+    if (uRoadEdges && idC >= uTreeIdMin && idC <= uTreeIdMax) {
+      float verge = texture2D(tRoadEdge, pixelUv).r;
+      if (verge > 0.004) {
+        gl_FragColor = vec4(uColor, verge * uRoadEdgeOpacity);
+        finishColor(); return;
+      }
+    }
     if (!uCharacterSelected && uSelectedId > 0.5 && abs(idC - uSelectedId) < 0.5) {
       gl_FragColor = vec4(uSelectionFill, uSelectionOpacity);
       finishColor(); return;
@@ -153,6 +199,7 @@ const FRAGMENT_SHADER = /* glsl */ `
 
 export function OutlinePass({ objects }: { objects?: Omit<Parameters<typeof selectionObjectId>[1], "piles"> }) {
   const { gl, scene } = useThree()
+  const characterRoots = usePixelCharacterRoots()
 
   // ID + depth buffer at drawing-buffer resolution. Nearest filtering is load-
   // bearing: interpolated ID colours would decode as phantom objects.
@@ -176,6 +223,23 @@ export function OutlinePass({ objects }: { objects?: Omit<Parameters<typeof sele
   const displayTarget = useMemo(() => new THREE.WebGLRenderTarget(1, 1, {
     minFilter: THREE.NearestFilter, magFilter: THREE.NearestFilter,
     generateMipmaps: false, depthTexture: new THREE.DepthTexture(1, 1),
+  }), [])
+
+  // The road's edge line over the terrain's depth alone: no trees, no
+  // buildings, so what a crown hides is still in the buffer. Coverage lands in
+  // the red channel, so the terrain's black ID copy reads as "no line here".
+  const roadEdgeTarget = useMemo(() => new THREE.WebGLRenderTarget(1, 1, {
+    minFilter: THREE.NearestFilter, magFilter: THREE.NearestFilter, generateMipmaps: false,
+  }), [])
+
+  // Every character drawn on its own, free of the world's depth, so the
+  // composite can put the hidden part of a walker back over the trees.
+  const maskTarget = useMemo(() => new THREE.WebGLRenderTarget(1, 1, {
+    minFilter: THREE.NearestFilter,
+    magFilter: THREE.NearestFilter,
+    type: THREE.HalfFloatType,
+    generateMipmaps: false,
+    depthTexture: new THREE.DepthTexture(1, 1),
   }), [])
 
   // Copy encoded world IDs without colour conversion, using exactly the same
@@ -214,10 +278,13 @@ export function OutlinePass({ objects }: { objects?: Omit<Parameters<typeof sele
       characterTarget.dispose()
       displayTarget.depthTexture?.dispose()
       displayTarget.dispose()
+      maskTarget.depthTexture?.dispose()
+      maskTarget.dispose()
+      roadEdgeTarget.dispose()
       worldIds.geometry.dispose()
       worldIds.material.dispose()
     },
-    [target, characterTarget, displayTarget, worldIds],
+    [target, characterTarget, displayTarget, maskTarget, roadEdgeTarget, worldIds],
   )
 
   const pass = useMemo(() => {
@@ -226,6 +293,16 @@ export function OutlinePass({ objects }: { objects?: Omit<Parameters<typeof sele
       tDepth: { value: null as THREE.Texture | null },
       tCharacter: { value: characterTarget.texture },
       tCharacterDepth: { value: characterTarget.depthTexture },
+      tMasked: { value: maskTarget.texture },
+      tMaskedDepth: { value: maskTarget.depthTexture },
+      tRoadEdge: { value: roadEdgeTarget.texture },
+      uRoadEdges: { value: false },
+      uRoadEdgeOpacity: { value: ROAD_EDGE_MASK_OPACITY },
+      uMaskCharacters: { value: false },
+      uMaskOpacity: { value: CHARACTER_MASK_OPACITY },
+      // Trees own the ID block between the buildings and the relic.
+      uTreeIdMin: { value: 1 },
+      uTreeIdMax: { value: RELIC_OBJECT_ID - 1 },
       uCharacterSelected: { value: false },
       uCharacterPass: { value: false },
       uCharacterIdMin: { value: MAX_OBJECT_ID - 0x2000 + 1 },
@@ -258,7 +335,7 @@ export function OutlinePass({ objects }: { objects?: Omit<Parameters<typeof sele
     quadScene.add(mesh)
     const quadCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1)
     return { uniforms, geometry, material, quadScene, quadCamera }
-  }, [characterTarget])
+  }, [characterTarget, maskTarget, roadEdgeTarget])
 
   useEffect(
     () => () => {
@@ -279,8 +356,14 @@ export function OutlinePass({ objects }: { objects?: Omit<Parameters<typeof sele
     const characterPass = stage.phase === "characters"
     const selectionInOtherPass = (stage.phase === "world" && selectingCharacter) || (characterPass && !selectingCharacter)
     const selectedId = selectionInOtherPass ? 0 : requestedId
+    // Masking people through trees reads the same world IDs and depth, so both
+    // passes prepare them whenever anyone is on the map, outlines off or not.
+    const maskCharacters = characterRoots.size > 0
+    // Trees hide the roads under them in the same pass they are drawn in.
+    const roadEdgePass = !characterPass
     // The world ID/depth is also needed when only a character is selected.
-    const needsOutline = mode !== "off" || requestedId !== 0
+    const needsOutline = mode !== "off" || requestedId !== 0 || maskCharacters || roadEdgePass
+    const maskPass = characterPass && maskCharacters
     const characterSelected = selectedId !== 0 && selectingCharacter
     const ids = characterPass ? displayTarget : target
     const background = scene.background
@@ -314,6 +397,22 @@ export function OutlinePass({ objects }: { objects?: Omit<Parameters<typeof sele
           gl.clear()
           gl.render(scene, camera)
         }
+        if (roadEdgePass) {
+          roadEdgeTarget.setSize(ids.width, ids.height)
+          gl.setClearColor(0x000000, 0)
+          camera.layers.set(ROAD_EDGE_LAYER)
+          gl.setRenderTarget(roadEdgeTarget)
+          gl.clear()
+          gl.render(scene, camera)
+        }
+        if (maskPass) {
+          maskTarget.setSize(ids.width, ids.height)
+          gl.setClearColor(0x000000, 0)
+          camera.layers.set(CHARACTER_COLOR_LAYER)
+          gl.setRenderTarget(maskTarget)
+          gl.clear()
+          gl.render(scene, camera)
+        }
       }
       camera.layers.mask = mask
       gl.setClearColor(prevClearColor, clearAlpha)
@@ -336,6 +435,9 @@ export function OutlinePass({ objects }: { objects?: Omit<Parameters<typeof sele
         pass.uniforms.uSelectedId.value = selectedId
         pass.uniforms.uCharacterSelected.value = characterSelected
         pass.uniforms.uCharacterPass.value = characterPass
+        pass.uniforms.uMaskCharacters.value = maskPass
+        pass.uniforms.uRoadEdges.value = roadEdgePass
+        pass.uniforms.uTreeIdMin.value = (objects?.buildings.length ?? 0) + 1
         gl.render(pass.quadScene, pass.quadCamera)
       }
     } finally {

--- a/components/game/terrain-tiles.tsx
+++ b/components/game/terrain-tiles.tsx
@@ -36,7 +36,7 @@ import {
   type TerrainId,
 } from "@/lib/game/map/terrain"
 import { tileAt, tileToWorldX, tileToWorldZ, type GameMap } from "@/lib/game/map/types"
-import { OUTLINE_ID_LAYER_MASK } from "@/lib/game/render/outline"
+import { OUTLINE_ID_LAYER_MASK, ROAD_EDGE_LAYER_MASK } from "@/lib/game/render/outline"
 import { diagonalRoadSegments, roadSegmentWear, type RoadSegment } from "@/lib/game/render/road-segments"
 import { ROAD_SHAPE_GLSL } from "@/lib/game/render/road-shape"
 import { DEFAULT_TRAFFIC } from "@/lib/game/travelers"
@@ -142,6 +142,12 @@ interface TileMaterialOptions {
    */
   gridOrigin?: { x: number; z: number }
   road?: RoadSurface
+  /**
+   * Draw nothing but the road's edge line, as coverage in the red channel.
+   * The outline pass renders this over the terrain's own depth, then traces
+   * the line back faintly wherever a tree stands in front of it.
+   */
+  edgeOnly?: boolean
 }
 
 /**
@@ -204,6 +210,7 @@ function makeTileMaterial({
   cliffTexture,
   gridOrigin,
   road,
+  edgeOnly = false,
 }: TileMaterialOptions): THREE.MeshLambertMaterial {
   const material = new THREE.MeshLambertMaterial()
   material.onBeforeCompile = (shader) => {
@@ -421,6 +428,7 @@ function makeTileMaterial({
             float px = max(fwidth(d), 0.00001);
             float halfLine = 0.5 * roadEdgeWidth * roadPixelRatio * px;
             float line = (1.0 - smoothstep(halfLine - 0.5 * px, halfLine + 0.5 * px, abs(d - edge))) * roadEdgeLine * (1.0 - shore);
+            ${edgeOnly ? "diffuseColor.a = line * roadOpacity * segmentOpacity * vGridTop;" : ""}
 
             vec3 top = mix(landTop, road, cover) * (1.0 - 0.75 * line * roadOpacity * segmentOpacity);
             // Layer broad earth stains with pixel-sized grit on building plots and aprons.
@@ -459,15 +467,29 @@ function makeTileMaterial({
           #endif
         }`,
       )
+    // Nothing but the line: no lighting, no surface, no colour conversion —
+    // just its coverage, for the outline pass to lay over the trees.
+    if (edgeOnly) {
+      shader.fragmentShader = shader.fragmentShader
+        .replace("#include <opaque_fragment>", "gl_FragColor = vec4(diffuseColor.a, 0.0, 0.0, 1.0);")
+    }
   }
   material.defines = {
     ...(road ? { USE_ROAD_MAP: "" } : {}),
     ...(gridOrigin ? { USE_GRID: "" } : {}),
   }
+  if (edgeOnly) {
+    material.toneMapped = false
+    // The line sits on the same tile tops the terrain's depth copy draws, so
+    // pull it a touch forward; a hill in front is still far nearer and wins.
+    material.polygonOffset = true
+    material.polygonOffsetFactor = -1
+    material.polygonOffsetUnits = -1
+  }
   // The grid origin is baked into the shader source, so it has to be part of
   // the program key or two maps of different sizes would share one program.
   const gridKey = gridOrigin ? `${gridOrigin.x.toFixed(3)}:${gridOrigin.z.toFixed(3)}` : "nogrid"
-  material.customProgramCacheKey = () => `tiles-${road ? "road" : "ground"}-${gridKey}-dirt-floors`
+  material.customProgramCacheKey = () => `tiles-${road ? "road" : "ground"}-${gridKey}-dirt-floors${edgeOnly ? "-edge" : ""}`
   return material
 }
 
@@ -649,6 +671,7 @@ export function TerrainTiles({
 }) {
   const groundMeshRef = useRef<THREE.InstancedMesh>(null)
   const roadMeshRef = useRef<THREE.InstancedMesh>(null)
+  const edgeMeshRef = useRef<THREE.InstancedMesh>(null)
   const idMeshRef = useRef<THREE.InstancedMesh>(null)
   const count = map.width * map.depth
 
@@ -767,6 +790,19 @@ export function TerrainTiles({
     [grass, dirt, gridOrigin, roadTexture, trailTexture, tier, lookUniforms, segmentData, floorTexture],
   )
   useEffect(() => () => roadMaterial.dispose(), [roadMaterial])
+  // The same road surface reduced to its edge line, for the outline pass.
+  const edgeMaterial = useMemo(
+    () =>
+      makeTileMaterial({
+        grassTexture: grass,
+        cliffTexture: dirt,
+        gridOrigin,
+        road: { texture: roadTexture, edgeWear: tier.edgeWear, look: lookUniforms, segments: segmentData.texture, floors: floorTexture, trail: trailTexture, isDirt: tier.tier === 0 },
+        edgeOnly: true,
+      }),
+    [grass, dirt, gridOrigin, roadTexture, trailTexture, tier, lookUniforms, segmentData, floorTexture],
+  )
+  useEffect(() => () => edgeMaterial.dispose(), [edgeMaterial])
 
   const floor = useMemo(() => (map.elevation?.height.reduce((a, b) => Math.min(a, b), SLAB_TOP) ?? SLAB_TOP) - 0.02, [map.elevation])
   const idGeometry = useMemo(() => makeTileGeometry(count), [count])
@@ -786,8 +822,9 @@ export function TerrainTiles({
   useLayoutEffect(() => {
     const groundMesh = groundMeshRef.current
     const roadMesh = roadMeshRef.current
+    const edgeMesh = edgeMeshRef.current
     const idMesh = idMeshRef.current
-    if (!groundMesh || !roadMesh || !idMesh) {
+    if (!groundMesh || !roadMesh || !edgeMesh || !idMesh) {
       return
     }
 
@@ -912,6 +949,9 @@ export function TerrainTiles({
             target.corners.setXYZW(i, corners[0], corners[1], corners[2], corners[3])
             target.mesh.setMatrixAt(i, matrix)
             target.mesh.setColorAt(i, color)
+            // The edge copy shares the road geometry and its instance data;
+            // only the transform lives on the mesh.
+            edgeMesh.setMatrixAt(i, matrix)
             target.overlay.setXYZW(i, tint.r, tint.g, tint.b, shoulderOnly ? TERRAIN.path.shadeBlend : def.shadeBlend)
             // -1 is a diagonal entrance, 0 an ordinary entrance, 1 open land.
             target.open.setXYZW(i, edge.open[0] - edge.diagonal[0], edge.open[1] - edge.diagonal[1],
@@ -976,9 +1016,11 @@ export function TerrainTiles({
       target.shorePaint.needsUpdate = true
     }
     attr(idGeometry, "aCorners").needsUpdate = true
+    edgeMesh.instanceMatrix.needsUpdate = true
     idMesh.instanceMatrix.needsUpdate = true
     // Recompute bounds after map edits for correct culling and picking.
     for (const target of [...roadTargets, ...groundTargets]) target.mesh.computeBoundingSphere()
+    edgeMesh.computeBoundingSphere()
     idMesh.computeBoundingSphere()
   }, [
     map,
@@ -1039,6 +1081,24 @@ export function TerrainTiles({
       </instancedMesh>
 
       {/*
+        The road's edge line alone (see ROAD_EDGE_LAYER). It shares the road
+        geometry, so the ragged line lands exactly where the visible one does;
+        the terrain's ID copy below joins this pass to supply the depth, so a
+        hill hides the verge behind it just as it does on screen.
+      */}
+      <instancedMesh
+        key={`edge-${tier.id}`}
+        visible={roadCount > 0}
+        frustumCulled={false}
+        ref={edgeMeshRef}
+        args={[undefined as unknown as THREE.BufferGeometry, undefined as unknown as THREE.Material, roadCount]}
+        layers-mask={ROAD_EDGE_LAYER_MASK}
+      >
+        <primitive object={roadGeometry} attach="geometry" />
+        <primitive object={edgeMaterial} attach="material" />
+      </instancedMesh>
+
+      {/*
         Terrain in the outline pass: ID 0 (black), depth only. It takes no
         outline itself, but its depth stops hidden object seams — say two
         buildings overlapping *behind* a hill — from drawing lines through it.
@@ -1051,7 +1111,7 @@ export function TerrainTiles({
         frustumCulled={false}
         ref={idMeshRef}
         args={[undefined as unknown as THREE.BufferGeometry, undefined as unknown as THREE.Material, count]}
-        layers-mask={OUTLINE_ID_LAYER_MASK}
+        layers-mask={OUTLINE_ID_LAYER_MASK | ROAD_EDGE_LAYER_MASK}
       >
         <primitive object={idGeometry} attach="geometry" />
         <primitive object={idMaterial} attach="material" />

--- a/components/game/travelers.tsx
+++ b/components/game/travelers.tsx
@@ -10,7 +10,7 @@ import * as THREE from "three"
 import { travelerAppearance } from "@/lib/game/base-person/population"
 import { isSelected, useCameraStore } from "@/lib/game/camera-store"
 import { useSimulationStore } from "@/lib/game/simulation-store"
-import { selectElement } from "@/lib/game/selection"
+import { markPerson, selectElement } from "@/lib/game/selection"
 import { CharacterHitTarget, CharacterSelectionShadow } from "./character-selection"
 import { useBalanceStore } from "@/lib/game/balance-store"
 import { woodcutterHuts } from "@/lib/game/settlement"
@@ -243,6 +243,7 @@ export function Travelers({
             <group
               key={traveler.id}
               ref={(node) => {
+                markPerson(node)
                 groupRefs.current[index] = node
               }}
             >

--- a/components/pixel-canvas.tsx
+++ b/components/pixel-canvas.tsx
@@ -39,6 +39,13 @@ export function usePixelWorldTexel() {
   return useContext(PixelRenderContext)?.worldTexel ?? NATIVE_WORLD_TEXEL
 }
 
+const NO_CHARACTERS: ReadonlySet<THREE.Object3D> = new Set()
+
+/** The live character roots, so effects can prepare passes only when people are on screen. */
+export function usePixelCharacterRoots(): ReadonlySet<THREE.Object3D> {
+  return useContext(PixelRenderContext)?.characters ?? NO_CHARACTERS
+}
+
 /** Character roots keep their original layers for picking and the unpixelated view. */
 export function PixelCharacters({ children }: { children: ReactNode }) {
   const renderer = useContext(PixelRenderContext)

--- a/lib/game/render/outline.ts
+++ b/lib/game/render/outline.ts
@@ -17,6 +17,15 @@ export const OUTLINE_ID_LAYER_MASK = 1 << OUTLINE_ID_LAYER
 export const SELECTED_CHARACTER_LAYER = 2
 
 /**
+ * The road's edge line on its own, over the terrain's depth: the outline pass
+ * traces it faintly back over the trees standing in front of it, so a road
+ * still reads where the canopy hides it. Layers 3 and 4 belong to the
+ * character passes (see render/pixel-characters).
+ */
+export const ROAD_EDGE_LAYER = 5
+export const ROAD_EDGE_LAYER_MASK = 1 << ROAD_EDGE_LAYER
+
+/**
  * Rendering modes, in the order the O key cycles through them:
  *  - overlap:    outline only where an object overlaps a different object.
  *  - silhouette: outline the whole silhouette, terrain boundaries included.

--- a/lib/game/selection.test.ts
+++ b/lib/game/selection.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { useBuildStore } from "./build-store"
 import { useCameraStore, type Selection } from "./camera-store"
-import { selectElement, selectionObjectId } from "./selection"
+import { markPerson, prioritizePeople, selectElement, selectionObjectId } from "./selection"
 import { buildingObjectId, pileObjectId, RELIC_OBJECT_ID, residentObjectId, travelerObjectId, treeObjectId, wildlifeObjectId } from "./render/outline"
 
 const objects = {
@@ -51,6 +51,27 @@ describe("shared selection", () => {
     ])
     expect(new Set(ids).size).toBe(ids.length)
     expect(selectionObjectId({ kind: "pile", id: "pile-b" }, { ...objects, piles: [objects.piles[1]] })).toBe(pileObjectId(0))
+  })
+
+  it("picks the person before the scenery standing in front of them", () => {
+    const person = { userData: {} as Record<string, unknown>, parent: null }
+    markPerson(person)
+    const walker = { object: { userData: {}, parent: person }, distance: 9 }
+    const hat = { object: { userData: {}, parent: person }, distance: 10 }
+    const crown = { object: { userData: {}, parent: null }, distance: 4 }
+    const trunk = { object: { userData: {}, parent: null }, distance: 6 }
+    expect(prioritizePeople([crown, walker, trunk, hat])).toEqual([walker, hat, crown, trunk])
+  })
+
+  it("leaves hits alone when people are not involved", () => {
+    const crown = { object: { userData: {}, parent: null }, distance: 4 }
+    const trunk = { object: { userData: {}, parent: null }, distance: 6 }
+    const hits = [crown, trunk]
+    expect(prioritizePeople(hits)).toBe(hits)
+    const person = { userData: {} as Record<string, unknown>, parent: null }
+    markPerson(person)
+    const people = [{ object: { userData: {}, parent: person }, distance: 1 }]
+    expect(prioritizePeople(people)).toBe(people)
   })
 
   it("clears the effect when a selected identity is gone", () => {

--- a/lib/game/selection.ts
+++ b/lib/game/selection.ts
@@ -40,3 +40,39 @@ export function selectionObjectId(selection: Selection | null, objects: {
     : selection.kind === "traveler" ? travelerObjectId(index)
       : selection.kind === "monk" ? residentObjectId(index) : pileObjectId(index)
 }
+
+/** Marks a rendered subtree as a person, for `prioritizePeople`. */
+const PERSON_PICK = "person"
+
+interface PickObject {
+  userData?: Record<string, unknown>
+  parent?: PickObject | null
+}
+
+/** Tag a character's root group so every hit inside it counts as that person. */
+export function markPerson(object: { userData: Record<string, unknown> } | null | undefined) {
+  if (object) object.userData[PERSON_PICK] = true
+}
+
+/** True when the object, or anything it hangs from, stands for a person. */
+function isPersonPick(object: PickObject | null | undefined): boolean {
+  for (let node = object ?? null; node; node = node.parent ?? null) {
+    if (node.userData?.[PERSON_PICK] === true) return true
+  }
+  return false
+}
+
+/**
+ * Re-order raycast hits so people come first. A walker is small next to the
+ * trees and buildings around them, so the nearest hit under the pointer is
+ * usually the scenery standing in front — clicking a pilgrim on a forest path
+ * would pick the crown that hides them. Distance order is kept within each
+ * group, so the nearest person still wins, and scenery is only demoted, never
+ * dropped: with no tool active the person's handler stops the event, and in
+ * build mode nothing stops it and the ground still takes the click.
+ */
+export function prioritizePeople<T extends { object: PickObject }>(hits: readonly T[]): T[] {
+  const people = hits.filter((hit) => isPersonPick(hit.object))
+  if (people.length === 0 || people.length === hits.length) return hits as T[]
+  return [...people, ...hits.filter((hit) => !isPersonPick(hit.object))]
+}


### PR DESCRIPTION
Walkers on a forest path used to disappear behind a crown along with the road they were on, so this branch brings both back through the canopy: every character renders once more free of the world's depth and the outline composite paints the hidden part back at half strength, while the road's edge line gets an edge-only variant of the tile material on its own layer, sharing the road geometry so the ragged verge lands exactly where the visible one does and the terrain's ID copy supplies depth so a hill still hides what's behind it. Only trees relent — terrain writes ID 0 and buildings own their own ID block, so hills and walls still hide whoever stands behind them. Clicking is fixed to match: raycast hits are re-ordered so people come first (`prioritizePeople`, unit-tested), with monk and traveler groups marking themselves, and scenery is demoted rather than dropped so build-tool clicks still fall through to the ground. Checked in the running game with headless screenshots — A/B pairs at a fixed camera show a walker cut off at the shoulders before and readable through the crown after, the trail's verges continuing across the canopy, and the shrine unchanged with no lines on its walls; clicks on covered travelers select the person while trees with nobody behind them still select the tree. The mask strengths are two named constants at the top of `outline-pass.tsx` if either wants tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)