### PR TITLE
Add building back-edge borders for terrain contrast

### DIFF
--- a/components/game/outline-pass.tsx
+++ b/components/game/outline-pass.tsx
@@ -55,8 +55,8 @@ const VERTEX_SHADER = /* glsl */ `
  * Edge detection over the ID buffer. A pixel is outlined when a *nearer*
  * neighbour belongs to a different object — so the line lands on the occluded
  * side of the boundary, haloing the foreground shape from outside rather than
- * eating into it. Overlap mode additionally requires the outlined pixel itself
- * to be an object, so no line ever lands on terrain or the void.
+ * eating into it. Overlap mode also traces buildings against the terrain
+ * behind them; other scenery keeps only its object-overlap edges.
  */
 const FRAGMENT_SHADER = /* glsl */ `
   uniform sampler2D tId;
@@ -102,6 +102,9 @@ const FRAGMENT_SHADER = /* glsl */ `
     float idN = idAt(uv);
     if (idN < 0.5) return false;            // only objects cast a halo
     if (abs(idN - idC) < 0.5) return false; // same object, no boundary
+    // Buildings occupy IDs 1 through uTreeIdMin - 1, including player-built
+    // structures. Let their back edges read against terrain in overlap mode.
+    if (uMode == 1 && idC < 0.5 && idN >= uTreeIdMin) return false;
     // Scenery-only edges already exist in the enlarged world image.
     if (uCharacterPass && idC < uCharacterIdMin && idN < uCharacterIdMin) return false;
     float dN = texture2D(tDepth, uv).x;
@@ -185,7 +188,6 @@ const FRAGMENT_SHADER = /* glsl */ `
       }
     }
     if (uMode == 0) discard;
-    if (uMode == 1 && idC < 0.5) discard; // overlap halos land only on objects
     bool edge =
       occludedBy(pixelUv + vec2(uTexel.x, 0.0), idC, dC) ||
       occludedBy(pixelUv - vec2(uTexel.x, 0.0), idC, dC) ||

--- a/lib/game/render/outline.ts
+++ b/lib/game/render/outline.ts
@@ -4,9 +4,9 @@
  *
  * Every outline-able object (buildings, trees) renders a flat ID colour into an
  * offscreen buffer on a dedicated layer; terrain renders ID 0 there, writing
- * depth only. A screen-space pass then draws an edge where two *different,
- * non-zero* IDs meet — so an outline appears exactly where one object overlaps
- * another on screen, and never where an object just sits against grass.
+ * depth only. A screen-space pass draws an edge where different non-zero IDs
+ * meet, and where a building stands in front of terrain, keeping its back
+ * edges readable against grass.
  */
 
 /** The three.js layer that ID-coloured silhouette meshes live on. */
@@ -27,7 +27,7 @@ export const ROAD_EDGE_LAYER_MASK = 1 << ROAD_EDGE_LAYER
 
 /**
  * Rendering modes, in the order the O key cycles through them:
- *  - overlap:    outline only where an object overlaps a different object.
+ *  - overlap:    object overlaps, plus building edges against terrain.
  *  - silhouette: outline the whole silhouette, terrain boundaries included.
  *  - off:        no outlines, lighting alone separates objects.
  */
@@ -37,7 +37,7 @@ export type OutlineMode = (typeof OUTLINE_MODES)[number]
 export const DEFAULT_OUTLINE_MODE: OutlineMode = "overlap"
 
 export const OUTLINE_MODE_LABELS: Record<OutlineMode, string> = {
-  overlap: "Overlap only",
+  overlap: "Overlap + buildings",
   silhouette: "Full silhouette",
   off: "Off",
 }


### PR DESCRIPTION
Buildings now draw dark, one-pixel borders against the terrain behind their visible edges in the default overlap mode, improving contrast while preserving depth occlusion and the shared pixel scale. The outline mode label and code comments now describe this behavior.

Validated with `npm run typecheck`, `node --test scripts/test-sprite-depth.mjs`, and visual inspection of the live game scene.
