### PR TITLE
Remove ground glow from character selection

### DIFF
--- a/components/game/character-selection.tsx
+++ b/components/game/character-selection.tsx
@@ -1,13 +1,9 @@
 "use client"
 
-import { useEffect, useLayoutEffect, useMemo, useRef } from "react"
-import { createPortal, useFrame, useThree } from "@react-three/fiber"
+import { useEffect, useLayoutEffect, useRef } from "react"
+import { useThree } from "@react-three/fiber"
 import * as THREE from "three"
-import { isObjectVisible } from "@/lib/game/scene-visibility"
-import { PixelCharacters } from "@/components/pixel-canvas"
-import { surfaceHeight } from "@/lib/game/map/bridges"
-import { worldToTileX, worldToTileZ, type GameMap } from "@/lib/game/map/types"
-import { prioritizePeople, SELECTION_COLOR } from "@/lib/game/selection"
+import { prioritizePeople } from "@/lib/game/selection"
 import { SELECTED_CHARACTER_LAYER } from "@/lib/game/render/outline"
 import type { FigureClickHandler } from "./traveler-figure"
 
@@ -34,13 +30,10 @@ export function CharacterHitTarget({ onClick }: { onClick: FigureClickHandler })
   </mesh>
 }
 
-/** A soft ground glow that stays level during work, camping, and flight. */
-export function CharacterSelectionShadow({ map, flying = false }: { map: GameMap; flying?: boolean }) {
+/** Include the animated figure and carried items in the selection outline. */
+export function CharacterSelectionOutline({ flying = false }: { flying?: boolean }) {
   const anchor = useRef<THREE.Group>(null)
-  const shadow = useRef<THREE.Mesh>(null)
   const scene = useThree((s) => s.scene)
-  const position = useMemo(() => new THREE.Vector3(), [])
-  const uniforms = useMemo(() => ({ uColor: { value: new THREE.Color(SELECTION_COLOR) } }), [])
   useLayoutEffect(() => {
     const tagged: Array<{ object: THREE.Object3D; mask: number }> = []
     const include = (object: THREE.Object3D) => {
@@ -60,27 +53,5 @@ export function CharacterSelectionShadow({ map, flying = false }: { map: GameMap
       for (const { object, mask } of tagged) object.layers.mask = mask
     }
   }, [scene, flying])
-  useFrame(() => {
-    if (!anchor.current || !shadow.current) return
-    shadow.current.visible = isObjectVisible(anchor.current)
-    anchor.current.getWorldPosition(position)
-    const y = flying ? surfaceHeight(map, worldToTileX(map, position.x), worldToTileZ(map, position.z)) : position.y
-    shadow.current.position.set(position.x, y + 0.035, position.z)
-  })
-  return <>
-    <group ref={anchor} />
-    {createPortal(<PixelCharacters><mesh ref={shadow} name="character-selection-shadow" rotation={[-Math.PI / 2, 0, 0]} raycast={() => {}}>
-      <planeGeometry args={[1, 1]} />
-      <shaderMaterial transparent depthWrite={false} toneMapped={false} uniforms={uniforms}
-        vertexShader={`varying vec2 vUv;
-          void main() { vUv = uv; gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0); }`}
-        fragmentShader={`uniform vec3 uColor; varying vec2 vUv;
-          void main() {
-            float radius = length(vUv - 0.5) * 2.0;
-            float alpha = 0.3 * (1.0 - smoothstep(0.0, 1.0, radius));
-            gl_FragColor = vec4(uColor, alpha);
-            #include <colorspace_fragment>
-          }`} />
-    </mesh></PixelCharacters>, scene)}
-  </>
+  return <group ref={anchor} />
 }

--- a/components/game/monks.tsx
+++ b/components/game/monks.tsx
@@ -22,7 +22,7 @@ import * as THREE from "three"
 import { useSimulationStore } from "@/lib/game/simulation-store"
 import { isSelected, useCameraStore } from "@/lib/game/camera-store"
 import { markPerson, selectElement } from "@/lib/game/selection"
-import { CharacterHitTarget, CharacterSelectionShadow } from "./character-selection"
+import { CharacterHitTarget, CharacterSelectionOutline } from "./character-selection"
 import type { GameMap } from "@/lib/game/map/types"
 import { monkStaminaRegistry, monkRegistry, monkPositionRegistry, type Monk, type MonkActivity } from "@/lib/game/monks"
 import { createMonkFlight, monkGroundTime, recallMonkFlight, stepMonkFlight, type MonkFlight } from "@/lib/game/monk-flight"
@@ -300,7 +300,7 @@ export function Monks({ map, monks, relic, flying = false, characterScale = 1 }:
                 walkTuning={MONK_WALK_TUNING} />
             </Suspense>
             <CharacterHitTarget onClick={select} />
-            {selected && <CharacterSelectionShadow map={map} flying={airborneIds.has(monk.id)} />}
+            {selected && <CharacterSelectionOutline flying={airborneIds.has(monk.id)} />}
           </group>
         )
       })}

--- a/components/game/travelers.tsx
+++ b/components/game/travelers.tsx
@@ -16,7 +16,7 @@ import { travelerAppearance } from "@/lib/game/base-person/population"
 import { isSelected, useCameraStore } from "@/lib/game/camera-store"
 import { useSimulationStore } from "@/lib/game/simulation-store"
 import { markPerson, selectElement } from "@/lib/game/selection"
-import { CharacterHitTarget, CharacterSelectionShadow } from "./character-selection"
+import { CharacterHitTarget, CharacterSelectionOutline } from "./character-selection"
 import { useBalanceStore } from "@/lib/game/balance-store"
 import { setFootpathObstacles } from "@/lib/game/footpaths"
 import { jobBuildings } from "@/lib/game/settlement"
@@ -325,7 +325,7 @@ export function Travelers({
               <TravelerFigure map={map} job={jobs.get(traveler.id)} age={traveler.attributes.age} {...(traveler.type.id === "knight" ? knightLoadout(traveler.id) : cartLoadout(traveler.id))} appearance={appearances[index]} selected={selected} type={traveler.type} onClick={select} idColor={idColor}
                 characterModel={characterModel} characterScale={characterScale} characterFps={characterFps} walkTuning={walkTuning} />
               <CharacterHitTarget onClick={select} />
-              {selected && <CharacterSelectionShadow map={map} />}
+              {selected && <CharacterSelectionOutline />}
             </group>
           )
         })}


### PR DESCRIPTION
Remove the soft ground glow beneath selected monks and travelers while preserving selection outlines, carried-item highlighting, and click behavior. Rename the shared selection component to `CharacterSelectionOutline` and remove the unused glow shader, portal, and position updates.

Validation: `npm run typecheck`, all 19 tests in `npm test -- lib/game/selection.test.ts`, and `git diff --check` pass.
