### PR TITLE
Fix shrine detours, worker rest returns, and shortcut cache timing

### DIFF
--- a/lib/game/footpaths.ts
+++ b/lib/game/footpaths.ts
@@ -20,7 +20,7 @@ export type FootpathObstacle = TilePos & { radius: number }
 /** Obstacles bucketed on a coarse world grid; see {@link indexObstacles}. */
 export interface ObstacleIndex { source: readonly FootpathObstacle[]; reach: number; cells: Map<number, FootpathObstacle[]> }
 /** One stretch of road's answer to "is there a way across here?"; see lib/game/walking-shortcuts. */
-export interface RoadCut { end: number | null; at: number; ground: number; buildings: number }
+export interface RoadCut { end: number | null; atSeconds: number; ground: number; buildings: number }
 export interface Footpaths { rerouted: Set<number>; obstacles?: readonly FootpathObstacle[]; obstacleIndex?: ObstacleIndex; paved?: boolean; founding: Map<number, number>; edges: Map<string, Footpath>; contacts: Map<string, ContactTrack>; cuts?: Map<number, RoadCut>; ground: number; revision: number; elapsed: number }
 export const createFootpaths = (map?: GameMap): Footpaths => ({
   rerouted: new Set(),

--- a/lib/game/hospitality.test.ts
+++ b/lib/game/hospitality.test.ts
@@ -1,7 +1,8 @@
 import { shrineSeats } from "./shrine-layout"
 import { afterEach, describe, expect, it } from "vitest"
 import { BUILD_CATALOG, DEFAULT_BALANCE } from "./balance"
-import { createSettlement, purchaseStructure, woodcutterHuts, jobBuildings, creditTimber, creditAdmission, syncTimberSpending, settlementRenown } from "./settlement"
+import { createSettlement, purchaseStructure, placementError, woodcutterHuts, jobBuildings, creditTimber, creditAdmission, syncTimberSpending, settlementRenown } from "./settlement"
+import { buildingEntry } from "./building-rotation"
 import { characterSupport } from "./character-support"
 import { HOUSE_BEDS } from "./building-art/early-geometry"
 import { MEAL_PRICE, servingHouses, tavernSeats } from "./tavern"
@@ -484,6 +485,27 @@ describe("shrine hospitality", () => {
 })
 
 describe("woodcutter huts", () => {
+  it("returns a homeless settler to their workplace after camping", () => {
+    const { map, camp, traveler } = fixture(), t = traveler(0)
+    map.buildings.push(camp)
+    const sim = createSim([t], map), s = sim.travelers.get(0)!
+    sim.buildings = jobBuildings(map)
+    const entry = buildingEntry(camp)
+    Object.assign(s, { employer: camp.id, home: null, activity: "idle", stamina: 0,
+      x: tileToWorldX(map, entry.x), z: tileToWorldZ(map, entry.z) })
+    run(sim, [t], map, 120, () => s.activity === "camping")
+    expect(s.activity).toBe("camping")
+    run(sim, [t], map, 120, () => s.activity === "fromCamp")
+    expect(s.activity).toBe("fromCamp")
+    run(sim, [t], map, 120, () => s.activity !== "fromCamp")
+    expect(s.activity).toBe("idle")
+    expect(s.employer).toBe(camp.id)
+    expect(s.x).toBeCloseTo(tileToWorldX(map, entry.x))
+    expect(s.z).toBeCloseTo(tileToWorldZ(map, entry.z))
+    expect(s.spot).toBeNull()
+    expect(s.offRoadRoute).toBeNull()
+  })
+
   it.each(["hunger", "thirst", "stamina"] as const)("keeps a settled builder assigned through completion with depleted %s", need => {
     for (const atWork of [false, true]) {
       const { map, camp, traveler } = fixture()
@@ -1095,4 +1117,86 @@ it("reserves separate kneelers, walks down the aisle, and frees seats after depa
   run(sim,people,map,20,()=>seated.every(s=>s.activity === "walking"))
   expect(seated.every(s=>s.shrineSeat === undefined)).toBe(true)
   expect(shrineVisitPlan(map,99,0,new Set([...sim.travelers.values()].flatMap(s=>s.shrineSeat?[s.shrineSeat]:[])))).not.toBeNull()
+})
+
+describe("shrine visits beside a covered junction", () => {
+  function obstructed(direction: 1 | -1, offset = 0) {
+    const { map, traveler } = fixture()
+    const cross = BUILD_CATALOG.find(b => b.id === "cross")!
+    const x = 10 + direction * offset
+    expect(placementError(map, cross, map.road![x])).toBeNull()
+    const obstacle = { ...cross, id: "road-cross", buildType: "cross", x, z: 4 }
+    map.buildings.push(obstacle)
+    const t = devout(traveler(0, direction))
+    t.offset = (10 - direction * 4) / 29
+    const sim = createEstablishedShrine([t], map, holy), s = sim.travelers.get(0)!
+    Object.assign(sim.balance.rules, { hungerDecay: 0, thirstDecay: 0, staminaDecay: 0 })
+    const step = () => {
+      const before = { x: s.x, z: s.z, activity: s.activity, branchProgress: s.branchProgress }
+      stepSim(sim, [t], map, 1.5, .1)
+      expect(containsTile(obstacle, { x: worldToTileX(map, s.x), z: worldToTileZ(map, s.z) })).toBe(false)
+      const movement = Math.hypot(s.x - before.x, s.z - before.z)
+      expect(movement, `${before.activity} at ${before.branchProgress} → ${s.activity} at ${s.branchProgress}`).toBeLessThan(.3)
+    }
+    return { map, t, sim, s, step }
+  }
+
+  it.each([1, -1] as const)("walks to the shrine and back around the obstruction (direction %i)", direction => {
+    const { sim, s, step } = obstructed(direction)
+    for (let i = 0; i < 300 && s.activity !== "toRelic"; i++) step()
+    expect(s.activity).toBe("toRelic")
+    const departure = { x: s.x, z: s.z, progress: s.progress }
+    expect((10 - departure.progress) * direction).toBeGreaterThan(0)
+    for (let i = 0; i < 2000 && s.activity !== "walking"; i++) step()
+    expect(s.activity).toBe("walking")
+    expect(sim.visits).toBe(1)
+    expect(s.progress).toBe(departure.progress)
+    expect(s.x).toBeCloseTo(departure.x)
+    expect(s.z).toBeCloseTo(departure.z)
+    for (let i = 0; i < 300 && direction * (s.progress - 10) < 3; i++) step()
+    expect(direction * (s.progress - 10)).toBeGreaterThanOrEqual(3)
+    expect(sim.visits).toBe(1)
+  })
+
+  it.each([1, -1] as const)("offers a declined visit only once while taking the diversion (direction %i)", direction => {
+    const { map, t, sim, s, step } = obstructed(direction)
+    t.attributes.piety = s.piety = 0
+    sim.relic = obscure
+    // Leave no completed cross granting an independent evangelism roll.
+    map.buildings.at(-1)!.construction = { work: 0, required: 1 }
+    for (let i = 0; i < 300 && direction * (s.progress - 10) < 3; i++) step()
+    expect(direction * (s.progress - 10)).toBeGreaterThanOrEqual(3)
+    expect(sim.visits).toBe(0)
+    expect(s.rolls).toBe(1)
+  })
+
+  it.each([1, -1] as const)("keeps the tavern accessible from the diversion departure (direction %i)", direction => {
+    const { map, t, sim, s, step } = obstructed(direction)
+    staffTavern(sim, map)
+    t.attributes.gold = s.gold = 20
+    t.attributes.hunger = s.hunger = 5
+    t.attributes.thirst = s.thirst = 5
+    for (let i = 0; i < 300 && s.activity !== "toTavern"; i++) step()
+    expect(s.activity).toBe("toTavern")
+    for (let i = 0; i < 2000 && s.activity !== "walking"; i++) step()
+    expect(s.activity).toBe("walking")
+    expect(sim.tradeGold).toBe(5)
+    expect(s.tavernVisit).toBeUndefined()
+    for (let i = 0; i < 300 && direction * (s.progress - 10) < 3; i++) step()
+    expect(direction * (s.progress - 10)).toBeGreaterThanOrEqual(3)
+  })
+
+  it.each([1, -1] as const)("offers a visit at arrival when the diversion ends exactly on the junction (direction %i)", direction => {
+    const { map, t, sim, s, step } = obstructed(direction, -2)
+    t.attributes.piety = s.piety = 0
+    sim.relic = obscure
+    map.buildings.at(-1)!.construction = { work: 0, required: 1 }
+    for (let i = 0; i < 300 && s.progress !== 10; i++) {
+      step()
+      expect(s.rolls).toBe(0)
+    }
+    expect(s.progress).toBe(10)
+    step()
+    expect(s.rolls).toBe(1)
+  })
 })

--- a/lib/game/settlement-route.ts
+++ b/lib/game/settlement-route.ts
@@ -55,13 +55,25 @@ export function settlementRoute(
   return null
 }
 
-/**
- * The walk from the road to the shrine door. The track is ordinary ground —
- * a footprint may stand on it — so the approach is routed around whatever is
- * built there, falling back to the original branch when nothing is.
- */
-export function shrineApproach(map: GameMap): TilePos[] {
-  const site = map.site
-  if (!site) return []
-  return settlementRoute(map, map.buildings, site.branch[0], site.door) ?? site.branch
+/** The clear road tile nearest the shrine's junction; walkers turn off there. */
+export function shrineRoadHead(map: GameMap, buildings: readonly BuildingDef[] = map.buildings): TilePos | null {
+  if (!map.site) return null
+  const road = map.road
+  const covered = (p: TilePos) => buildings.some(b => p.x >= b.x && p.x < b.x + b.w && p.z >= b.z && p.z < b.z + b.d)
+  const original = map.site.branch[0]
+  if (!road) return original && !covered(original) ? original : null
+  for (let step = 0; step < road.length; step++) {
+    for (const index of step ? [map.site!.junction - step, map.site!.junction + step] : [map.site!.junction]) {
+      const tile = road[index]
+      if (tile && !covered(tile)) return tile
+    }
+  }
+  return null
+}
+
+/** The reachable approach from a visitor's departure tile, or the nearest clear road tile. */
+export function shrineApproach(map: GameMap, from?: TilePos): TilePos[] {
+  const start = from ?? shrineRoadHead(map)
+  if (!map.site || !start) return []
+  return settlementRoute(map, map.buildings, start, map.site.door) ?? []
 }

--- a/lib/game/settlement.ts
+++ b/lib/game/settlement.ts
@@ -2,7 +2,7 @@ import { buildingEntrance, constructionWork, isComplete } from "./construction"
 import { rotatedFootprint, buildingEntry, buildingApproaches, type BuildingRotation } from "./building-rotation"
 import { groundHeight, levelBuildingGround } from "./map/elevation"
 import { buildingKind, placementProblem, PLACEMENT_PROBLEM_LABELS, type PlacedBuilding } from "./buildings"
-import { settlementRoute, shrineApproach } from "./settlement-route"
+import { settlementRoute, shrineRoadHead } from "./settlement-route"
 import { getBuildInfluence, type BuildInfluence } from "./build-influence"
 import type { SimState } from "./sim"
 import { DEFAULT_ADMISSION_FEE } from "./shrine-visit"
@@ -209,20 +209,6 @@ export function buildTileError(map: GameMap, x: number, z: number, influence: Bu
   return null
 }
 
-/** The clear road tile nearest the shrine's junction; walkers turn off there. */
-function roadHead(map: GameMap, buildings: readonly BuildingDef[]): TilePos | null {
-  const road = map.road
-  const covered = (p: TilePos) => buildings.some(b => p.x >= b.x && p.x < b.x + b.w && p.z >= b.z && p.z < b.z + b.d)
-  if (!road) return map.site && !covered(map.site.branch[0]) ? map.site.branch[0] : null
-  for (let step = 0; step < road.length; step++) {
-    for (const index of step ? [map.site!.junction - step, map.site!.junction + step] : [map.site!.junction]) {
-      const tile = road[index]
-      if (tile && !covered(tile)) return tile
-    }
-  }
-  return null
-}
-
 /**
  * A settlement may grow over the road — travellers walk around a footprint and
  * wear their own way past it — so long as there is a way around to be found.
@@ -286,7 +272,7 @@ export function placementError(
     if (roadBlock) return roadBlock
     // The shrine's own track is buildable ground, but its door must stay
     // reachable — from the nearest stretch of road still clear to walk on.
-    const junction = roadHead(map, occupied)
+    const junction = shrineRoadHead(map, occupied)
     if (junction && !settlementRoute(map, occupied, junction, map.site.door))
       return "Leave a way through from the road to the shrine door."
     for (const camp of map.buildings.filter(b => b.buildType)) {

--- a/lib/game/shrine-navigation.test.ts
+++ b/lib/game/shrine-navigation.test.ts
@@ -3,6 +3,7 @@ import { buildingStepAllowed } from "./building-navigation"
 import { monkWander, type WanderSpot } from "./monk-wander"
 import { shrineLayout, shrineKneelers, shrineSeats } from "./shrine-layout"
 import { shrineVisitPlan } from "./shrine-visit"
+import { processionGrounds } from "./relic-procession"
 import { tileToWorldX, tileToWorldZ, type GameMap, type TilePos } from "./map/types"
 
 function fixture(direction: number): GameMap {
@@ -89,5 +90,23 @@ describe("a footprint on the shrine track", () => {
     expect(route[0]).toEqual(map.site!.branch[0])
     expect(route.some(p => p.x === map.site!.door.x && p.z === map.site!.door.z)).toBe(true)
     expect(route.length).toBeGreaterThan(straight.length)
+  })
+
+  it("shares a clear road entry when the original junction is covered", () => {
+    const map = approachMap()
+    map.buildings.push({ id: "cross", label: "Cross", x: 5, z: 4, w: 1, d: 1, height: 1, color: "", roofColor: "" })
+    const plan = shrineVisitPlan(map, 0, 0)!
+    expect(plan.route[0]).toEqual({ x: 4, z: 4 })
+    expect(plan.route.some(p => p.x === 5 && p.z === 4)).toBe(false)
+    const procession = processionGrounds(map)!
+    expect(procession.branch.at(-1)).toMatchObject({ x: tileToWorldX(map, 4), z: tileToWorldZ(map, 4) })
+    const from = { x: 8, z: 4 }
+    expect(shrineVisitPlan(map, 0, 0, new Set(), from)!.route[0]).toEqual(from)
+  })
+
+  it("declines a visit when the approach is sealed instead of falling back through walls", () => {
+    const map = approachMap()
+    for (let x = 0; x < map.width; x++) map.tiles[6 * map.width + x] = "water"
+    expect(shrineVisitPlan(map, 0, 0)).toBeNull()
   })
 })

--- a/lib/game/shrine-visit.ts
+++ b/lib/game/shrine-visit.ts
@@ -10,12 +10,13 @@ export function admissionFee(map: GameMap): number {
 }
 
 /** Reserve a kneeler before leaving the road; enter by the aisle and retrace it on exit. */
-export function shrineVisitPlan(map: GameMap, visitor: number, visits: number, occupied: ReadonlySet<string> = new Set()) {
+export function shrineVisitPlan(map: GameMap, visitor: number, visits: number, occupied: ReadonlySet<string> = new Set(), from?: TilePos) {
   const site = map.site
   const shrine = map.buildings.find(b => b.id === site?.hovelId)
   if (!site || !shrine) return null
   const gate = shrineGates(shrine, site.door)[0]
-  const branch = shrineApproach(map)
+  const branch = shrineApproach(map, from)
+  if (!branch.length) return null
   if (!buildingStepAllowed(map,map.buildings,gate.outside,gate.inside,true)) return null
   const seats=shrineSeats(shrine,site.door),layout=shrineLayout(shrine,site.door)
   for(let i=0;i<seats.length;i++) {

--- a/lib/game/sim.ts
+++ b/lib/game/sim.ts
@@ -263,7 +263,7 @@ function minstrelWalkSeconds(id: number, cycle: number): number {
 export interface SimTraveler {
   roadShortcut?: WalkingShortcut
   shortcutCheck?: number
-  /** Half-tile gate on looking ahead for a footprint blocking the road. */
+  /** Road-tile gate on looking ahead for a footprint blocking the road. */
   diversionCheck?: number
   musicCooldown?: number
   musicVisit?: { performerId: number; cycle: number; spot: WorldPoint }
@@ -547,11 +547,15 @@ function shrineWorldPoint(map: GameMap, s: SimTraveler): WorldPoint {
   }
   // Leave the walking lane before reaching the grounds; cross gates centrally.
   const laneBlend = s.shrineRoute ? Math.max(0, Math.min(1, site.branch.length - 1 - s.branchProgress)) : 1
-  const point = routeWorldPoint(map, route, s.branchProgress, s.lane * laneBlend)
+  // A departure before a blocked junction uses a routed approach around walls.
+  // Keep that route centred; an offset lane can clip the inside of its bends.
+  const diverted = route[0].x !== site.branch[0].x || route[0].z !== site.branch[0].z
+  const lane = diverted ? 0 : s.lane * laneBlend
+  const point = routeWorldPoint(map, route, s.branchProgress, lane)
   if (s.branchProgress < 1) {
-    const start = routeWorldPoint(map, site.branch, 0, s.lane)
+    const start = routeWorldPoint(map, route, 0, lane)
     const roadLane = s.activity === "toRelic" ? s.branchEntryLane : s.direction * s.laneOffset
-    const road = roadWorldPoint(map, site.junction, roadLane)
+    const road = roadWorldPoint(map, s.progress, roadLane)
     const blend = 1 - s.branchProgress
     point.x += (road.x - start.x) * blend
     point.y += (road.y - start.y) * blend
@@ -997,6 +1001,15 @@ function workplaceReturn(sim: SimState, s: SimTraveler, map: GameMap): WorldPoin
   return { x: tileToWorldX(map, entry.x), y: surfaceHeight(map, entry.x, entry.z), z: tileToWorldZ(map, entry.z) }
 }
 
+/** Rest and meals return settlers to work and passing travelers to their journey. */
+function finishErrand(s: SimTraveler): void {
+  s.walkFrom = null
+  s.offRoadRoute = null
+  s.diversionCheck = undefined
+  s.activity = s.employer ? "idle" : "walking"
+  if (s.employer) s.timer = GAME_HOUR_SECONDS
+}
+
 /** Head back out of the door to the road, or to the work they left. */
 function leaveTavern(s: SimTraveler, map: GameMap, back: WorldPoint): void {
   const route = settlementRoute(map, map.buildings, { x: worldToTileX(map, s.x), z: worldToTileZ(map, s.z) },
@@ -1089,6 +1102,62 @@ function finishVisit(sim: SimState, s: SimTraveler, t: Traveler, map: GameMap): 
     }
   }
   s.activity = "fromRelic"
+}
+
+/** Offer one shrine or meal visit before crossing its junction, including a diversion across it. */
+function tryRoadVisit(sim: SimState, s: SimTraveler, t: Traveler, map: GameMap,
+  counters: ReturnType<typeof openCounters>, direction: 1 | -1, parkingProgress: number,
+  characterScale: number, from?: TilePos): boolean {
+  const isVendor = t.type.id === "vendor", needsParking = isVendor || t.type.id === "knight"
+  const renown = sim.shrineRenown + sim.visits * sim.balance.rules.visitRenown
+  // Hunger and thirst only draw anyone in while a counter is open:
+  // the shrine itself keeps no table (see the tavern and the stall).
+  const served = counters.length > 0
+  const chance = visitChance({ ...t.attributes, piety: s.piety,
+    hunger: served ? s.hunger : 100, thirst: served ? s.thirst : 100, stamina: s.stamina },
+    sim.relic, renown, sim.balance)
+  s.visitCooldown = 5
+  const ordinaryVisit = nextRoll(s) < chance
+  const evangelism = ordinaryVisit ? 0 : roadsideEvangelism(map)
+  const persuaded = evangelism > 0 && nextRoll(s) < evangelism
+  // A traveler drawn by need heads for the counter, not the relic.
+  // Wagons and horses stay on the road; only walkers turn aside for a meal.
+  if ((ordinaryVisit || persuaded) && served && !needsParking &&
+    Math.min(s.hunger, s.thirst) < hospitalityNeedThreshold(renown, sim.balance) &&
+    startTavernTrip(sim, s, map, counters, null)) return true
+  const wantsVisit = (ordinaryVisit || persuaded) && s.gold >= admissionFee(map)
+  const occupiedSeats = new Set([...sim.travelers.values()].flatMap(other =>
+    other.shrineSeat && ["toParking","toRelic","visiting","fromRelic"].includes(other.activity) ? [other.shrineSeat] : []))
+  const visit = wantsVisit ? shrineVisitPlan(map, s.id, s.visits, occupiedSeats, from) : null
+  let visitRoute = visit?.route ?? null
+  let parking: ShrineParking | null = null
+  if (visitRoute && needsParking) {
+    const puller = isVendor ? cartLoadout(s.id).puller : "horse"
+    parking = shrineParking(map, parkingProgress, direction, isVendor ? -cartOffset(puller) * characterScale : 0, puller, characterScale,
+      [...sim.travelers.values()].flatMap(other => other.shrineParking ? [other.shrineParking.parked] : []), parkingContext(sim, s, characterScale))
+    const footRoute = parking ? settlementRoute(map, map.buildings,
+      { x: worldToTileX(map, parking.parked.hitch.x), z: worldToTileZ(map, parking.parked.hitch.z) }, visitRoute.at(-1)!, false, true, visit!.seat) : null
+    visitRoute = footRoute
+  }
+  if (visitRoute) {
+    s.progress = parkingProgress
+    s.branchProgress = 0
+    s.shrineRoute = visitRoute
+    s.shrineSeat = visit!.seat
+    s.admissionPaid = 0
+    if (parking) s.direction = direction
+    s.shrineParking = parking ?? undefined
+    s.activity = parking ? "toParking" : "toRelic"
+    s.targetId = null
+    s.branchEntryLane = s.lane
+    s.lane = s.laneOffset
+    const at = parking ? { ...parking.entry[0], y: s.y } : shrineWorldPoint(map, s)
+    s.x = at.x
+    s.y = at.y
+    s.z = at.z
+    return true
+  }
+  return false
 }
 
 export function stepSim(
@@ -1234,7 +1303,7 @@ export function stepSim(
             s.shrineParking.walking = false; s.shrineParking.distance = 0
             s.activity = "fromParking"
           } else {
-            s.activity = "walking"; s.shrineRoute = null; s.visitCooldown = 30
+            s.activity = "walking"; s.shrineRoute = null; s.visitCooldown = 30; s.diversionCheck = undefined
           }
         }
         break
@@ -1411,12 +1480,9 @@ export function stepSim(
       case "fromTavern": {
         const back = s.tavernVisit?.returnTo ?? currentRoutePoint(map, s)
         if (stepOffRoadWalk(s, back, worldSpeed, dt, map)) {
-          const settled = !!s.employer
           s.tavernVisit = undefined
-          s.walkFrom = null
-          s.offRoadRoute = null
-          if (settled) { s.activity = "idle"; s.timer = GAME_HOUR_SECONDS }
-          else { s.activity = "walking"; s.visitCooldown = 30 }
+          finishErrand(s)
+          if (!s.employer) s.visitCooldown = 30
         }
         break
       }
@@ -1577,73 +1643,36 @@ export function stepSim(
           break
         }
 
+        // Plan before offering a visit: a diversion can cross the shrine's
+        // junction without ever standing on that now-covered road tile.
+        let diversion: WalkingShortcut | null = null
+        if (dt > 0) {
+          const check = Math.floor(s.progress) * 2 + (direction === 1 ? 1 : 0)
+          if (s.diversionCheck !== check) {
+            s.diversionCheck = check
+            diversion = findRoadDiversion(map, blockedRoad(map), { x: s.x, z: s.z }, s.progress, direction,
+              p => roadWorldPoint(map, p, s.lane))
+          }
+        }
         const site = map.site
         if (site && site.branch.length >= 2 && s.activity !== "fleeing" && s.visitCooldown <= 0) {
           const distance = ((direction * (site.junction - s.progress)) % length + length) % length
           const crossingTile = Math.floor(s.progress) !== Math.floor(s.progress + direction * worldSpeed * haste * dt)
-          // A wooded junction may have no verge. Convoys look for a clearing
-          // on their approach, so the walking visitor can cover the last stretch.
-          if (distance <= worldSpeed * haste * dt || (needsParking && distance <= 12 && crossingTile)) {
-            const parkingProgress = needsParking ? s.progress : site.junction
-            // Hunger and thirst only draw anyone in while a counter is open:
-            // the shrine itself keeps no table (see the tavern and the stall).
-            const served = counters.length > 0
-            const chance = visitChance({ ...t.attributes, piety: s.piety,
-              hunger: served ? s.hunger : 100, thirst: served ? s.thirst : 100, stamina: s.stamina },
-              sim.relic, renown, sim.balance)
-            s.visitCooldown = 5
-            const ordinaryVisit = nextRoll(s) < chance
-            const evangelism = ordinaryVisit ? 0 : roadsideEvangelism(map)
-            const persuaded = evangelism > 0 && nextRoll(s) < evangelism
-            // A traveler drawn by need heads for the counter, not the relic.
-            // Wagons and horses stay on the road; only walkers turn aside for a meal.
-            if ((ordinaryVisit || persuaded) && served && !needsParking &&
-              Math.min(s.hunger, s.thirst) < hospitalityNeedThreshold(renown, sim.balance) &&
-              startTavernTrip(sim, s, map, counters, null)) break
-            const wantsVisit = (ordinaryVisit || persuaded) && s.gold >= admissionFee(map)
-            const occupiedSeats = new Set([...sim.travelers.values()].flatMap(other =>
-              other.shrineSeat && ["toParking","toRelic","visiting","fromRelic"].includes(other.activity) ? [other.shrineSeat] : []))
-            const visit = wantsVisit ? shrineVisitPlan(map, s.id, s.visits, occupiedSeats) : null
-            let visitRoute = visit?.route ?? null
-            let parking: ShrineParking | null = null
-            if (visitRoute && needsParking) {
-              const puller = isVendor ? cartLoadout(s.id).puller : "horse"
-              parking = shrineParking(map, parkingProgress, direction, isVendor ? -cartOffset(puller) * characterScale : 0, puller, characterScale,
-                [...sim.travelers.values()].flatMap(other => other.shrineParking ? [other.shrineParking.parked] : []), parkingContext(sim, s, characterScale))
-              const footRoute = parking ? settlementRoute(map, map.buildings,
-                { x: worldToTileX(map, parking.parked.hitch.x), z: worldToTileZ(map, parking.parked.hitch.z) }, visitRoute.at(-1)!, false, true, visit!.seat) : null
-              visitRoute = footRoute
-            }
-            if (visitRoute) {
-              s.progress = parkingProgress
-              s.branchProgress = 0
-              s.shrineRoute = visitRoute
-              s.shrineSeat = visit!.seat
-              s.admissionPaid = 0
-              if (parking) s.direction = direction
-              s.shrineParking = parking ?? undefined
-              s.activity = parking ? "toParking" : "toRelic"
-              s.targetId = null
-              s.branchEntryLane = s.lane
-              s.lane = s.laneOffset
-              const at = parking ? { ...parking.entry[0], y: s.y } : shrineWorldPoint(map, s)
-              s.x = at.x
-              s.y = at.y
-              s.z = at.z
-              break
-            }
+          const bypassesJunction = diversion !== null && direction * (site.junction - s.progress) >= 0
+            && direction * (site.junction - diversion.end) < 0
+          // Convoys seek a parking verge in advance. Pedestrians whose detour
+          // bypasses the turning leave from this clear road tile and return here.
+          if (distance <= worldSpeed * haste * dt || bypassesJunction || (needsParking && distance <= 12 && crossingTile)) {
+            const leaveHere = needsParking || bypassesJunction
+            const from = leaveHere ? { x: worldToTileX(map, s.x), z: worldToTileZ(map, s.z) } : undefined
+            if (tryRoadVisit(sim, s, t, map, counters, direction, leaveHere ? s.progress : site.junction,
+              characterScale, from)) break
           }
         }
-        // A footprint standing on the road turns everyone off it, carts and
-        // riders included; the road is only theirs as far as the next wall.
-        if (dt > 0 && !s.track) {
-          const diversionCheck = Math.floor(s.progress) * 2 + (direction === 1 ? 1 : 0)
-          if (s.diversionCheck !== diversionCheck) {
-            s.diversionCheck = diversionCheck
-            s.roadShortcut = findRoadDiversion(map, blockedRoad(map), { x: s.x, z: s.z }, s.progress, direction,
-              p => roadWorldPoint(map, p, s.lane)) ?? undefined
-            if (s.roadShortcut) { stepRoadShortcut(s, map, worldSpeed * dt); break }
-          }
+        if (diversion) {
+          s.roadShortcut = diversion
+          stepRoadShortcut(s, map, worldSpeed * dt)
+          break
         }
         if (dt > 0 && s.activity === "walking" && !needsParking && map.footpaths) {
           const check = Math.floor(s.progress) * 2 + (direction === 1 ? 1 : 0)
@@ -1651,7 +1680,7 @@ export function stepSim(
             s.shortcutCheck = check
             s.roadShortcut = takeRoadShortcut(map, s.progress, direction, s.lane,
               (p, lane) => roadWorldPoint(map, p, lane),
-              exploresRoadShortcut(explorerRanks.get(s.id)!, s.cycle, map.seed ?? 0, roadWalkers.length), sim.time) ?? undefined
+              exploresRoadShortcut(explorerRanks.get(s.id)!, s.cycle, map.seed ?? 0, roadWalkers.length), sim.time * GAME_DAY_SECONDS) ?? undefined
             if (s.roadShortcut) { stepRoadShortcut(s, map, worldSpeed * dt); break }
           }
         }
@@ -1817,11 +1846,10 @@ export function stepSim(
       }
 
       case "fromCamp": {
-        const back = currentRoutePoint(map, s)
+        const back = workplaceReturn(sim, s, map) ?? currentRoutePoint(map, s)
         if (stepOffRoadWalk(s, back, worldSpeed, dt, map)) {
-          s.activity = "walking"
+          finishErrand(s)
           s.spot = null
-          s.walkFrom = null
         }
         break
       }

--- a/lib/game/transport/navigation.test.ts
+++ b/lib/game/transport/navigation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { convoyClear, convoyPoint, shrineParking, parkingClear, parkingTree, convoyBounds, stallParking } from "./navigation"
-import { cartOffset } from "./assets"
+import { cartLoadout, cartOffset } from "./assets"
 import { alignCart, cartOnRoute, followCart } from "./follow"
 import { createSim, stepSim } from "../sim"
 import { generateTravelers, TRAVELER_TYPES } from "../travelers"
@@ -22,6 +22,41 @@ function fixture(): GameMap {
 }
 
 describe("merchant shrine parking", () => {
+  it.each([0, 4, 8, "knight"] as const)("keeps parking and shrine access around a covered junction (%s)", loadout => {
+    for (const direction of [1, -1] as const) {
+      const map = fixture(), t = generateTravelers(1, 1)[0]
+      map.buildings.push({ id: "obstruction", label: "Cross", x: 10, z: 4, w: 1, d: 1, height: 1, color: "", roofColor: "" })
+      t.id = loadout === "knight" ? 0 : loadout
+      t.type = TRAVELER_TYPES[loadout === "knight" ? "knight" : "vendor"]
+      t.offset = (10 - direction * 4) / 29; t.direction = direction; t.pace = 1
+      Object.assign(t.attributes, { piety: 100, status: 0, hunger: 100, thirst: 100, stamina: 100, gold: 100 })
+      const sim = createSim([t], map, [], { sanctity: 100, spectacle: 100, doubt: 0 }), s = sim.travelers.get(t.id)!
+      // One tether tree leaves a full wagon's departure clear on either side.
+      sim.trees = [{ x: tileToWorldX(map, 10), y: .2, z: tileToWorldZ(map, 1), species: "oak" }]
+      const puller = loadout === "knight" ? "horse" : cartLoadout(loadout).puller
+      const wheelbase = loadout === "knight" ? 0 : -cartOffset(puller) * 1.5
+      expect(shrineParking(map, 10 - direction * 4, direction, wheelbase, puller, 1.5, [], { trees: sim.trees })).not.toBeNull()
+      sim.shrineRenown = sim.balance.rules.drawCap
+      s.timer = 10000
+      let sawVisit = false
+      for (let i = 0; i < 4000; i++) {
+        stepSim(sim, [t], map, 1, .1)
+        if (s.shrineParking) {
+          expect(convoyClear(map, s.shrineParking.parked, puller, 1.5, true)).toBe(true)
+        }
+        if (s.activity === "visiting") {
+          sawVisit = true
+          expect(s.shrineRoute!.some(p => p.x === 10 && p.z === 4)).toBe(false)
+          s.timer = 0; s.hunger = s.thirst = s.stamina = 100
+        }
+        if (sawVisit && s.activity === "walking") break
+      }
+      expect({ sawVisit, visits: s.visits, activity: s.activity }).toEqual({ sawVisit: true, visits: 1, activity: "walking" })
+      expect(s.shrineParking).toBeUndefined()
+      expect(s.shrineSeat).toBeUndefined()
+    }
+  })
+
   it.each(["hand", "donkey", "horse"] as const)("finds grass for the whole %s convoy in both directions", puller => {
     for (const direction of [1, -1] as const) {
       const map = fixture(), plan = shrineParking(map, 10, direction, -cartOffset(puller) * 1.5, puller, 1.5, [], { trees: trees(map) })

--- a/lib/game/walking-shortcuts.test.ts
+++ b/lib/game/walking-shortcuts.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
-import { createFootpaths, recordWalkingPath, regrowFootpaths } from "./footpaths"
-import { blockedRoad, findRoadDiversion, findRoadShortcut, retireBypassedRoad, exploresRoadShortcut, shortcutCost, smoothWalkingRoute } from "./walking-shortcuts"
+import { createFootpaths, markGroundChanged, recordWalkingPath, regrowFootpaths } from "./footpaths"
+import { blockedRoad, findRoadDiversion, findRoadShortcut, takeRoadShortcut, retireBypassedRoad, exploresRoadShortcut, shortcutCost, smoothWalkingRoute } from "./walking-shortcuts"
 import { tileToWorldX, tileToWorldZ, worldToTileX, worldToTileZ, type GameMap, type TilePos } from "./map/types"
 import { DEFAULT_ELEVATION } from "./map/elevation"
 import { createSim, stepSim } from "./sim"
@@ -31,6 +31,39 @@ function walk(map: GameMap, a: TilePos, b: TilePos, passes: number) {
 }
 
 describe("traffic gradually cuts off detours", () => {
+  it("lets arriving walkers adopt new wear after three simulation seconds", () => {
+    const map = fixture()
+    const travelers = generateTravelers(7, 8).map(t => ({ ...t, type: TRAVELER_TYPES.peasant, direction: 1 as const,
+      pace: 1, offset: 1 / (map.road!.length - 1), attributes: { ...t.attributes, hunger: 100, thirst: 100, stamina: 100, jobless: false } }))
+    const sim = createSim(travelers, map)
+    // With seed 0, ordinal 0 explores and ordinal 1 follows established wear.
+    const follower = sim.travelers.get(travelers[1].id)!
+    stepSim(sim, travelers, map, 0, .1)
+    expect(follower.roadShortcut).toBeUndefined()
+    walk(map, pointAt(map, 1), pointAt(map, 10), 20)
+    expect(findRoadShortcut(map, 1, 1, p => pointAt(map, p), false)).not.toBeNull()
+    // Simulate a fresh arrival at this stretch while retaining the shared cache.
+    const arrival = () => {
+      Object.assign(follower, { progress: 1, ...pointAt(map, 1), shortcutCheck: undefined })
+      stepSim(sim, travelers, map, 0, .1)
+    }
+    stepSim(sim, [], map, 0, 1)
+    arrival()
+    expect(follower.roadShortcut).toBeUndefined()
+    stepSim(sim, [], map, 0, 3)
+    arrival()
+    expect(follower.roadShortcut).toBeDefined()
+  })
+
+  it("invalidates cached shortcuts immediately when the ground changes", () => {
+    const map = fixture()
+    const take = () => takeRoadShortcut(map, 1, 1, 0, p => pointAt(map, p), true, 1)
+    expect(take()).not.toBeNull()
+    map.tiles = map.tiles.map(terrain => terrain === "grass" ? "water" : terrain)
+    markGroundChanged(map.footpaths!)
+    expect(take()).toBeNull()
+  })
+
   it("keeps a pioneer in small pedestrian populations without rerolling at each bend", () => {
     for (const population of [3, 8, 20]) for (const seed of [1, 7, 42]) {
       const chosen = Array.from({ length: population }, (_, ordinal) => exploresRoadShortcut(ordinal, 0, seed, population))

--- a/lib/game/walking-shortcuts.ts
+++ b/lib/game/walking-shortcuts.ts
@@ -153,7 +153,7 @@ export function retireBypassedRoad(map: GameMap, cut: WalkingShortcut): void {
  * a building, a felled tree, a path the player lays down — bumps the ground
  * revision instead and invalidates the stretch on the walkers' next step.
  */
-export const SHORTCUT_REFRESH = 3
+export const SHORTCUT_REFRESH_SECONDS = 3
 
 /**
  * Where the road offers a way across, if anywhere, for traffic heading this way
@@ -167,17 +167,17 @@ export const SHORTCUT_REFRESH = 3
  * re-deriving the same answer hundreds of times.
  */
 function roadCut(map: GameMap, progress: number, direction: 1 | -1, exploring: boolean,
-  pointAt: (p: number, lane: number) => TilePos, now: number): number | null {
+  pointAt: (p: number, lane: number) => TilePos, nowSeconds: number): number | null {
   const paths = map.footpaths!
   const cuts = paths.cuts ??= new Map()
   const key = (Math.floor(progress) * 2 + (direction === 1 ? 1 : 0)) * 2 + (exploring ? 1 : 0)
   const cached = cuts.get(key)
   if (cached && cached.ground === paths.ground && cached.buildings === map.buildings.length
-    && now - cached.at < SHORTCUT_REFRESH && now >= cached.at) return cached.end
+    && nowSeconds - cached.atSeconds < SHORTCUT_REFRESH_SECONDS && nowSeconds >= cached.atSeconds) return cached.end
   // Resolved on the road's own centre line: what is published is the line, and
   // each walker offers its own lane against it below.
   const cut = findRoadShortcut(map, progress, direction, p => pointAt(p, 0), exploring)
-  cuts.set(key, { end: cut?.end ?? null, at: now, ground: paths.ground, buildings: map.buildings.length })
+  cuts.set(key, { end: cut?.end ?? null, atSeconds: nowSeconds, ground: paths.ground, buildings: map.buildings.length })
   return cut?.end ?? null
 }
 
@@ -190,9 +190,9 @@ function roadCut(map: GameMap, progress: number, direction: 1 | -1, exploring: b
  * one cost evaluation, against the lookahead scan it replaces.
  */
 export function takeRoadShortcut(map: GameMap, progress: number, direction: 1 | -1, lane: number,
-  pointAt: (p: number, lane: number) => TilePos, exploring: boolean, now: number): WalkingShortcut | null {
+  pointAt: (p: number, lane: number) => TilePos, exploring: boolean, nowSeconds: number): WalkingShortcut | null {
   if (!map.footpaths || !map.road) return null
-  const end = roadCut(map, progress, direction, exploring, pointAt, now)
+  const end = roadCut(map, progress, direction, exploring, pointAt, nowSeconds)
   if (end === null) return null
   // A stretch is resolved once per road tile, so a walker part way through that
   // tile can be handed a rejoin point it has already passed. Nobody doubles back.


### PR DESCRIPTION
Road diversions now preserve shrine and tavern visits, route visitors from their actual departure point, and share clear road access with placement validation and processions while retaining convoy parking.

Workers return to their employers after camping through a shared rest and meal completion transition, and shortcut caches now expire after three simulation seconds.

Adds 17 regression tests covering both travel directions, convoy loadouts, unreachable approaches, worker returns, and cache invalidation.

Validation: `npm run typecheck` passed; 1,189 tests passed in the full suite and all six timeout failures passed on targeted reruns, with a command-line timeout override on the final rerun.
