### PR TITLE
Replace rabbit holes with subtle grass-covered burrows

### DIFF
--- a/components/game/terrain-tiles.tsx
+++ b/components/game/terrain-tiles.tsx
@@ -7,6 +7,7 @@ import * as THREE from "three"
 import { terrainCorner, type CliffCorner } from "@/lib/game/map/cliff-corners"
 import { waterDepthCorners } from "@/lib/game/map/water-depth-corners"
 import { groundCornerTiles, groundPaintCode } from "@/lib/game/map/ground-transitions"
+import { DEEP_WOOD_TINT, OPEN_MEADOW_TINT, DARK_WOOD_DARKEN } from "@/lib/game/render/ground-palette"
 import { GROUND_TRANSITIONS_GLSL } from "@/lib/game/render/ground-transitions"
 import { groundGrowthField } from "@/lib/game/environment/ground-growth"
 import { foundingRoadStrength, foundingRoadTraffic } from "@/lib/game/footpaths"
@@ -71,25 +72,6 @@ const DIRT_TEXTURE_URL = "/textures/dirt-side.png"
 const GRID_HALF_WIDTH = 0.025
 /** How much a grid line darkens the tile colour underneath it. */
 const GRID_DARKEN = 0.8
-
-/**
- * Anchor tints for the forest-shade gradient. Every tile's colour is pulled
- * (by its terrain's `shadeBlend`) toward a point on the ramp between these two,
- * chosen by how deep in the woods it sits — so the ground darkens under the
- * forest cluster and brightens continuously toward open meadow, instead of
- * snapping between two flat greens at the tree line.
- */
-const DEEP_WOOD_TINT = new THREE.Color("#36452a")
-const OPEN_MEADOW_TINT = new THREE.Color("#94a158")
-
-/**
- * The ground darkens by this much more under the heart of a dark forest.
- * Unlike the forest-shade tint this ignores `shadeBlend`: it is the canopy's
- * shadow, and it falls on the track cut through the old growth just as it
- * falls on the forest floor — a bright ribbon through the dark would lie
- * about how dark it is in there.
- */
-const DARK_WOOD_DARKEN = 0.4
 
 /**
  * Which ground wears the grass texture, and how strongly the tile's own colour

--- a/components/game/wildlife.tsx
+++ b/components/game/wildlife.tsx
@@ -3,7 +3,10 @@
 import { useEffect, useMemo, useRef } from "react"
 import { useFrame } from "@react-three/fiber"
 import * as THREE from "three"
-import type { GameMap } from "@/lib/game/map/types"
+import { worldToTileX, worldToTileZ, type GameMap } from "@/lib/game/map/types"
+import { computeForestShade, computeDarkShade } from "@/lib/game/map/forest-field"
+import { grassSurfaceColor } from "@/lib/game/render/ground-palette"
+import { deriveSeed, makeRng, SEED_STREAM } from "@/lib/game/rng"
 import { walkingSurface } from "@/lib/game/map/walking-surface"
 import { useBuildStore } from "@/lib/game/build-store"
 import { useSimulationStore } from "@/lib/game/simulation-store"
@@ -59,8 +62,17 @@ export function Wildlife({ map, trees, characterScale }: { map: GameMap; trees: 
       accumulator.current -= 1 / 30
     }
   }, -1)
+  const burrowTurf = useMemo(() => {
+    const shade = computeForestShade(map), dark = computeDarkShade(map)
+    const rng = makeRng(deriveSeed(map.seed ?? 0, SEED_STREAM.tileJitter))
+    const grains = map.tiles.map(() => rng() - .5)
+    return world.burrows.map(burrow => {
+      const i = worldToTileZ(map, burrow.z) * map.width + worldToTileX(map, burrow.x)
+      return grassSurfaceColor(shade[i], dark[i], grains[i])
+    })
+  }, [map, world])
   return <group name="wildlife" userData={{ animals: world.animals, burrows: world.burrows }}>
-    {world.burrows.map(burrow => <RabbitHole key={burrow.id} burrow={burrow} map={map} scale={characterScale} />)}
+    {world.burrows.map(burrow => <RabbitHole key={burrow.id} burrow={burrow} map={map} scale={characterScale} turf={burrowTurf[burrow.id]} />)}
     {batches.map(([kind, animals]) => <WildlifeBatch key={kind} kind={kind} animals={animals} map={map} scale={characterScale} />)}
   </group>
 }
@@ -140,13 +152,18 @@ export function WildlifeBatch({ kind, animals, map, scale, grazing }: { kind: Wi
   </group>
 }
 
-function RabbitHole({ burrow, map, scale }: { burrow: import("@/lib/game/wildlife/simulation").RabbitBurrow; map: GameMap; scale: number }) {
-  const rig = useMemo(() => createBurrowRig(), [])
+function RabbitHole({ burrow, map, scale, turf }: { burrow: import("@/lib/game/wildlife/simulation").RabbitBurrow; map: GameMap; scale: number; turf: THREE.Color }) {
+  const rig = useMemo(() => createBurrowRig(turf), [turf])
   useEffect(() => () => rig.dispose(), [rig])
   const surface = walkingSurface(map, burrow.x, burrow.z)
   const c = Math.cos(burrow.heading), s = Math.sin(burrow.heading)
   const rotation = new THREE.Euler(-Math.atan(surface.dx * s + surface.dz * c), burrow.heading, Math.atan(surface.dx * c - surface.dz * s), "YXZ")
   return <group name="rabbit-burrow" position={[burrow.x, surface.height, burrow.z]} rotation={rotation} scale={RIG_TO_WORLD * scale}>
     <primitive object={rig.root} />
+    {/* Like terrain, the raised bank writes depth with ID zero so selection
+        outlines cannot show rabbits through the turf roof. */}
+    <mesh geometry={rig.geometry} layers-mask={OUTLINE_ID_LAYER_MASK} raycast={() => null}>
+      <meshBasicMaterial color="#000000" side={THREE.DoubleSide} toneMapped={false} />
+    </mesh>
   </group>
 }

