### PR TITLE
Use grid-aligned diagonal paths and remove grass seams from worn dirt

### DIFF
--- a/lib/game/map/diagonal-shapes.test.ts
+++ b/lib/game/map/diagonal-shapes.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { parseAsciiMap } from "./prototype-map"
-import { diagonalRoadPoint, roadDiagonals } from "./road"
+import { diagonalRoadBend, diagonalRoadPoint, roadDiagonals } from "./road"
 import { isWaterTile, shorelineCorners, shorelineInset } from "./shoreline"
 
 const staircase = parseAsciiMap([
@@ -13,23 +13,16 @@ const staircase = parseAsciiMap([
 ])
 
 describe("diagonal roads", () => {
-  it("prefers diagonals most of the time while retaining ordinary bends across seeded worlds", () => {
-    let diagonal = 0
+  it("straightens every seeded staircase instead of leaving random zigzag regions", () => {
     for (let seed = 0; seed < 1000; seed++) {
       const map = { ...staircase, seed }
-      const sides = roadDiagonals(map, 3, 2)
-      expect(roadDiagonals(map, 3, 2)).toEqual(sides)
-      // A local stretch has one style, rather than a different roll per tile.
-      expect(sides[1]).toBe(sides[2])
-      expect(roadDiagonals(map, 3, 3)[3]).toBe(sides[2])
-      if (sides[2]) diagonal++
-      else expect(diagonalRoadPoint(map, 3, 2)).toEqual({ x: 3, z: 2, laneScale: 1 })
+      expect(roadDiagonals(map, 3, 2)).toEqual([0, 1, 1, 0])
+      expect(roadDiagonals(map, 3, 3)).toEqual([1, 0, 0, 1])
+      expect(diagonalRoadPoint(map, 3, 2)).toEqual({ x: 2.75, z: 2.25, laneScale: Math.SQRT1_2 })
     }
-    expect(diagonal).toBeGreaterThan(870)
-    expect(diagonal).toBeLessThan(930)
   })
 
-  it("agrees at shared entrances across style-region boundaries", () => {
+  it("agrees at shared entrances across the former style-region boundaries", () => {
     // Move the staircase over the eight-tile region boundary.
     const shifted = parseAsciiMap([
       "..................", "......===.........", "........==........",
@@ -54,6 +47,32 @@ describe("diagonal roads", () => {
     expect(b).toEqual({ x: 3.25, z: 2.75, laneScale: Math.SQRT1_2 })
     // The two lane centres travel diagonally instead of stepping down a column.
     expect(b.x - a.x).toBe(b.z - a.z)
+  })
+
+  it("keeps shallow staircases on grid entrances and only straightens at 45 degrees", () => {
+    let rows = [
+      "...................", "====...............", "...===.............",
+      ".....===...........", ".......===.........", ".........=====.....",
+      "...................",
+    ]
+    for (let rotation = 0; rotation < 4; rotation++) {
+      const map = parseAsciiMap(rows)
+      for (let z = 0; z < map.depth; z++) for (let x = 0; x < map.width; x++) {
+        if (map.tiles[z * map.width + x] !== "path") continue
+        const bend = diagonalRoadBend(map, x, z)
+        if (!bend) {
+          expect(diagonalRoadPoint(map, x, z)).toEqual({ x, z, laneScale: 1 })
+          continue
+        }
+        // Each end stays at a tile-edge midpoint; no projected, off-grid joins.
+        for (const p of [bend.a, bend.b]) {
+          expect([[x, z + .5], [x + 1, z + .5], [x + .5, z], [x + .5, z + 1]])
+            .toContainEqual([p.x, p.z])
+        }
+        if (bend.straight) expect(Math.abs(bend.b.x - bend.a.x)).toBe(Math.abs(bend.b.z - bend.a.z))
+      }
+      rows = Array.from({ length: rows[0].length }, (_, x) => rows.map(row => row[x]).reverse().join(""))
+    }
   })
 
   it("preserves straight roads, isolated bends, junctions, plazas and bridge entries", () => {

--- a/lib/game/map/road.ts
+++ b/lib/game/map/road.ts
@@ -1,5 +1,4 @@
 import { OUTLINE_THICKNESS_PX } from "../render/outline"
-import { deriveSeed, makeRng, SEED_STREAM } from "../rng"
 import type { TerrainId } from "./terrain"
 import { tileAt, type GameMap } from "./types"
 
@@ -268,25 +267,7 @@ export function roadEdge(map: GameMap, x: number, z: number): RoadEdge {
   return { open, filledCorners, diagonal: roadDiagonals(map, x, z) }
 }
 
-/** Most suitable stretches straighten, with some ordinary bends for variety. */
-export const DIAGONAL_ROAD_SHARE = 0.9
-/** Choose a style over a stretch of land, rather than independently at every bend. */
-const ROAD_STYLE_REGION = 8
-
-function prefersDiagonalRoad(map: GameMap, x: number, z: number, nx: number, nz: number): boolean {
-  // Hand-authored fixtures express their shape directly. Generated worlds
-  // choose a repeatable mix, shared by the renderer and traveler movement.
-  if (map.seed === undefined) return true
-  // Use the shared entrance's midpoint, so both tiles make the same choice
-  // even when that entrance crosses a style-region boundary.
-  const rx = Math.floor((x + nx + 1) / (2 * ROAD_STYLE_REGION))
-  const rz = Math.floor((z + nz + 1) / (2 * ROAD_STYLE_REGION))
-  const region = Math.imul(rx, 73856093) ^ Math.imul(rz, 19349663)
-  const seed = deriveSeed(deriveSeed(map.seed, SEED_STREAM.roadShape), region)
-  return makeRng(seed)() < DIAGONAL_ROAD_SHARE
-}
-
-/** Only selected simple alternating bends straighten; junctions, plazas and bridges keep their entrances. */
+/** Alternating bends always use the grid's 45-degree diagonal; junctions, plazas and bridges keep their entrances. */
 export function roadDiagonals(map: GameMap, x: number, z: number): SideFlags {
   const bend = (bx: number, bz: number): number[] => {
     if (!isRoadTerrain(tileAt(map, bx, bz))) return []
@@ -300,7 +281,7 @@ export function roadDiagonals(map: GameMap, x: number, z: number): SideFlags {
     const [dx, dz] = EDGE_DIRS[side]
     const neighbour = bend(x + dx, z + dz)
     const other = sides.find((s) => s !== side)!
-    if (neighbour.includes(side ^ 1) && neighbour.includes(other ^ 1) && prefersDiagonalRoad(map, x, z, x + dx, z + dz)) {
+    if (neighbour.includes(side ^ 1) && neighbour.includes(other ^ 1)) {
       diagonal[side] = 1
     }
   }

--- a/lib/game/render/road-shape.ts
+++ b/lib/game/render/road-shape.ts
@@ -18,7 +18,10 @@ export const ROAD_SHAPE_GLSL = /* glsl */ `
     float d = 0.5 - distanceToTrack;
     float dn = d + roughness;
     float outer = smoothstep(edge - 0.06, edge + 0.12, dn);
-    float middle = smoothstep(inner - 0.06, inner + 0.04, dn);
+    // Once traffic has worn through the median, verge noise must not bring
+    // little green seams back through the middle of the dirt surface.
+    float middle = smoothstep(inner - 0.06, inner + 0.04, dn)
+      * (1.0 - smoothstep(0.5, 0.6, inner));
     return vec2(outer * (1.0 - middle), d);
   }
 


### PR DESCRIPTION
Eligible alternating road bends now consistently use the existing grid-aligned 45° diagonal instead of sometimes retaining a zigzag, with the existing route finding, tile entrances, and walking curves preserved.
The road shader also prevents noise from reintroducing grass seams through fully worn dirt.
Regression coverage checks seeded diagonals and tile-edge alignment across all four rotations.
Validated with 24 relevant tests, `npm run typecheck`, and an in-game visual check.
