### PR TITLE
Add scene visibility and building interior controls

### DIFF
--- a/app/play/page.tsx
+++ b/app/play/page.tsx
@@ -2,6 +2,7 @@ import { DEFAULT_ELEVATION, ELEVATION_CONTROLS, elevationSettings, type Elevatio
 import type { Metadata } from "next"
 
 import { GameShell, type MapSettings } from "@/components/game/game-shell"
+import { parseSceneVisibility } from "@/lib/game/scene-visibility"
 import { isTreeModel } from "@/lib/game/trees/render-model"
 
 export const metadata: Metadata = {
@@ -28,7 +29,7 @@ export default async function PlayPage({
 }) {
   const params = await searchParams
 
-  const initialSettings: Partial<MapSettings> = {}
+  const initialSettings: Partial<MapSettings> = parseSceneVisibility(params)
   if (params.characters === "base" || params.characters === "callings") {
     initialSettings.characterModel = params.characters
   }

--- a/components/game/buildings.tsx
+++ b/components/game/buildings.tsx
@@ -33,7 +33,7 @@ import {
 } from "@/lib/game/render/outline"
 
 /** Built structures share their geometry with the menu and placement preview. */
-export function Buildings({ map, characterScale = 1.5 }: { map: GameMap; characterScale?: number }) {
+export function Buildings({ map, characterScale = 1.5, showInteriors = false }: { map: GameMap; characterScale?: number; showInteriors?: boolean }) {
   const costs = useRef<ConstructionCostHandle>(null)
   const selectSite = (building: BuildingDef, event: Parameters<typeof selectElement>[1]) => {
     if (selectElement({ kind: "building", id: building.id }, event)) costs.current?.show(building)
@@ -65,7 +65,7 @@ export function Buildings({ map, characterScale = 1.5 }: { map: GameMap; charact
 
         const local = rotatedFootprint(building, building.rotation)
         const cutaway = models[index].some(p => p.layer === "roof") && (
-          unitInterior === building.id || isSelected(selection, { kind: "building", id: building.id }) ||
+          showInteriors || unitInterior === building.id || isSelected(selection, { kind: "building", id: building.id }) ||
           (selection?.kind === "pile" && piles.some(p => p.id === selection.id && p.campId === building.id)))
         if (building.buildType === "storehouse" || building.buildType === "workshop") {
           return (

--- a/components/game/character-selection.tsx
+++ b/components/game/character-selection.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useLayoutEffect, useMemo, useRef } from "react"
 import { createPortal, useFrame, useThree } from "@react-three/fiber"
 import * as THREE from "three"
+import { isObjectVisible } from "@/lib/game/scene-visibility"
 import { PixelCharacters } from "@/components/pixel-canvas"
 import { surfaceHeight } from "@/lib/game/map/bridges"
 import { worldToTileX, worldToTileZ, type GameMap } from "@/lib/game/map/types"
@@ -61,6 +62,7 @@ export function CharacterSelectionShadow({ map, flying = false }: { map: GameMap
   }, [scene, flying])
   useFrame(() => {
     if (!anchor.current || !shadow.current) return
+    shadow.current.visible = isObjectVisible(anchor.current)
     anchor.current.getWorldPosition(position)
     const y = flying ? surfaceHeight(map, worldToTileX(map, position.x), worldToTileZ(map, position.z)) : position.y
     shadow.current.position.set(position.x, y + 0.035, position.z)

--- a/components/game/game-canvas.tsx
+++ b/components/game/game-canvas.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { DEFAULT_SCENE_VISIBILITY, type SceneVisibility } from "@/lib/game/scene-visibility"
 import { SURFACE_LIGHT } from "@/lib/game/render/lighting"
 
 import { useEffect, useMemo } from "react"
@@ -70,6 +71,7 @@ export function GameCanvas({
   relicTraffic,
   roadLook,
   showGrid = false,
+  visibility = DEFAULT_SCENE_VISIBILITY,
   buildType,
   shrineRenown,
   baseRenown,
@@ -107,7 +109,17 @@ export function GameCanvas({
   roadLook?: RoadLook
   /** Draw the global tile lattice over the ground. Off by default. */
   showGrid?: boolean
+  visibility?: SceneVisibility
 } & PixelationProps) {
+  const selection = useCameraStore(s => s.selection)
+  useEffect(() => {
+    if (!selection) return
+    const hidden = selection.kind === "tree" ? !visibility.showTrees
+      : selection.kind === "traveler" || selection.kind === "monk" ? !visibility.showCharacters
+        : selection.kind === "animal" ? !visibility.showWildlife
+          : visibility.buildingVisibility === "hidden"
+    if (hidden) useCameraStore.getState().select(null)
+  }, [selection, visibility.showTrees, visibility.showCharacters, visibility.showWildlife, visibility.buildingVisibility])
   const population = usePopulationStore(s => s.pack)
   const assets = useCharacterAssetStore(s => s.assets)
   const speedScales = useMemo(() => new Map(travelers.map(traveler => {
@@ -157,17 +169,28 @@ export function GameCanvas({
           showGrid={showGrid}
         />
         <Bridges map={map} roadTier={roadTier} />
-        <Trees map={map} placements={trees} ents={lastMarch} characterScale={characterScale} model={treeModel} />
-        <Environment map={map} />
-        <Wildlife map={map} trees={trees} characterScale={characterScale} />
-        <Buildings map={map} characterScale={characterScale} />
-        <Shrine map={map} relic={relic} />
-        <Signpost map={map} />
-        <PixelCharacters>
-          <Monks map={map} monks={monks} relic={relic} flying={blasterPastor} characterScale={characterScale} />
-        </PixelCharacters>
-        <Travelers map={map} travelers={travelers} speed={walkSpeed} speedScales={speedScales} relic={relic} trees={trees} shrineRenown={baseRenown}
-          characterModel={characterModel} characterScale={characterScale} characterFps={characterFps} walkTuning={walkTuning} movement={movement} />
+        {/* Keep simulation components mounted when their visual layer is hidden. */}
+        <group name="visibility-trees" visible={visibility.showTrees}>
+          <Trees map={map} placements={trees} ents={lastMarch} characterScale={characterScale} model={treeModel} />
+        </group>
+        <group name="visibility-scenery" visible={visibility.showScenery}>
+          <Environment map={map} />
+          <Signpost map={map} />
+        </group>
+        <group name="visibility-wildlife" visible={visibility.showWildlife}>
+          <Wildlife map={map} trees={trees} characterScale={characterScale} />
+        </group>
+        <group name="visibility-buildings" visible={visibility.buildingVisibility !== "hidden"}>
+          <Buildings map={map} characterScale={characterScale} showInteriors={visibility.buildingVisibility === "interiors"} />
+          <Shrine map={map} relic={relic} showInteriors={visibility.buildingVisibility === "interiors"} />
+        </group>
+        <group name="visibility-characters" visible={visibility.showCharacters}>
+          <PixelCharacters>
+            <Monks map={map} monks={monks} relic={relic} flying={blasterPastor} characterScale={characterScale} />
+          </PixelCharacters>
+          <Travelers map={map} travelers={travelers} speed={walkSpeed} speedScales={speedScales} relic={relic} trees={trees} shrineRenown={baseRenown}
+            characterModel={characterModel} characterScale={characterScale} characterFps={characterFps} walkTuning={walkTuning} movement={movement} />
+        </group>
       </RenownSaturation>
       <TileCursor map={map} buildType={buildType} resources={resources} shrineRenown={shrineRenown} />
       <BuildInfluenceOverlay map={map} buildMode={!!buildType} />

--- a/components/game/game-hud.tsx
+++ b/components/game/game-hud.tsx
@@ -53,6 +53,7 @@ import { BugReportDialog } from "./bug-report-dialog"
 import { browserDiagnostics, diagnosticsSchema, type BugReportDiagnostics } from "@/lib/bug-report"
 import { useBugReportRuntime } from "@/hooks/use-bug-report-runtime"
 import { useSimulationStore } from "@/lib/game/simulation-store"
+import { DEFAULT_SCENE_VISIBILITY, VISIBILITY_TOGGLES } from "@/lib/game/scene-visibility"
 import { Section, Tuner } from "./property-controls"
 import { BuildControls, HudClock, HudHelp, HudResources } from "./hud-controls"
 
@@ -119,15 +120,17 @@ function Chooser({
   value,
   options,
   onChange,
+  labelClassName = "w-16",
 }: {
   label: string
   value: number
   options: string[]
   onChange: (index: number) => void
+  labelClassName?: string
 }) {
   return (
     <div className="flex items-center">
-      <span className="w-16 shrink-0 text-[13px] font-medium text-ink-light">{label}</span>
+      <span className={`${labelClassName} shrink-0 text-[13px] font-medium text-ink-light`}>{label}</span>
       <div className="relative h-8 flex-1 rounded-[6px] bg-parchment-dark">
         <span className="absolute inset-x-1.5 top-1/2 -translate-y-1/2 truncate font-display text-[11px] font-black text-ink-light">
           {options[value]}
@@ -811,6 +814,17 @@ export function GameHud({
           />
           <p className="pt-1 text-[11px] italic text-ink-light">Pixel foliage draws the baked tree sprites from the playground; trees stand one to a tile.</p>
         </div>
+        <Section {...section("Visibility")}>
+          {VISIBILITY_TOGGLES.map(([key, label]) => (
+            <Chooser key={key} label={label} labelClassName="w-24" value={settings[key] ? 1 : 0}
+              options={["Hidden", "Shown"]} onChange={(index) => set({ [key]: index === 1 })} />
+          ))}
+          <Chooser label="Buildings" labelClassName="w-24" value={["auto", "interiors", "hidden"].indexOf(settings.buildingVisibility)}
+            options={["Automatic interiors", "Show all interiors", "Hidden"]}
+            onChange={(index) => set({ buildingVisibility: (["auto", "interiors", "hidden"] as const)[index] })} />
+          <p className="py-1 text-[11px] italic text-ink-light">Automatic interiors open when you select a building or someone inside. Scenery includes rocks, plants and the signpost. Hidden objects keep working.</p>
+          <HudButton onClick={() => set(DEFAULT_SCENE_VISIBILITY)}>Reset visibility</HudButton>
+        </Section>
         {SHOW_PROPERTY_PANELS && <>
         <Section {...section("Seed")}>
           <SeedField seed={seed} onSeedChange={onSeedChange} />

--- a/components/game/game-shell.tsx
+++ b/components/game/game-shell.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { DEFAULT_SCENE_VISIBILITY, VISIBILITY_TOGGLES, type SceneVisibility } from "@/lib/game/scene-visibility"
 import { DEFAULT_ELEVATION, type ElevationSettings } from "@/lib/game/map/elevation"
 import dynamic from "next/dynamic"
 import { useEffect, useMemo, useState } from "react"
@@ -54,7 +55,7 @@ const GameCanvas = dynamic(() => import("./game-canvas").then((m) => m.GameCanva
 })
 
 /** Map tuning knobs, in HUD units (coverage is a percentage for URL cleanliness). */
-export interface MapSettings {
+export interface MapSettings extends SceneVisibility {
   elevation: ElevationSettings
   /** Map edge length in tiles; maps are square. */
   size: number
@@ -106,6 +107,7 @@ export interface MapSettings {
 export const WATER_COUNT_AUTO = -1
 
 export const DEFAULT_SETTINGS: MapSettings = {
+  ...DEFAULT_SCENE_VISIBILITY,
   elevation: DEFAULT_ELEVATION,
   size: DEFAULT_MAP_WIDTH,
   coverage: Math.round(DEFAULT_FOREST_COVERAGE * 100),
@@ -209,6 +211,8 @@ export function GameShell({
       lakes: String(settings.lakes),
       ponds: String(settings.ponds),
     })
+    for (const [key] of VISIBILITY_TOGGLES) query.set(key, settings[key] ? "1" : "0")
+    query.set("buildingVisibility", settings.buildingVisibility)
     for (const [key, value] of Object.entries(settings.elevation)) query.set(`e_${key}`, String(value))
     window.history.replaceState(null, "", `?${query}`)
   }, [seed, settings])
@@ -330,6 +334,7 @@ export function GameShell({
           walkTuning={walkTuning}
           characterModel={settings.characterModel}
           treeModel={settings.treeModel}
+          visibility={settings}
           characterScale={settings.characterModel === "base" ? settings.baseSize : settings.draftSize}
           roadTier={settings.road}
           relicTraffic={relicTraffic}

--- a/components/game/shrine.tsx
+++ b/components/game/shrine.tsx
@@ -24,7 +24,7 @@ import {
 } from "@/lib/game/render/outline"
 
 /** A timber upper nave and lower thatched aisles shelter the rear altar. */
-export function Shrine({ map, relic }: { map: GameMap; relic: Relic }) {
+export function Shrine({ map, relic, showInteriors = false }: { map: GameMap; relic: Relic; showInteriors?: boolean }) {
   const unitInterior = useUnitInterior(map)
   const relicGroup = useRef<THREE.Group>(null)
   useFrame(() => {
@@ -59,7 +59,7 @@ export function Shrine({ map, relic }: { map: GameMap; relic: Relic }) {
   return (
     <group position={[layout.centreX, layout.baseY, layout.centreZ]}>
       <group rotation={[0, layout.rotation, 0]} onClick={event => selectElement({ kind: "building", id: hovel.id }, event)}>
-        <StructureModel terrainFloors parts={layout.parts} cutaway={selected || unitInterior === hovel.id} idColor={shrineId} ink={false} />
+        <StructureModel terrainFloors parts={layout.parts} cutaway={showInteriors || selected || unitInterior === hovel.id} idColor={shrineId} ink={false} />
         {[-1,1].map(side => <pointLight key={side} position={[side*.73,.8,layout.altarZ+.08]} color="#ffd184" intensity={.18} distance={1.8} decay={2} />)}
       </group>
       <group ref={relicGroup} position={[layout.offset.x,0,layout.offset.z]}><RelicDisplay color={relic.color} idColor={relicId} onClick={select} /></group>

--- a/lib/game/scene-visibility.ts
+++ b/lib/game/scene-visibility.ts
@@ -1,0 +1,41 @@
+/** Display preferences only; hiding a layer never changes the simulation. */
+export interface SceneVisibility {
+  showTrees: boolean
+  showCharacters: boolean
+  showWildlife: boolean
+  showScenery: boolean
+  buildingVisibility: "auto" | "interiors" | "hidden"
+}
+
+export const DEFAULT_SCENE_VISIBILITY: SceneVisibility = {
+  showTrees: true,
+  showCharacters: true,
+  showWildlife: true,
+  showScenery: true,
+  buildingVisibility: "auto",
+}
+
+export const VISIBILITY_TOGGLES = [
+  ["showTrees", "Trees"],
+  ["showCharacters", "Characters"],
+  ["showWildlife", "Wildlife"],
+  ["showScenery", "Scenery"],
+] as const
+
+export function parseSceneVisibility(params: Record<string, string | undefined>): Partial<SceneVisibility> {
+  const visibility: Partial<SceneVisibility> = {}
+  for (const [key] of VISIBILITY_TOGGLES) {
+    if (params[key] === "0" || params[key] === "1") visibility[key] = params[key] === "1"
+  }
+  const buildings = params.buildingVisibility
+  if (buildings === "auto" || buildings === "interiors" || buildings === "hidden") visibility.buildingVisibility = buildings
+  return visibility
+}
+
+/** Three's raycaster ignores visibility, unlike its renderer. Check ancestors too. */
+export function isObjectVisible(object: { visible?: boolean; parent?: object | null }): boolean {
+  for (let node: typeof object | null = object; node; node = node.parent ?? null) {
+    if (node.visible === false) return false
+  }
+  return true
+}

--- a/lib/game/selection.test.ts
+++ b/lib/game/selection.test.ts
@@ -74,6 +74,19 @@ describe("shared selection", () => {
     expect(prioritizePeople(people)).toBe(people)
   })
 
+  it("ignores hidden scenery and characters, including visible children of hidden layers", () => {
+    const hiddenLayer = { visible: false, parent: null }
+    const person = { visible: true, userData: {} as Record<string, unknown>, parent: hiddenLayer }
+    markPerson(person)
+    const walker = { object: { visible: true, parent: person } }
+    const roof = { object: { visible: false, parent: null } }
+    const tree = { object: { visible: true, parent: hiddenLayer } }
+    const ground = { object: { visible: true, parent: null } }
+    expect(prioritizePeople([walker, roof, tree, ground])).toEqual([ground])
+    hiddenLayer.visible = true
+    expect(prioritizePeople([ground, tree, walker])).toEqual([walker, ground, tree])
+  })
+
   it("clears the effect when a selected identity is gone", () => {
     expect(selectionObjectId(null, objects)).toBe(0)
     expect(selectionObjectId({ kind: "building", id: "gone" }, objects)).toBe(0)

--- a/lib/game/selection.ts
+++ b/lib/game/selection.ts
@@ -1,3 +1,4 @@
+import { isObjectVisible } from "./scene-visibility"
 import { useBuildStore } from "./build-store"
 import { isSelected, useCameraStore, type Selection } from "./camera-store"
 import {
@@ -45,6 +46,7 @@ export function selectionObjectId(selection: Selection | null, objects: {
 const PERSON_PICK = "person"
 
 interface PickObject {
+  visible?: boolean
   userData?: Record<string, unknown>
   parent?: PickObject | null
 }
@@ -72,6 +74,8 @@ function isPersonPick(object: PickObject | null | undefined): boolean {
  * build mode nothing stops it and the ground still takes the click.
  */
 export function prioritizePeople<T extends { object: PickObject }>(hits: readonly T[]): T[] {
+  const visibleHits = hits.filter(hit => isObjectVisible(hit.object))
+  if (visibleHits.length !== hits.length) hits = visibleHits
   const people = hits.filter((hit) => isPersonPick(hit.object))
   if (people.length === 0 || people.length === hits.length) return hits as T[]
   return [...people, ...hits.filter((hit) => !isPersonPick(hit.object))]


### PR DESCRIPTION
Adds a Visibility section to World settings so players can hide trees, characters, wildlife, scenery, and buildings, or reveal every building interior including the shrine.
Preferences persist in the URL and can be reset, while hidden objects continue simulating without intercepting clicks or leaving selection effects behind.

Validated with TypeScript checking, 23 focused tests, and browser checks covering cutaways, hidden layers, continued simulation, URL reload, and reset.