--- a/lib/game/render/ground-palette.ts
+++ b/lib/game/render/ground-palette.ts
@@ -1,0 +1,28 @@
+import * as THREE from "three"
+import { TERRAIN } from "../map/terrain"
+
+/**
+ * Anchor tints for the forest-shade gradient. Every tile's colour is pulled
+ * (by its terrain's `shadeBlend`) toward a point on the ramp between these two,
+ * chosen by how deep in the woods it sits — so the ground darkens under the
+ * forest cluster and brightens continuously toward open meadow, instead of
+ * snapping between two flat greens at the tree line.
+ */
+export const DEEP_WOOD_TINT = new THREE.Color("#36452a")
+export const OPEN_MEADOW_TINT = new THREE.Color("#94a158")
+
+/**
+ * The ground darkens by this much more under the heart of a dark forest.
+ * Unlike the forest-shade tint this ignores `shadeBlend`: it is the canopy's
+ * shadow, and it falls on the track cut through the old growth just as it
+ * falls on the forest floor — a bright ribbon through the dark would lie
+ * about how dark it is in there.
+ */
+export const DARK_WOOD_DARKEN = 0.4
+
+/** Grass base colour shared by terrain and small turf-covered scenery. */
+export function grassSurfaceColor(shade = 0, dark = 0, grain = 0) {
+  const tint = OPEN_MEADOW_TINT.clone().lerp(DEEP_WOOD_TINT, shade)
+  return new THREE.Color(TERRAIN.grass.color).lerp(tint, TERRAIN.grass.shadeBlend)
+    .multiplyScalar((1 + grain * TERRAIN.grass.jitter) * (1 - DARK_WOOD_DARKEN * dark))
+}

