### PR TITLE
Fix parallel cliff bands along diagonal rivers

### DIFF
--- a/lib/game/map/elevation.test.ts
+++ b/lib/game/map/elevation.test.ts
@@ -120,6 +120,24 @@ describe("topography", () => {
     expect(e.cliffs).toEqual([1, 2])
   })
 
+  it.each([0, 0.8])("keeps a diagonal river bank continuous with waterfall relief %s", (waterfallDrop) => {
+    // Reported seed: the northeast bank alternated between intact ground and
+    // deep, straight trenches whenever the river centerline took a grid turn.
+    const map = generateMap({ seed: 1995993239, elevation: { waterfallDrop } })
+    const e = map.elevation!, water = map.water!, w = map.width
+    // The river beside the affected bank is an ordinary flowing reach.
+    for (const [x, z] of [[28, 12], [30, 15], [32, 20], [33, 25]]) {
+      expect(water.motion![z * w + x]).toBe("flow")
+    }
+    for (let z = 8; z < 27; z++) for (let x = 35; x < 47; x++) {
+      const i = z * w + x
+      expect(water.depth[i]).toBe(0)
+      for (const n of [i + 1, i + w]) {
+        expect(Number.isFinite(elevationStep(e, i, n)), `bank at ${x},${z} → ${n}`).toBe(true)
+      }
+    }
+  })
+
   it("routes around a cliff and prefers a flat detour over a climb", () => {
     const water = new Uint8Array(25)
     const e = generateElevation(1, 5, 5, water)

--- a/lib/game/map/straighten-road.test.ts
+++ b/lib/game/map/straighten-road.test.ts
@@ -57,4 +57,21 @@ describe("initial roads through open land", () => {
     const map = fixture(); map.tiles[detour[3]] = "bridge"
     expect(straightenRoad(map, detour)).toContain(detour[3])
   })
+
+  it.each([false, true])("joins nearby perpendicular crossings without a deck U-turn (reversed: %s)", (reversed) => {
+    const map = fixture()
+    const route = [[2, 2], [2, 3], [2, 4], [2, 5], [3, 5], [4, 5], [5, 5], [6, 5], [7, 5]]
+      .map(([x, z]) => index(x, z))
+    const crossings = [index(2, 3), index(2, 4), index(4, 5), index(5, 5)]
+    for (const i of crossings) map.tiles[i] = "water"
+    if (reversed) route.reverse()
+    const line = straightenRoad(map, route)
+    expect(new Set(line).size).toBe(line.length)
+    expect(line[0]).toBe(route[0]); expect(line.at(-1)).toBe(route.at(-1))
+    for (const i of crossings) expect(line).toContain(i)
+    for (let i = 1; i < line.length; i++) {
+      expect(Math.abs(line[i] % 12 - line[i - 1] % 12)
+        + Math.abs(Math.floor(line[i] / 12) - Math.floor(line[i - 1] / 12))).toBe(1)
+    }
+  })
 })

--- a/lib/game/map/straighten-road.ts
+++ b/lib/game/map/straighten-road.ts
@@ -45,6 +45,11 @@ export function straightenRoad(map: GameMap, original: readonly number[]): numbe
         if (!approachOpen(route[join])) break
         const line = straightTiles(landing, route[join], map.width)
         if (line.includes(i) || !line.every(approachOpen) || !Number.isFinite(climb([i, ...line]))) continue
+        // Closely spaced crossings can align toward the same landing. Do not
+        // splice through retained road: that creates a loop and a U-turn on
+        // the deck, which has no continuous walking lane.
+        const retained = new Set([...route.slice(0, bank + 1), ...route.slice(join + 1)])
+        if (line.some((tile) => retained.has(tile))) continue
         // Keep the crossing and its ramp while reconnecting to the dry road.
         route.splice(bank + 1, join - bank, ...line)
         pinned.add(i); pinned.add(landing)
@@ -67,6 +72,10 @@ export function straightenRoad(map: GameMap, original: readonly number[]): numbe
       // Also regularize equal-length Manhattan paths: otherwise reducing random
       // routing costs still leaves arbitrary side-to-side steps in an empty glade.
       if (line.length > old.length || line.every((p, i) => p === old[i])) continue
+      // A shortcut must not double back through an already emitted tile or a
+      // later pinned approach, even when the straight line itself is clear.
+      const retained = new Set([...result.slice(0, -1), ...route.slice(to + 1)])
+      if (line.some((tile) => retained.has(tile))) continue
       best = to; replacement = line
     }
     result.push(...replacement.slice(1)); from = best

--- a/lib/game/map/water.ts
+++ b/lib/game/map/water.ts
@@ -132,7 +132,7 @@ export interface WaterField {
   kind: Uint8Array
   /** Row-major: 0 on land, 1–3 on water (distance from shore, capped). */
   depth: Uint8Array
-  /** Flow direction per river-water tile index. Lake tiles never flow. */
+  /** Smoothed unit heading for river-bank shaping. Lake tiles have no heading. */
   flow: Map<number, readonly [number, number]>
   /**
    * Land tiles on the inside bank of river bends — point bars, where a real
@@ -702,15 +702,6 @@ function carveBand(world: RiverWorld, river: RiverRecord, riverIndex: number, fr
   let added = 0
   for (let i = from; i <= to; i++) {
     const cur = line[i]
-    const nxt = line[Math.min(i + 1, line.length - 1)]
-    const ref = i + 1 < line.length ? nxt : line[i - 1]
-    let dx = (nxt % width) - (cur % width)
-    let dz = Math.floor(nxt / width) - Math.floor(cur / width)
-    if (i + 1 >= line.length) {
-      dx = (cur % width) - (ref % width)
-      dz = Math.floor(cur / width) - Math.floor(ref / width)
-    }
-    if (dx === 0 && dz === 0) continue
     const [ux, uz] = headings[i]
     const nx = -uz
     const nz = ux
@@ -736,7 +727,10 @@ function carveBand(world: RiverWorld, river: RiverRecord, riverIndex: number, fr
         }
         if (kind[t] === WATER_KIND_RIVER) {
           if (owner[t] === -1) owner[t] = riverIndex
-          flow.set(t, reversed ? [-dx, -dz] : [dx, dz])
+          // Bank shaping needs the river's tangent, not the alternating grid
+          // steps of a diagonal centerline. Those steps repeatedly classified
+          // the same bank as opposite sides, carving long parallel trenches.
+          flow.set(t, reversed ? [-ux, -uz] : [ux, uz])
         }
       }
     }


### PR DESCRIPTION
Diagonal river grid steps repeatedly flipped bank erosion on and off, producing long parallel cliff bands; bank shaping now uses the existing smoothed river heading.
Road alignment also avoids crossing retained route tiles, preventing bridge loops and U-turns exposed by the corrected terrain.
Regression tests cover seed 1995993239 with waterfalls enabled and disabled, plus nearby perpendicular bridge crossings in both travel directions.
Validation: all 1,327 tests pass (`npm test -- --maxWorkers=4`), `npm run typecheck` passes, and the reported seed was visually verified in the game.
