### PR TITLE
Add saved map size defaults and a new-map size dialog

### DIFF
--- a/components/game/game-hud.tsx
+++ b/components/game/game-hud.tsx
@@ -21,7 +21,6 @@ import {
   dangerLabel,
 } from "@/lib/game/map/danger"
 import { clampRoadTier, ROAD_TIERS } from "@/lib/game/map/road"
-import { MIN_MAP_SIZE } from "@/lib/game/map/generate-map"
 import { TERRAIN } from "@/lib/game/map/terrain"
 import { tileAt, type BuildingDef, type GameMap } from "@/lib/game/map/types"
 import { nerve } from "@/lib/game/route-choice"
@@ -50,6 +49,8 @@ import { useBalanceStore } from "@/lib/game/balance-store"
 import { MusicPlayer } from "./music-player"
 import { HudButton } from "./hud-button"
 import { BugReportDialog } from "./bug-report-dialog"
+import { MapSizeControl } from "./map-size-control"
+import { NewMapDialog } from "./new-map-dialog"
 import { browserDiagnostics, diagnosticsSchema, type BugReportDiagnostics } from "@/lib/bug-report"
 import { useBugReportRuntime } from "@/hooks/use-bug-report-runtime"
 import { useSimulationStore } from "@/lib/game/simulation-store"