--- a/lib/game/wildlife/REFERENCES.md
+++ b/lib/game/wildlife/REFERENCES.md
@@ -21,6 +21,11 @@ in the game are authored animation choices, not measurements of wild animals.
 - [University of Michigan, European rabbit](https://animaldiversity.org/accounts/Oryctolagus_cuniculus/):
   burrowing rabbits use warrens. The game's rabbits approach a persistent opening,
   enter below its lip, remain underground and emerge from that same opening.
+- [University of Waikato Science Learning Hub, rabbit burrow photograph](https://www.sciencelearn.org.nz/images/1781-rabbit-burrow)
+  (checked 8 September 2026): a recessed entrance beneath a rooted, vegetated bank,
+  with exposed earth and scattered soil outside. `burrow.ts` simplifies those cues
+  into a low turf roof, irregular earthen lip and short scraped approach at the
+  shared character pixel scale; the dimensions are authored to fit the rabbit rig.
 - [Sheep locomotor study, 1999](https://journals.physiology.org/doi/full/10.1152/jappl.1999.87.5.1887):
   walking differs from diagonal trotting and suspended galloping. Sheep here use a
   slow walk with long support periods, remaining with their grazing flock.

--- a/lib/game/wildlife/burrow.test.ts
+++ b/lib/game/wildlife/burrow.test.ts
@@ -47,11 +47,18 @@ it("aligns at the approach and applies saved entry and exit timing in the world"
   expect(rabbit.shelter).toBeCloseTo(1-.05/BURROW_SECONDS)
 })
 
-it("keeps the hole flat and fully conceals the rabbit below ground at the end of entry", () => {
+it("raises a low bank and fully conceals the rabbit below ground at the end of entry", () => {
   const hole = createBurrowRig(), rabbit = createWildlifeRig("rabbit")
   const bounds = new THREE.Box3().setFromObject(hole.root)
   expect(bounds.min.y).toBeGreaterThanOrEqual(0)
-  expect(bounds.max.y).toBeLessThan(.03)
+  expect(bounds.max.y).toBeGreaterThan(.5)
+  expect(bounds.max.y).toBeLessThan(1)
+  // The entrance must remain open below the roof, with a recessed tunnel back.
+  hole.root.updateMatrixWorld(true)
+  const ray = new THREE.Raycaster(new THREE.Vector3(0, .2, 1), new THREE.Vector3(0, 0, -1))
+  const hits = ray.intersectObject(hole.root, true)
+  expect(hits.length).toBeGreaterThan(0)
+  expect(hits[0].point.z).toBeLessThan(-.4)
   for (const entering of [true, false]) {
     const motion = burrowMotion(1, entering)
     rabbit.pose(motion.clipPhase, false, 0, 0, false, "walk", { clip: "burrow", burrow: { ...motion, concealed: true } })

--- a/lib/game/wildlife/burrow.ts
+++ b/lib/game/wildlife/burrow.ts
@@ -1,29 +1,97 @@
 import * as THREE from "three"
-import { model } from "../transport/geometry"
+import { mergeVertices } from "three/examples/jsm/utils/BufferGeometryUtils.js"
+import { grassSurfaceColor } from "../render/ground-palette"
+import { model, type Point } from "../transport/geometry"
 
-/** A ground-level opening. Nested earthen edges shade into a dark throat;
- * the rabbit descends through this plane using the shared burrow motion. */
-export function createBurrowRig() {
-  const m = model()
-  function oval(rx: number, rz: number, y: number, z: number, color: string) {
-    const shape = new THREE.Shape()
-    for (let i = 0; i < 20; i++) {
-      const angle = i / 20 * Math.PI * 2
-      const edge = 1 + 0.035 * Math.sin(i * 2.7)
-      const x = Math.cos(angle) * rx * edge, depth = Math.sin(angle) * rz * edge
-      if (i === 0) shape.moveTo(x, depth)
-      else shape.lineTo(x, depth)
-    }
-    shape.closePath()
-    const geometry = new THREE.ShapeGeometry(shape)
-    geometry.rotateX(-Math.PI / 2)
-    return m.mesh(geometry, color, [0, y, z])
+/** A small turf bank with an open, earth-lined tunnel facing +Z.
+ * Shared by the world and animal playground, in the rabbit rig's units.
+ * The bank covers the existing underground path; its mouth stays at ground level.
+ */
+export function createBurrowRig(turfColor = grassSurfaceColor()) {
+  const m = model(), vertices: number[] = [], colors: number[] = []
+  const turf = [`#${turfColor.getHexString()}`]
+  const earth = ["#75654a", "#79694e", "#706047", "#7d6c50"]
+  function triangle(a: Point, b: Point, c: Point, color: string) {
+    vertices.push(...a, ...b, ...c)
+    const shade = new THREE.Color(color)
+    for (let i = 0; i < 3; i++) colors.push(shade.r, shade.g, shade.b)
   }
-  // Just enough offset to clear terrain depth, with no raised bank or roof.
-  oval(.58, .83, .012, -.05, "#736044")
-  oval(.51, .75, .016, -.06, "#51412d")
-  oval(.44, .66, .020, -.10, "#30281d")
-  const throat = oval(.38, .55, .024, -.16, "#000000")
-  throat.material.emissive.set("#16150f")
-  return m
+  function strip(a: Point[], b: Point[], palette: string[]) {
+    for (let i = 0; i < a.length - 1; i++) {
+      triangle(a[i], b[i], a[i + 1], palette[i % palette.length])
+      triangle(a[i + 1], b[i], b[i + 1], palette[(i + 1) % palette.length])
+    }
+  }
+  // Uneven half arches give the bank real thickness without blocking the mouth.
+  function arch(width: number, height: number, depth: number, lean = 0): Point[] {
+    return Array.from({ length: 13 }, (_, i) => {
+      const angle = i / 12 * Math.PI, rise = Math.sin(angle)
+      const rough = 1 + .045 * Math.sin(i * 2.4)
+      return [Math.cos(angle) * width * rough + .035 * rise,
+        .014 + rise * height * rough, depth - rise * lean]
+    })
+  }
+  const mouth = arch(.35, .40, .27, .14)
+  const lip = arch(.42, .46, .24, .18)
+  const brow = arch(.76, .56, -.03, .15)
+  const crown = arch(.86, .39, -.53, .05)
+  const heel = arch(.66, .10, -1.01)
+  const base = arch(.40, 0, -1.27)
+  strip(mouth, lip, earth)
+  strip(lip, brow, turf)
+  strip(brow, crown, turf)
+  strip(crown, heel, turf)
+  strip(heel, base, turf)
+
+  // Recessed walls and a shadowed back, rather than a black disk on the lawn.
+  const throat = arch(.29, .32, -.55)
+  strip(throat, mouth, ["#493d2b", "#50422f", "#594a35"])
+  for (let i = 0; i < throat.length - 1; i++) {
+    triangle([0, .014, -.55], throat[i], throat[i + 1], "#30291e")
+  }
+  triangle([-.35, .015, .27], [.35, .015, .27], [-.29, .015, -.55], "#403222")
+  triangle([.35, .015, .27], [.29, .015, -.55], [-.29, .015, -.55], "#403222")
+
+  // A short, irregular apron of scraped soil, kept flat for planted feet.
+  const apron: Point[] = [[-.35,.018,.18],[-.43,.018,.32],[-.46,.018,.53],
+    [-.34,.018,.66],[-.13,.018,.73],[.08,.018,.77],[.30,.018,.69],
+    [.44,.018,.53],[.42,.018,.36],[.35,.018,.18]]
+  const soil = ["#756047", "#786349", "#705c43", "#7c664a"]
+  for (let i = 0; i < apron.length - 1; i++) {
+    triangle([0,.023,.42], apron[i], apron[i + 1], soil[i % soil.length])
+  }
+
+  // Coarse turf blades break the rim silhouette at the same native pixel scale
+  // as the animals. Everything shares one vertex-coloured mesh/draw call.
+  for (const [x, y, z] of [brow[3], brow[8], crown[6]]) {
+    triangle([x-.07,y,z], [x+.04,y+.08,z-.025], [x+.02,y,z+.025], turf[0])
+    triangle([x-.02,y,z+.035], [x-.08,y+.06,z+.06], [x+.07,y,z+.065], turf[0])
+  }
+  for (const [x, z, size] of [[-.43,.60,.045],[.37,.69,.035]]) {
+    const top: Point = [x,.035,z]
+    triangle([x-size,.016,z], top, [x,.016,z+size], "#7d6c50")
+    triangle([x,.016,z+size], top, [x+size,.016,z], "#6b573e")
+  }
+  const faces = new THREE.BufferGeometry()
+  faces.setAttribute("position", new THREE.Float32BufferAttribute(vertices, 3))
+  faces.setAttribute("color", new THREE.Float32BufferAttribute(colors, 3))
+  // Weld the turf surface so lighting rolls across the mound without dark ribs.
+  const geometry = mergeVertices(faces)
+  faces.dispose()
+  geometry.computeVertexNormals()
+  // Ease turf lighting toward the surrounding ground, especially at the skirt.
+  // The tunnel keeps its full shading; the low bank should not read as a boulder.
+  const normal = geometry.getAttribute("normal"), color = geometry.getAttribute("color")
+  const position = geometry.getAttribute("position"), grass = new THREE.Color(turf[0])
+  const softened = new THREE.Vector3(), up = new THREE.Vector3(0, 1, 0)
+  for (let i = 0; i < normal.count; i++) {
+    if (Math.abs(color.getX(i) - grass.r) > 1e-6 || Math.abs(color.getY(i) - grass.g) > 1e-6) continue
+    const blend = .55 + .4 * (1 - Math.min(1, position.getY(i) / .24))
+    softened.fromBufferAttribute(normal, i).lerp(up, blend).normalize()
+    normal.setXYZ(i, softened.x, softened.y, softened.z)
+  }
+  const bank = m.mesh(geometry, "#ffffff", [0, 0, 0])
+  bank.material.vertexColors = true
+  bank.material.side = THREE.DoubleSide
+  return { ...m, geometry }
 }


### PR DESCRIPTION
Replace flat rabbit-hole ovals with low grassy banks, recessed earthen entrances, and small patches of disturbed soil in both the game and animal playground.
Share the terrain's meadow and woodland palette, shade, and seeded color variation so the softened turf blends into grass tiles, and include the raised bank in the existing depth mask to hide selection outlines behind it.
Document the photographic reference and update the burrow regression test to check the open entrance and underground concealment.

Validation: all 30 targeted wildlife tests and TypeScript checks pass; visually checked pixel scale, entry/exit frames, camera angles, and selection overlap in the existing app.
