### PR TITLE
Add mobile pinch zoom, panning, and responsive game menus

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -44,7 +44,7 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
-  maximumScale: 1,
+  viewportFit: 'cover',
   themeColor: '#1a1208',
 }
 

--- a/components/game/camera-rig.tsx
+++ b/components/game/camera-rig.tsx
@@ -6,6 +6,7 @@ import * as THREE from "three"
 
 import { groundHeight } from "@/lib/game/map/elevation"
 import { surfaceHeight, ropeHeightAt } from "@/lib/game/map/bridges"
+import { CameraGesture } from "@/lib/game/camera-gesture"
 import { useBuildStore } from "@/lib/game/build-store"
 import { useCameraStore } from "@/lib/game/camera-store"
 import { worldToTileX, worldToTileZ, type GameMap, type TilePos } from "@/lib/game/map/types"
@@ -45,12 +46,10 @@ export function CameraRig({ map, onPlace }: { map: GameMap; onPlace?: (at: TileP
     const canvas = gl.domElement
     const { pan, setHovered } = useCameraStore.getState()
 
-    let dragPointerId: number | null = null
-    let lastX = 0
-    let lastY = 0
-    let startX = 0
-    let startY = 0
-    let dragged = false
+    const gesture = new CameraGesture()
+    const point = (event: PointerEvent) => ({ x: event.clientX, y: event.clientY })
+    const previousTouchAction = canvas.style.touchAction
+    canvas.style.touchAction = "none"
 
     const updateHover = (event: PointerEvent) => {
       const rect = canvas.getBoundingClientRect()
@@ -89,62 +88,78 @@ export function CameraRig({ map, onPlace }: { map: GameMap; onPlace?: (at: TileP
     }
 
     const onPointerDown = (event: PointerEvent) => {
-      if (dragPointerId !== null) return
-      dragPointerId = event.pointerId
-      lastX = startX = event.clientX
-      lastY = startY = event.clientY
-      dragged = false
+      gesture.start(event.pointerId, point(event))
       canvas.setPointerCapture(event.pointerId)
+      if (gesture.pinching) setHovered(null)
     }
 
     const onPointerMove = (event: PointerEvent) => {
-      if (event.pointerId === dragPointerId) {
-        if (Math.hypot(event.clientX - startX, event.clientY - startY) > 6) dragged = true
-        const dx = event.clientX - lastX
-        const dy = event.clientY - lastY
-        lastX = event.clientX
-        lastY = event.clientY
-        if (dx !== 0 || dy !== 0) {
-          canvas.style.cursor = "grabbing"
-          const scale = worldPerPixel(displayViewSize.current, canvas.clientHeight)
-          const delta = panDelta(displayYaw.current, dx, dy, scale)
-          pan(delta.dx, delta.dz)
-        }
-        // A drag cannot place a building. Repeated terrain ray marches here
-        // compete with rendering on high-rate mice/trackpads; restore the
-        // cursor's tile when the drag ends.
-        if (dragged) {
-          // A committed drag is camera input. Avoid Fiber's per-object pointer
-          // handler filtering and hover raycasts until release.
-          event.stopPropagation()
-          if (useCameraStore.getState().hovered) setHovered(null)
-        } else updateHover(event)
+      const movement = gesture.move(event.pointerId, point(event))
+      if (!movement) {
+        if (event.pointerType !== "touch") updateHover(event)
         return
       }
-      updateHover(event)
+      if (gesture.dragged) {
+        canvas.style.cursor = "grabbing"
+        const rect = canvas.getBoundingClientRect()
+        const oldScale = worldPerPixel(displayViewSize.current, rect.height)
+        if (gesture.pinching) {
+          // Touch follows the fingers directly, including during a wheel tween.
+          useCameraStore.setState({ viewSize: displayViewSize.current })
+          useCameraStore.getState().zoomBy(movement.zoom)
+          displayViewSize.current = useCameraStore.getState().viewSize
+        }
+        const newScale = worldPerPixel(displayViewSize.current, rect.height)
+        const cx = rect.left + rect.width / 2, cy = rect.top + rect.height / 2
+        // Preserve the ground point under the moving pinch midpoint, even when
+        // zoom reaches its limits. A one-finger drag is the same transform.
+        const dx = (movement.after.x - cx) * newScale - (movement.before.x - cx) * oldScale
+        const dy = (movement.after.y - cy) * newScale - (movement.before.y - cy) * oldScale
+        const delta = panDelta(displayYaw.current, dx, dy, 1)
+        pan(delta.dx, delta.dz)
+        event.stopPropagation()
+        setHovered(null)
+      } else updateHover(event)
     }
 
     const endDrag = (event: PointerEvent) => {
-      if (event.pointerId !== dragPointerId) return
+      if (!gesture.has(event.pointerId)) return
+      const tap = gesture.end(event.pointerId, point(event), event.type !== "pointerup")
       if (canvas.hasPointerCapture(event.pointerId)) canvas.releasePointerCapture(event.pointerId)
-      dragPointerId = null
-      canvas.style.cursor = "grab"
-      updateHover(event)
-      if (event.type === "pointerup" && event.button === 0 && !dragged && Math.hypot(event.clientX - startX, event.clientY - startY) <= 6) {
+      canvas.style.cursor = gesture.active ? "grabbing" : "grab"
+      if (tap && event.button === 0) {
+        updateHover(event)
         const tile = useCameraStore.getState().hovered
         if (tile) placeRef.current?.(tile)
-      }
+      } else if (!gesture.active && event.pointerType !== "touch" && event.type === "pointerup") {
+        updateHover(event)
+      } else setHovered(null)
     }
 
+    // Fiber's click distance alone cannot distinguish a pinch from a tap.
+    const onClick = (event: MouseEvent) => {
+      if (gesture.dragged) {
+        event.preventDefault()
+        event.stopImmediatePropagation()
+      }
+    }
+    const onBlur = () => {
+      gesture.clear()
+      setHovered(null)
+      canvas.style.cursor = "grab"
+    }
     const onPointerLeave = () => {
-      if (dragPointerId === null) setHovered(null)
+      if (!gesture.active) setHovered(null)
     }
 
     // Suppress the context menu so right-drag panning stays available later.
     const onContextMenu = (event: Event) => event.preventDefault()
 
     canvas.style.cursor = "grab"
-    canvas.addEventListener("pointerdown", onPointerDown)
+    canvas.addEventListener("pointerdown", onPointerDown, true)
+    canvas.addEventListener("click", onClick, true)
+    canvas.addEventListener("lostpointercapture", endDrag)
+    window.addEventListener("blur", onBlur)
     canvas.addEventListener("pointermove", onPointerMove, true)
     canvas.addEventListener("pointerup", endDrag)
     canvas.addEventListener("pointercancel", endDrag)
@@ -152,7 +167,11 @@ export function CameraRig({ map, onPlace }: { map: GameMap; onPlace?: (at: TileP
     canvas.addEventListener("contextmenu", onContextMenu)
 
     return () => {
-      canvas.removeEventListener("pointerdown", onPointerDown)
+      canvas.style.touchAction = previousTouchAction
+      canvas.removeEventListener("pointerdown", onPointerDown, true)
+      canvas.removeEventListener("click", onClick, true)
+      canvas.removeEventListener("lostpointercapture", endDrag)
+      window.removeEventListener("blur", onBlur)
       canvas.removeEventListener("pointermove", onPointerMove, true)
       canvas.removeEventListener("pointerup", endDrag)
       canvas.removeEventListener("pointercancel", endDrag)

--- a/components/game/game-hud.css
+++ b/components/game/game-hud.css
@@ -137,36 +137,96 @@
 @media (max-width: 1100px) {
   .hud-brand { display: none; }
 }
-@media (max-width: 700px) {
-  .game-hud { --hud-right: var(--hud-space); --hud-map-height: 118px; --hud-header-height: calc(var(--hud-bar-height) * 2 + var(--hud-space)); }
-  .hud-header { display: grid; grid-template-columns: auto 1fr; }
-  .hud-resource-bar { grid-column: 1 / -1; justify-self: start; max-width: 100%; }
-  .hud-resources { gap: 8px; }
-  .hud-resources > :is(span, button) { font-size: 15px; }
-  .hud-header-actions { grid-column: 1; grid-row: 2; }
-  .hud-header-right { display: contents; }
-  .hud-clock { grid-column: 2; grid-row: 2; justify-self: end; }
-  .hud-details-dock { bottom: calc(var(--hud-space) * 2 + var(--hud-bar-height)); width: 160px; max-width: calc(100% - var(--hud-space) * 2); max-height: calc(100% - var(--hud-header-height) - var(--hud-bar-height) * 2 - var(--hud-space) * 5); }
-  .hud-details-dock[data-selected="true"] { width: 280px; }
-  .hud-minimap canvas { max-width: 140px; }
-  .hud-build-tray { margin-bottom: calc(var(--hud-map-height) + var(--hud-space)); }
-  .hud-building-tiles { overflow-x: auto; }
-  .hud-placement-status { font-size: 12px; }
-  .hud-world { top: calc(var(--hud-header-height) + var(--hud-bar-height) + var(--hud-space) * 3); width: min(var(--hud-dock-width), calc(100% - var(--hud-space) * 2)); max-height: calc(100% - var(--hud-map-height) - var(--hud-header-height) - var(--hud-bar-height) * 2 - var(--hud-space) * 6); }
-}
-
 .hud-resource-button { cursor: pointer; }
 .hud-resource-button:hover, .hud-resource-button[aria-expanded="true"] { color: #f9e5af; }
 .hud-resource-bar { min-width: 0; }
 .hud-resources { overflow-x: auto; }
 .hud-resources > :is(span, button) { flex-shrink: 0; }
-@media (max-width: 480px) {
-  .hud-clock { grid-column: 1 / -1; grid-row: 3; }
-  .game-hud { --hud-header-height: calc(var(--hud-bar-height) * 3 + var(--hud-space) * 2); }
-}
-
 .hud-traffic { position: absolute; top: calc(var(--hud-header-height) + var(--hud-space) * 2); left: var(--hud-space); width: 216px; gap: 8px; padding: 3px var(--hud-space); z-index: 24; font-size: 12px; }
 .hud-traffic input { min-width: 0; width: 100%; accent-color: #bea067; }
 .hud-traffic output { min-width: 34px; text-align: right; font-variant-numeric: tabular-nums; }
 
 .hud-report { font-family: var(--font-garamond), Georgia, serif; }
+
+.hud-mobile-camera, .hud-mobile-speed, .hud-building-label, .hud-building-cost { display: none; }
+.hud-menu { max-height: calc(100dvh - 100px); overflow-y: auto; overscroll-behavior: contain; }
+
+/* Reuse the HUD's wells and buttons, with one panel above a reachable toolbar. */
+@media (max-width: 1024px) {
+  .game-hud {
+    --hud-space: 8px;
+    --hud-bar-height: 52px;
+    --hud-header-height: 104px;
+    --hud-right: var(--hud-space);
+    inset: env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
+  }
+  .hud-frame { border-width: 3px; }
+  .hud-header { display: grid; grid-template-columns: auto 1fr; gap: 8px 4px; }
+  .hud-resource-bar { grid-column: 1 / -1; width: 100%; }
+  .hud-resources { width: 100%; justify-content: space-between; gap: 12px; min-height: 44px; }
+  .hud-resources > :is(span, button) { font-size: 16px; min-height: 44px; }
+  .hud-header-actions { grid-column: 1; grid-row: 2; }
+  .hud-header-right { display: contents; }
+  .hud-header-button { width: 44px; height: 44px; }
+  .hud-clock { grid-column: 2; grid-row: 2; justify-self: end; gap: 2px; padding: 0; height: 46px; }
+  .hud-day { font-size: 10px; margin-left: 4px; }
+  .hud-time { font-size: 15px; margin-right: 2px; }
+  .hud-pause { width: 44px; height: 44px; }
+  .hud-speeds { display: none; }
+  .hud-mobile-speed { display: block; width: 52px; padding: 0 3px; font-size: 16px; }
+  .hud-traffic { height: 36px; width: 190px; }
+  .hud-traffic input { height: 32px; }
+  .hud-action, .hud-close { min-height: 44px; }
+  .hud-close { width: 44px; }
+  .hud-bottom-actions { width: 100%; height: var(--hud-bar-height); gap: 4px; }
+  .hud-bottom-actions > .hud-action { flex: 1; padding-inline: 8px; }
+  .hud-mobile-camera { display: flex; flex: 1; gap: 4px; }
+  .hud-mobile-camera .hud-action { flex: 1; min-width: 44px; padding: 0; }
+  .hud-future-tool { display: none; }
+  .hud-build-tray { max-height: min(42dvh, 320px); overflow-y: auto; overscroll-behavior: contain; }
+  .hud-building-tiles { align-items: stretch; gap: 8px; padding-bottom: 6px; }
+  .hud-building-tile { width: 112px; height: auto; min-height: 110px; padding: 6px; }
+  .hud-building-tile img { margin-inline: auto; }
+  .hud-building-label, .hud-building-cost { display: block; line-height: 15px; }
+  .hud-building-label { font-size: 13px; margin-top: 4px; }
+  .hud-building-cost { font-size: 11px; color: #cbb783; }
+  .hud-building-tile kbd, .hud-build-rotation kbd { display: none; }
+  .hud-build-rotation { gap: 6px; }
+  .hud-build-rotation .hud-action { min-width: 44px; }
+  .hud-entry-key { flex-basis: 100%; }
+  .hud-placement-status { font-size: 13px; line-height: 17px; }
+  .hud-details-dock { display: none; bottom: calc(var(--hud-space) * 2 + var(--hud-bar-height)); width: 200px; max-height: 50%; }
+  .hud-details-dock[data-map-open="true"] { display: flex; }
+  .hud-details-dock[data-selected="true"] { display: flex; left: var(--hud-space); width: auto; }
+  .hud-details-dock[data-selected="true"] .hud-minimap { display: none; }
+  .hud-minimap { height: 144px; }
+  .hud-minimap canvas { max-width: 180px; }
+  .game-hud:is([data-panel="build"], [data-panel="world"], [data-panel="menu"]) .hud-details-dock { display: none; }
+  .game-hud:is([data-panel="world"], [data-panel="menu"]) .hud-traffic { visibility: hidden; }
+  .hud-world { top: calc(var(--hud-header-height) + var(--hud-space) * 2); bottom: calc(var(--hud-bar-height) + var(--hud-space) * 2); left: var(--hud-space); width: auto; max-height: none; z-index: 26; }
+  .hud-header-actions .hud-menu {
+    position: fixed;
+    top: calc(env(safe-area-inset-top) + var(--hud-header-height) + var(--hud-space) * 2);
+    bottom: calc(env(safe-area-inset-bottom) + var(--hud-bar-height) + var(--hud-space) * 2);
+    left: calc(env(safe-area-inset-left) + var(--hud-space));
+    right: calc(env(safe-area-inset-right) + var(--hud-space));
+    width: auto; max-height: none; margin-top: 0;
+  }
+  .hud-menu :is(a, nav button) { display: flex; align-items: center; min-height: 44px; font-size: 12px; }
+  .hud-world-heading { min-height: 44px; }
+  .hud-world-heading button, .hud-inspector button { min-width: 44px; min-height: 44px; }
+  .hud-choice-track { min-height: 44px; }
+  .hud-world :is(button, select), .hud-report button { min-height: 44px; }
+  .hud-world :is(input, select), .hud-report :is(input, select, textarea) { font-size: 16px; }
+  .hud-inspector summary { min-height: 44px; padding-block: 12px; }
+}
+
+@media (max-width: 1024px) and (max-height: 500px) {
+  .game-hud { --hud-header-height: 48px; }
+  .hud-header { display: flex; }
+  .hud-resource-bar { width: auto; flex: 1; }
+  .hud-header-right { display: flex; }
+  .hud-resources { gap: 8px; }
+  .hud-details-dock { max-height: calc(100% - 128px); }
+  .hud-build-tray { max-height: calc(100dvh - 208px); }
+}

--- a/components/game/game-hud.tsx
+++ b/components/game/game-hud.tsx
@@ -59,9 +59,9 @@ import { Section, Tuner } from "./property-controls"
 import { BuildControls, HudClock, HudHelp, HudResources } from "./hud-controls"
 
 const CONTROLS: Array<[string, string]> = [
-  ["Click", "Inspect people, trees & piles"],
+  ["Tap / click", "Inspect people, trees & piles"],
   ["Drag", "Pan"],
-  ["Scroll", "Zoom"],
+  ["Pinch / scroll", "Zoom"],
   ["Q / E", "Rotate view"],
   ["W A S D", "Pan"],
   ["O", "Cycle outlines"],
@@ -132,7 +132,7 @@ function Chooser({
   return (
     <div className="flex items-center">
       <span className={`${labelClassName} shrink-0 text-[13px] font-medium text-ink-light`}>{label}</span>
-      <div className="relative h-8 flex-1 rounded-[6px] bg-parchment-dark">
+      <div className="hud-choice-track relative h-8 flex-1 rounded-[6px] bg-parchment-dark">
         <span className="absolute inset-x-1.5 top-1/2 -translate-y-1/2 truncate font-display text-[11px] font-black text-ink-light">
           {options[value]}
         </span>
@@ -154,13 +154,14 @@ function Chooser({
 }
 
 /** Top-level navigation, folded into the play view. Controls live in here too. */
-function MenuPanel() {
+function MenuPanel({ onClose }: { onClose: () => void }) {
   const [showControls, setShowControls] = useState(false)
 
   return (
     <div
       className={`hud-menu pointer-events-auto absolute right-0 top-full mt-2 w-56 border border-rule bg-parchment/95 px-4 py-3 ${PANEL_SHADOW}`}
     >
+      <div className="hud-world-heading"><span>Menu</span><button type="button" className="hud-close" aria-label="Close menu" onClick={onClose}><X size={16} /></button></div>
       <nav className="flex flex-col gap-1.5">
         {SITE_MENU.map((item) => (
           <div key={item.href} className="flex flex-col gap-1">
@@ -191,6 +192,8 @@ function MenuPanel() {
         >
           Controls {showControls ? "▾" : "▸"}
         </button>
+        <button type="button" onClick={() => { useCameraStore.getState().reset(); onClose() }}
+          className="text-left font-display text-[11px] uppercase tracking-[2px] text-ink hover:text-red">Reset camera</button>
         {showControls && (
           <dl className="grid grid-cols-[auto_auto] gap-x-3 gap-y-0.5">
             {CONTROLS.map(([key, action]) => (
@@ -673,6 +676,7 @@ export function GameHud({
   const set = (patch: Partial<MapSettings>) => onSettingsChange({ ...settings, ...patch })
   const selection = useCameraStore((s) => s.selection)
   const [menuOpen, setMenuOpen] = useState(false)
+  const [minimapOpen, setMinimapOpen] = useState(false)
   const [panel, setPanel] = useState<"build" | "world" | "settlement" | null>(null)
 
   const closeBuild = () => {
@@ -767,7 +771,7 @@ export function GameHud({
   return (
     <Tooltip.Provider delayDuration={180} skipDelayDuration={100}>
     <BugReportDialog diagnostics={report} onClose={() => setReport(null)} />
-    <div className="game-hud">
+    <div className="game-hud" data-panel={menuOpen ? "menu" : panel ?? (selection ? "selection" : "none")}>
       <div className="hud-frame" aria-hidden="true" />
       <header className="hud-header">
         <div className="hud-resource-bar">
@@ -792,10 +796,11 @@ export function GameHud({
           <button type="button" className="hud-header-button" aria-label="Menu" title="Menu"
             aria-expanded={menuOpen} onClick={() => {
               setMenuOpen((open) => !open)
+              useCameraStore.getState().select(null)
               setPanel(null)
               economy.chooseBuild(null)
             }}><Menu size={16} /></button>
-          {menuOpen && <MenuPanel />}
+          {menuOpen && <MenuPanel onClose={() => setMenuOpen(false)} />}
         </div>
         <HudClock />
         </div>
@@ -1083,8 +1088,15 @@ export function GameHud({
         </>}
       </aside>}
 
-      <BuildControls economy={economy} open={panel === "build"} onToggle={toggleBuild} onClose={closeBuild} />
-      {map && <aside className="hud-details-dock hud-well" aria-label="Minimap and selection" data-selected={!!selection || panel === "settlement"}>
+      <BuildControls economy={economy} open={panel === "build"} onToggle={toggleBuild} onClose={closeBuild}
+        minimapOpen={minimapOpen} onToggleMinimap={() => {
+          setMinimapOpen((open) => !open)
+          setMenuOpen(false)
+          setPanel(null)
+          economy.chooseBuild(null)
+          useCameraStore.getState().select(null)
+        }} />
+      {map && <aside id="minimap-dock" data-map-open={minimapOpen} className="hud-details-dock hud-well" aria-label="Minimap and selection" data-selected={!!selection || panel === "settlement"}>
         {panel === "settlement" && <div className="hud-inspector" id="settlement-details">
           <SettlementPanel economy={economy} monks={monks} relic={relic} onClose={() => setPanel(null)} />
         </div>}

--- a/components/game/hud-controls.tsx
+++ b/components/game/hud-controls.tsx
@@ -3,7 +3,7 @@
 import Image from "next/image"
 import { useEffect, useMemo, useState, type ReactElement, type ReactNode } from "react"
 import * as Tooltip from "@radix-ui/react-tooltip"
-import { Coins, Footprints, Hammer, House, Pause, Play, RotateCcw, RotateCw, Sparkles, Users, X } from "lucide-react"
+import { Coins, Map, Minus, Plus, Footprints, Hammer, House, Pause, Play, RotateCcw, RotateCw, Sparkles, Users, X } from "lucide-react"
 
 import type { useSettlement } from "@/hooks/use-settlement"
 import { buildCatalog, buildingIncomeLabel } from "@/lib/game/balance"
@@ -66,11 +66,13 @@ export function HudResources({ economy, settlers, open, onToggle }: {
  * @see https://app.paper.design/file/01M1QTYBYHXP4H1BXFQ79N18AP/2-0/1GB-0
  * @see https://app.paper.design/file/01M1QTYBYHXP4H1BXFQ79N18AP/2-0/1SK-0
  */
-export function BuildControls({ economy, open, onToggle, onClose }: {
+export function BuildControls({ economy, open, onToggle, onClose, minimapOpen, onToggleMinimap }: {
   economy: ReturnType<typeof useSettlement>
   open: boolean
   onToggle: () => void
   onClose: () => void
+  minimapOpen: boolean
+  onToggleMinimap: () => void
 }) {
   const { map, balance, settlement, buildType, chooseBuild } = economy
   const rotation = useBuildStore((s) => s.rotation)
@@ -112,6 +114,8 @@ export function BuildControls({ economy, open, onToggle, onClose }: {
                 aria-pressed={buildType === item.id} aria-disabled={unavailable}
                 onClick={() => { if (!unavailable) chooseBuild(buildType === item.id ? null : item.id) }}>
                 <BuildThumbnail id={item.id} />
+                <span className="hud-building-label">{item.label}</span>
+                <span className="hud-building-cost">{locked ? `${item.requiredRenown} renown` : `${item.cost.gold} gold · ${item.cost.wood} wood`}</span>
                 {item.id === "workshop" && <kbd>L</kbd>}
               </button>
             </HudHelp>
@@ -131,18 +135,24 @@ export function BuildControls({ economy, open, onToggle, onClose }: {
       <button type="button" className="hud-close" aria-label="Close build options" onClick={onClose}><X size={14} /></button>
     </section>}
     {open && (selected || economy.message) && <div className={`hud-placement-status ${problem ? "hud-placement-error" : ""}`} role="status">
-      {problem ?? (selected ? `Place ${selected.label.toLowerCase()} inside influence · Click to build · Esc to cancel` : economy.message)}
+      {problem ?? (selected ? `Place ${selected.label.toLowerCase()} inside influence · Tap or click the map to build` : economy.message)}
     </div>}
     <nav className="hud-bottom-actions" aria-label="Building tools">
       <button id="build-menu-button" type="button" className="hud-action" aria-expanded={open} aria-controls="build-tray" onClick={onToggle}>
         <House size={17} aria-hidden />Build
       </button>
       <HudHelp content={<><div className="hud-help-title">Paths</div><p>Path construction is not available yet.</p></>}>
-        <button type="button" className="hud-action" aria-disabled="true"><Footprints size={17} aria-hidden />Paths</button>
+        <button type="button" className="hud-action hud-future-tool" aria-disabled="true"><Footprints size={17} aria-hidden />Paths</button>
       </HudHelp>
       <HudHelp content={<><div className="hud-help-title">Demolish</div><p>Building demolition is not available yet.</p></>}>
-        <button type="button" className="hud-action" aria-disabled="true"><Hammer size={17} aria-hidden />Demolish</button>
+        <button type="button" className="hud-action hud-future-tool" aria-disabled="true"><Hammer size={17} aria-hidden />Demolish</button>
       </HudHelp>
+      <div className="hud-mobile-camera" role="group" aria-label="Camera controls">
+        <button type="button" className="hud-action" aria-label="Zoom out" onClick={() => useCameraStore.getState().zoomBy(1.25)}><Minus size={18} /></button>
+        <button type="button" className="hud-action" aria-label="Zoom in" onClick={() => useCameraStore.getState().zoomBy(1 / 1.25)}><Plus size={18} /></button>
+        <button type="button" className="hud-action" aria-label="Rotate view" onClick={() => useCameraStore.getState().rotate(1)}><RotateCw size={18} /></button>
+        <button type="button" className="hud-action" aria-label="Toggle minimap" aria-expanded={minimapOpen} aria-controls="minimap-dock" onClick={onToggleMinimap}><Map size={18} /></button>
+      </div>
     </nav>
   </div>
 }
@@ -167,6 +177,13 @@ export function HudClock() {
       aria-pressed={paused} onClick={() => useSimulationStore.getState().togglePaused()}>
       {paused ? <Play size={14} /> : <Pause size={14} />}
     </button>
+    <select className="hud-mobile-speed hud-action" aria-label="Simulation speed" value={speed}
+      onChange={(event) => {
+        const choice = SIMULATION_SPEEDS.find((item) => item.rate === Number(event.target.value))
+        if (choice) useSimulationStore.getState().setSpeed(choice.rate)
+      }}>
+      {SIMULATION_SPEEDS.map(({ label, rate }) => <option key={rate} value={rate}>{label}×</option>)}
+    </select>
     <div className="hud-speeds" aria-label="Simulation speed">
       {SIMULATION_SPEEDS.map(({ label, rate }) => <button type="button" key={rate} aria-label={`${label}× simulation speed`} aria-pressed={speed === rate}
         onClick={() => useSimulationStore.getState().setSpeed(rate)}>{label}×</button>)}

--- a/lib/game/camera-gesture.test.ts
+++ b/lib/game/camera-gesture.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest"
+import { CameraGesture } from "./camera-gesture"
+
+describe("camera touch gestures", () => {
+  it("allows a tap with finger jitter, but rejects a drag that returns to its start", () => {
+    const gesture = new CameraGesture()
+    gesture.start(1, { x: 100, y: 100 })
+    gesture.move(1, { x: 103, y: 102 })
+    expect(gesture.end(1, { x: 103, y: 102 })).toBe(true)
+    gesture.start(2, { x: 100, y: 100 })
+    gesture.move(2, { x: 150, y: 100 })
+    gesture.move(2, { x: 100, y: 100 })
+    expect(gesture.end(2, { x: 100, y: 100 })).toBe(false)
+  })
+
+  it("zooms around the midpoint and continues panning after either finger lifts", () => {
+    for (const lifted of [1, 2]) {
+      const gesture = new CameraGesture()
+      gesture.start(1, { x: 100, y: 100 })
+      gesture.start(2, { x: 200, y: 100 })
+      expect(gesture.move(2, { x: 300, y: 100 })).toEqual({
+        before: { x: 150, y: 100, distance: 100 },
+        after: { x: 200, y: 100, distance: 200 },
+        zoom: 0.5,
+      })
+      expect(gesture.end(lifted, { x: lifted === 1 ? 100 : 300, y: 100 })).toBe(false)
+      const remaining = lifted === 1 ? 2 : 1
+      const x = remaining === 1 ? 100 : 300
+      const movement = gesture.move(remaining, { x: x + 10, y: 110 })!
+      expect(movement.after.x - movement.before.x).toBe(10)
+      expect(movement.zoom).toBe(1)
+      expect(gesture.end(remaining, { x: x + 10, y: 110 })).toBe(false)
+      expect(gesture.active).toBe(false)
+      gesture.start(3, { x: 100, y: 100 })
+      expect(gesture.end(3, { x: 100, y: 100 })).toBe(true)
+    }
+  })
+
+  it("never treats a stationary multi-touch sequence or cancellation as a tap", () => {
+    const gesture = new CameraGesture()
+    gesture.start(1, { x: 100, y: 100 })
+    gesture.start(2, { x: 100, y: 100 })
+    expect(gesture.move(2, { x: 101, y: 100 })?.zoom).toBe(1)
+    expect(gesture.end(2, { x: 101, y: 100 })).toBe(false)
+    expect(gesture.end(1, { x: 100, y: 100 })).toBe(false)
+    gesture.start(3, { x: 100, y: 100 })
+    expect(gesture.end(3, { x: 100, y: 100 }, true)).toBe(false)
+    gesture.start(4, { x: 100, y: 100 })
+    gesture.clear()
+    expect(gesture.move(4, { x: 150, y: 100 })).toBeNull()
+    expect(gesture.end(4, { x: 100, y: 100 })).toBe(false)
+  })
+})

--- a/lib/game/camera-gesture.ts
+++ b/lib/game/camera-gesture.ts
@@ -1,0 +1,54 @@
+export interface GesturePoint { x: number; y: number }
+
+function frame(points: Map<number, GesturePoint>) {
+  const [a, b] = points.values()
+  return b
+    ? { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2, distance: Math.hypot(b.x - a.x, b.y - a.y) }
+    : { ...a, distance: 0 }
+}
+
+/** A gesture stays camera-only after a drag or pinch, until every finger lifts. */
+export class CameraGesture {
+  private points = new Map<number, GesturePoint>()
+  private origin: GesturePoint = { x: 0, y: 0 }
+  dragged = false
+
+  has(id: number) { return this.points.has(id) }
+
+  get active() { return this.points.size > 0 }
+  get pinching() { return this.points.size > 1 }
+
+  start(id: number, point: GesturePoint) {
+    if (!this.active) {
+      this.origin = point
+      this.dragged = false
+    } else this.dragged = true
+    this.points.set(id, point)
+  }
+
+  move(id: number, point: GesturePoint) {
+    if (!this.points.has(id)) return null
+    const before = frame(this.points)
+    this.points.set(id, point)
+    if (Math.hypot(point.x - this.origin.x, point.y - this.origin.y) > 6) this.dragged = true
+    const after = frame(this.points)
+    return {
+      before, after,
+      zoom: before.distance > 0 && after.distance > 0 ? before.distance / after.distance : 1,
+    }
+  }
+
+  end(id: number, point: GesturePoint, cancelled = false) {
+    if (!this.points.has(id)) return false
+    const tap = !cancelled && !this.dragged && this.points.size === 1
+      && Math.hypot(point.x - this.origin.x, point.y - this.origin.y) <= 6
+    if (!tap) this.dragged = true
+    this.points.delete(id)
+    return tap
+  }
+
+  clear() {
+    this.points.clear()
+    this.dragged = true
+  }
+}


### PR DESCRIPTION
Adds one-finger panning and midpoint-anchored pinch zoom, with gesture cancellation and click suppression to prevent accidental selection or construction.

Adapts the existing HUD with touch-sized camera and playback controls, scrollable viewport-sized menus, a minimap toggle, visible building names and costs, and safe-area support while allowing browser page zoom.

Validated with TypeScript, 74 targeted tests, and Chromium touch and layout checks across phone portrait, phone landscape, tablet, and desktop viewports.

Uses the existing [HUD and build design](https://app.paper.design/file/01M1QTYBYHXP4H1BXFQ79N18AP/2-0/1GB-0).