@@ -610,7 +611,10 @@ export function GameHud({
   economy,
   pixelation,
   onPixelationChange,
-  onReroll,
+  defaultMapSize,
+  mapSizeSaved,
+  onDefaultMapSizeChange,
+  onNewMap,
   onSeedChange,
   cheats,
 }: {
@@ -627,7 +631,10 @@ export function GameHud({
   onSettingsChange: (settings: MapSettings) => void
   pixelation: Required<PixelationProps>
   onPixelationChange: (patch: PixelationProps) => void
-  onReroll: () => void
+  defaultMapSize: number
+  mapSizeSaved: boolean
+  onDefaultMapSizeChange: (size: number) => void
+  onNewMap: (size: number) => void
   onSeedChange: (seed: number) => void
 }) {
   const readRuntime = useBugReportRuntime()
@@ -801,10 +808,15 @@ export function GameHud({
       {panel === "world" && <aside id="world-settings" className="hud-world hud-well" aria-label="World settings">
         <div className="hud-world-heading"><span>World</span><button type="button" aria-label="Close world settings" onClick={() => setPanel(null)}><X size={16} /></button></div>
         <div className="mb-4 flex flex-wrap gap-2">
-          <HudButton onClick={onReroll}>✦ New Map</HudButton>
+          <NewMapDialog defaultSize={defaultMapSize} onCreate={onNewMap} />
           <HudButton id="bug-report-button" onClick={openBugReport}>Report a bug</HudButton>
         </div>
         {reportError && <p role="alert" className="mb-4 text-sm text-red">{reportError}</p>}
+        <div className="mb-4 space-y-1">
+          <MapSizeControl label="Default size" value={defaultMapSize} onChange={onDefaultMapSizeChange} />
+          <p className="text-[11px] italic text-ink-light">Used for new maps and visits without a map size in the link. Your current map stays the same.</p>
+          {!mapSizeSaved && <p role="status" className="text-[11px] text-red">Could not save this preference. It will apply for this session only.</p>}
+        </div>
         <div className="mb-4">
           <Chooser
             label="Trees"
@@ -828,15 +840,7 @@ export function GameHud({
         {SHOW_PROPERTY_PANELS && <>
         <Section {...section("Seed")}>
           <SeedField seed={seed} onSeedChange={onSeedChange} />
-          <Tuner
-            label="Size"
-            value={settings.size}
-            display={String(settings.size)}
-            min={MIN_MAP_SIZE}
-            max={512}
-            step={32}
-            onChange={(size) => set({ size })}
-          />
+          <MapSizeControl label="Size" value={settings.size} onChange={(size) => set({ size })} />
         </Section>
 
         <Section {...section("Pixelation")}>

--- a/components/game/game-shell.tsx
+++ b/components/game/game-shell.tsx
@@ -16,6 +16,7 @@ import type { CharacterModel } from "@/lib/game/character-assets"
 import { DEFAULT_TREE_MODEL, type TreeModel } from "@/lib/game/trees/render-model"
 import { DEFAULT_ROAD_LOOK, DEFAULT_ROAD_TIER, ROAD_TIERS } from "@/lib/game/map/road"
 import { loadSavedSeed } from "@/lib/game/seed-storage"
+import { loadDefaultMapSize, saveDefaultMapSize } from "@/lib/game/map-size-storage"
 import { generateMonks } from "@/lib/game/monks"
 import { tileToWorldX, tileToWorldZ } from "@/lib/game/map/types"
 import { generateRelic, visitChance } from "@/lib/game/relic"
@@ -162,6 +163,9 @@ export function GameShell({
   const [seed, setSeed] = useState<number | null>(initialSeed ?? null)
   const [blasterPastor, setBlasterPastor] = useState(false)
   const [lastMarch, setLastMarch] = useState(false)
+  const [defaultMapSize, setDefaultMapSize] = useState(DEFAULT_MAP_WIDTH)
+  const [mapSizeReady, setMapSizeReady] = useState(false)
+  const [mapSizeSaved, setMapSizeSaved] = useState(true)
   const [settings, setSettings] = useState<MapSettings>({
     ...DEFAULT_SETTINGS,
     ...initialSettings,
@@ -174,6 +178,14 @@ export function GameShell({
   }
 
   useEffect(() => {
+    // Resolve the browser preference before generating terrain or writing the URL.
+    const size = loadDefaultMapSize()
+    setDefaultMapSize(size)
+    if (initialSettings?.size === undefined) setSettings(current => ({ ...current, size }))
+    setMapSizeReady(true)
+  }, [initialSettings?.size])
+
+  useEffect(() => {
     // A seed the player saved takes precedence over a random roll, but never
     // over one named in the URL (that arrives via initialSeed).
     if (seed === null) setSeed(loadSavedSeed() ?? randomSeed())
@@ -181,7 +193,7 @@ export function GameShell({
 
   // Keep seed and tuning in the URL so any map can be bookmarked and revisited.
   useEffect(() => {
-    if (seed === null) return
+    if (seed === null || !mapSizeReady) return
     const query = new URLSearchParams({
       seed: String(seed),
       size: String(settings.size),
@@ -216,11 +228,11 @@ export function GameShell({
     query.set("buildingVisibility", settings.buildingVisibility)
     for (const [key, value] of Object.entries(settings.elevation)) query.set(`e_${key}`, String(value))
     window.history.replaceState(null, "", `?${query}`)
-  }, [seed, settings])
+  }, [seed, settings, mapSizeReady])
 
   const baseMap = useMemo(
     () =>
-      seed === null
+      seed === null || !mapSizeReady
         ? null
         : generateMap({
             seed,
@@ -239,6 +251,7 @@ export function GameShell({
           }),
     [
       seed,
+      mapSizeReady,
       settings.elevation,
       settings.size,
       settings.coverage,
@@ -368,7 +381,16 @@ export function GameShell({
         onSettingsChange={setSettings}
         pixelation={pixelationSettings}
         onPixelationChange={(patch) => setPixelationOverrides((current) => ({ ...current, ...patch }))}
-        onReroll={() => setSeed(randomSeed())}
+        defaultMapSize={defaultMapSize}
+        mapSizeSaved={mapSizeSaved}
+        onDefaultMapSizeChange={size => {
+          setDefaultMapSize(size)
+          setMapSizeSaved(saveDefaultMapSize(size))
+        }}
+        onNewMap={size => {
+          setSettings(current => ({ ...current, size }))
+          setSeed(randomSeed())
+        }}
         onSeedChange={setSeed}
       />
       <CheatBar blasterPastor={blasterPastor} onBlasterPastor={() => setBlasterPastor(active => !active)} onLastMarch={() => setLastMarch(true)} />

--- a/components/game/map-size-control.tsx
+++ b/components/game/map-size-control.tsx
@@ -1,0 +1,16 @@
+"use client"
+
+import { MIN_MAP_SIZE } from "@/lib/game/map/generate-map"
+import { MAP_SIZE_STEP, MAX_MAP_SIZE } from "@/lib/game/map-size-storage"
+import { Tuner } from "./property-controls"
+
+/** Shared square-map dimensions for the saved preference and new-map dialog. */
+export function MapSizeControl({ label = "Map size", value, onChange }: {
+  label?: string
+  value: number
+  onChange: (size: number) => void
+}) {
+  return <Tuner label={label} labelClassName="w-24" value={value}
+    display={`${value} × ${value}`} min={MIN_MAP_SIZE} max={MAX_MAP_SIZE}
+    step={MAP_SIZE_STEP} showHandle onChange={onChange} />
+}

--- a/components/game/new-map-dialog.tsx
+++ b/components/game/new-map-dialog.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import { useState } from "react"
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog"
+import { HudButton } from "./hud-button"
+import { MapSizeControl } from "./map-size-control"
+
+/** Draft dimensions stay local until the player confirms a fresh world. */
+export function NewMapDialog({ defaultSize, onCreate }: {
+  defaultSize: number
+  onCreate: (size: number) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const [size, setSize] = useState(defaultSize)
+
+  return <Dialog open={open} onOpenChange={setOpen}>
+    <HudButton id="new-map-button" aria-haspopup="dialog" onClick={() => {
+      setSize(defaultSize)
+      setOpen(true)
+    }}>✦ New Map</HudButton>
+    <DialogContent className="hud-report max-h-[85dvh] overflow-y-auto rounded-none border-rule bg-parchment text-ink sm:max-w-md"
+      onKeyDown={event => event.stopPropagation()}
+      onCloseAutoFocus={event => {
+        event.preventDefault()
+        document.getElementById("new-map-button")?.focus()
+      }}>
+      <DialogTitle className="font-display text-lg">New map</DialogTitle>
+      <DialogDescription className="text-sm text-ink-light">
+        Choose the size of your new land. Creating a map replaces the current map and starts a fresh settlement.
+      </DialogDescription>
+      <form className="grid gap-4" onSubmit={event => {
+        event.preventDefault()
+        setOpen(false)
+        onCreate(size)
+      }}>
+        <MapSizeControl value={size} onChange={setSize} />
+        <p className="text-xs text-ink-light">Dimensions are in tiles. Larger maps take longer to generate.</p>
+        <div className="flex justify-end gap-3">
+          <HudButton onClick={() => setOpen(false)}>Cancel</HudButton>
+          <HudButton type="submit">Create map</HudButton>
+        </div>
+      </form>
+    </DialogContent>
+  </Dialog>
+}

--- a/lib/game/map-size-storage.test.ts
+++ b/lib/game/map-size-storage.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { DEFAULT_MAP_WIDTH, MIN_MAP_SIZE } from "./map/generate-map"
+import { loadDefaultMapSize, MAX_MAP_SIZE, saveDefaultMapSize } from "./map-size-storage"
+
+let saved: Map<string, string>
+beforeEach(() => {
+  saved = new Map()
+  vi.stubGlobal("window", {
+    localStorage: {
+      getItem: (key: string) => saved.get(key) ?? null,
+      setItem: (key: string, value: string) => saved.set(key, value),
+    },
+  })
+})
+afterEach(() => vi.unstubAllGlobals())
+
+describe("default map size", () => {
+  it("uses the original default until a size is saved", () => {
+    expect(loadDefaultMapSize()).toBe(DEFAULT_MAP_WIDTH)
+    for (const size of [MIN_MAP_SIZE, 256, MAX_MAP_SIZE]) {
+      expect(saveDefaultMapSize(size)).toBe(true)
+      expect(loadDefaultMapSize()).toBe(size)
+    }
+  })
+
+  it.each([0, MIN_MAP_SIZE - 1, MAX_MAP_SIZE + 1, 192.5, NaN, Infinity])(
+    "rejects invalid size %s without overwriting the preference", size => {
+      saveDefaultMapSize(256)
+      expect(saveDefaultMapSize(size)).toBe(false)
+      expect(loadDefaultMapSize()).toBe(256)
+      saved.set("pilgrimage.map-size", String(size))
+      expect(loadDefaultMapSize()).toBe(DEFAULT_MAP_WIDTH)
+    },
+  )
+
+  it("recovers from corrupt or inaccessible storage and server rendering", () => {
+    saved.set("pilgrimage.map-size", "broken")
+    expect(loadDefaultMapSize()).toBe(DEFAULT_MAP_WIDTH)
+    vi.stubGlobal("window", { get localStorage() { throw new Error("blocked") } })
+    expect(loadDefaultMapSize()).toBe(DEFAULT_MAP_WIDTH)
+    expect(saveDefaultMapSize(256)).toBe(false)
+    vi.stubGlobal("window", undefined)
+    expect(loadDefaultMapSize()).toBe(DEFAULT_MAP_WIDTH)
+    expect(saveDefaultMapSize(256)).toBe(false)
+  })
+})

--- a/lib/game/map-size-storage.ts
+++ b/lib/game/map-size-storage.ts
@@ -1,0 +1,30 @@
+import { DEFAULT_MAP_WIDTH, MIN_MAP_SIZE } from "./map/generate-map"
+
+export const MAX_MAP_SIZE = 512
+export const MAP_SIZE_STEP = 32
+const MAP_SIZE_STORAGE_KEY = "pilgrimage.map-size"
+
+function isMapSize(value: number): boolean {
+  return Number.isInteger(value) && value >= MIN_MAP_SIZE && value <= MAX_MAP_SIZE
+}
+
+/** Read after mounting; a bookmarked size still takes precedence over this default. */
+export function loadDefaultMapSize(): number {
+  try {
+    const value = Number(window.localStorage.getItem(MAP_SIZE_STORAGE_KEY))
+    return isMapSize(value) ? value : DEFAULT_MAP_WIDTH
+  } catch {
+    return DEFAULT_MAP_WIDTH
+  }
+}
+
+/** Keep the session usable when the browser cannot persist preferences. */
+export function saveDefaultMapSize(size: number): boolean {
+  if (!isMapSize(size)) return false
+  try {
+    window.localStorage.setItem(MAP_SIZE_STORAGE_KEY, String(size))
+    return true
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
World settings now lets players save a default map size from 128 × 128 to 512 × 512 tiles, and New Map opens a size chooser before replacing the current settlement.
The shared size control prefills the dialog from the saved preference, preserves the current map on cancellation, and keeps explicit bookmarked sizes ahead of the default.
Preferences load before terrain generation, validate stored values, and report when browser storage cannot save them.

Validation: TypeScript passed, all 50 targeted storage and map-generation tests passed, and desktop/mobile browser checks covered persistence, bookmark precedence, creation, cancellation, keyboard limits, and focus restoration with no browser errors.
