### PR TITLE
Align resting characters with benches and beds

### DIFF
--- a/components/game/character-sprite.tsx
+++ b/components/game/character-sprite.tsx
@@ -13,6 +13,7 @@ import type { FrameRegistration } from "@/lib/game/base-person/bake"
 import type { GameMap } from "@/lib/game/map/types"
 import { walkingSurface } from "@/lib/game/map/walking-surface"
 import { characterSupport } from "@/lib/game/character-support"
+import { restContacts, restContactOrigin } from "@/lib/game/base-person/rest-contact"
 import { personRecipe } from "@/lib/game/base-person/design"
 import { BASE_PERSON } from "@/lib/game/base-person/pose"
 import { walkContact, reducedWalkFrame, crossedWalkSupport, plantFoot, type FootPlant, type FootPlantResult, DEFAULT_WALK_STRIDE } from "@/lib/game/base-person/gait"
@@ -247,10 +248,11 @@ export function CharacterSprite({ map, type, onClick, outlineColor, selected = f
       }
     }
     if (sprite.current) sprite.current.userData.clip = flight ? "flying" : playing ? "performing" : action ? requested : moving ? "walk" : "idle"
+    origin.setFromMatrixPosition(parent.matrixWorld)
+    const support = map && !moving && !special && action ? characterSupport(map, origin.x, origin.z, requested) : undefined
+    if (support) heading = support.heading
     const direction = spriteRow(heading, yaw)
     const row = visual.rowOffset + direction
-    origin.setFromMatrixPosition(parent.matrixWorld)
-    const support = map && !moving && !flight ? characterSupport(map, origin.x, origin.z, requested) : undefined
     if (poseRoot.current) {
       if (workTarget && workPoint) {
         footPlant.current = null
@@ -285,8 +287,11 @@ export function CharacterSprite({ map, type, onClick, outlineColor, selected = f
         poseRoot.current.position.copy(corrected.applyMatrix4(parentInverse))
       } else {
         footPlant.current = null
-        if (support) {
-          corrected.set(origin.x, Math.max(origin.y, support.height), origin.z)
+        if (support && visual.design && (requested === "sitting" || requested === "sleeping" || requested === "seatedPrayer")) {
+          const point = restContacts(visual.design, requested, clip.columns)[frame]
+          const aligned = restContactOrigin({ ...support.anchor, y: support.height }, point,
+            direction, yaw, pitch, size / BASE_PERSON.camera.viewSize)
+          corrected.set(aligned.x, aligned.y, aligned.z)
           poseRoot.current.position.copy(corrected.applyMatrix4(parentInverse))
         } else poseRoot.current.position.set(0, 0, 0)
       }
@@ -318,9 +323,9 @@ export function CharacterSprite({ map, type, onClick, outlineColor, selected = f
       poseRoot.current.updateWorldMatrix(false, false)
       corrected.setFromMatrixPosition(poseRoot.current.matrixWorld)
       const surface = walkingSurface(map, corrected.x, corrected.z)
-      // The same authored top lifts the pose and clears enlarged scenery depth
-      // in both body and ID passes. Furniture is level even on graded terrain.
-      if (support && support.height >= surface.height) groundPlane.value.set(0, 1, 0, -support.height)
+      // A mattress supports the whole body; seated legs can hang below the
+      // bench, so their color and ID depth must still use the terrain plane.
+      if (support && requested === "sleeping" && support.height >= surface.height) groundPlane.value.set(0, 1, 0, -support.height)
       else groundPlane.value.set(-surface.dx, 1, -surface.dz,
         surface.dx * corrected.x + surface.dz * corrected.z - surface.height)
     } else groundPlane.value.set(0, 0, 0, 0)

--- a/lib/game/base-person/rest-contact.test.ts
+++ b/lib/game/base-person/rest-contact.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest"
+import * as THREE from "three"
+import { PERSON_PRESETS, personRecipe } from "./design"
+import { BASE_PERSON, PERSON_CLIPS } from "./pose"
+import { createBasePersonRig } from "./rig"
+import { POPULATION_PROFILES, populationDesign } from "./population"
+import { TRAVELER_TYPES } from "../travelers"
+import { restContacts, restContactOrigin } from "./rest-contact"
+import { structureParts } from "../building-art/structure"
+import { BUILD_CATALOG } from "../balance"
+import { BASE_CHARACTER_SCALE, PERSON_SPRITE_SCALE } from "./gait"
+
+const designs = [...POPULATION_PROFILES.map((_, variant) => populationDesign(TRAVELER_TYPES.peasant, variant)), PERSON_PRESETS.Monk]
+
+describe("furniture pose registration", () => {
+  it("fits the reclining population on the authored beds at the shared character scale", () => {
+    const beds = ["house", "shelter", "monk-shelter"].flatMap(type => {
+      const building = BUILD_CATALOG.find(b => b.id === type)!
+      return structureParts({ ...building, buildType: type }).filter(part => part.name.startsWith("straw-bed-"))
+    })
+    expect(beds.length).toBeGreaterThan(0)
+    for (const design of designs) {
+      const rig = createBasePersonRig(personRecipe(design))
+      try {
+        rig.pose(0, "sleeping")
+        rig.root.scale.setScalar(PERSON_SPRITE_SCALE * BASE_CHARACTER_SCALE / BASE_PERSON.camera.viewSize)
+        rig.root.updateMatrixWorld(true)
+        const bounds = new THREE.Box3()
+        for (const name of [design.garment === "Robe" ? "robe" : design.bodyType === "Female" ? "sleeveless-dress" : "shirt", "head-shape", "left-foot", "right-foot"]) {
+          bounds.expandByObject(rig.root.getObjectByName(name)!, true)
+        }
+        for (const bed of beds) {
+          expect(bounds.max.x - bounds.min.x).toBeLessThanOrEqual(bed.size![0])
+          expect(bounds.max.z - bounds.min.z).toBeLessThanOrEqual(bed.size![2])
+        }
+      } finally { rig.dispose() }
+    }
+  })
+
+  it("rests every population profile and monk outfit on the surface throughout both animations", () => {
+    const pitch = Math.tan(BASE_PERSON.camera.pitch * Math.PI / 180)
+    for (const design of designs) {
+      const rig = createBasePersonRig(personRecipe(design))
+      try {
+        for (const clip of ["sitting", "sleeping"] as const) {
+          const frames = PERSON_CLIPS[clip].frames
+          const contacts = restContacts(design, clip, frames)
+          for (let frame = 0; frame < frames; frame++) {
+            const scale = .427, target = { x: 3, y: .3, z: -2 }
+            const origin = restContactOrigin(target, contacts[frame], 0, 0, pitch, scale)
+            rig.root.position.set(origin.x, origin.y, origin.z)
+            rig.root.scale.setScalar(scale)
+            rig.pose(frame / frames, clip)
+            rig.root.updateMatrixWorld(true)
+            const torso = rig.root.getObjectByName(design.garment === "Robe" ? "robe" : design.bodyType === "Female" ? "sleeveless-dress" : "shirt")!
+            expect(new THREE.Box3().setFromObject(torso, true).min.y).toBeCloseTo(target.y, 6)
+            if (clip === "sitting") {
+              const hips = rig.root.getObjectByName("pelvis")!.getWorldPosition(new THREE.Vector3())
+              expect(hips.x).toBeCloseTo(target.x, 6)
+              expect(hips.z).toBeCloseTo(target.z, 6)
+            }
+          }
+        }
+      } finally { rig.dispose() }
+    }
+  })
+
+  it("keeps the baked contact's screen position and depth on rotated furniture at different zooms and pitches", () => {
+    const bakedPitch = BASE_PERSON.camera.pitch * Math.PI / 180
+    const point: [number, number, number] = [.08, .16, -.22]
+    for (const scale of [.28, .427, .7]) for (const yaw of [0, .23, Math.PI / 2, Math.PI]) {
+      for (const pitch of [.45, Math.tan(bakedPitch), 1.3]) for (let row = 0; row < 8; row++) {
+        const target = new THREE.Vector3(3, .3, -2)
+        const origin = restContactOrigin(target, point, row, yaw, pitch, scale)
+        const camera = new THREE.OrthographicCamera(-3, 3, 3, -3, .1, 30)
+        camera.position.set(10 * Math.sin(yaw), 10 * pitch, 10 * Math.cos(yaw))
+        camera.lookAt(0, 0, 0); camera.updateMatrixWorld(true)
+        // Sprite pixels and depth are camera-relative baked coordinates.
+        const baked = new THREE.Vector3(...point).multiplyScalar(scale)
+          .applyAxisAngle(new THREE.Vector3(0, 1, 0), -row * Math.PI / 4)
+          .applyAxisAngle(new THREE.Vector3(1, 0, 0), bakedPitch)
+        const registered = new THREE.Vector3(origin.x, origin.y, origin.z).applyMatrix4(camera.matrixWorldInverse).add(baked)
+        const expected = target.clone().applyMatrix4(camera.matrixWorldInverse)
+        expect(registered.distanceTo(expected)).toBeLessThan(1e-8)
+      }
+    }
+  })
+
+  it("uses the selected clip's frame count and caches contacts only for the same design", () => {
+    const design = PERSON_PRESETS.Stout
+    const contacts = restContacts(design, "sleeping", 12)
+    expect(contacts).toHaveLength(12)
+    expect(restContacts(design, "sleeping", 12)).toBe(contacts)
+    expect(restContacts(design, "sleeping", 16)).toHaveLength(16)
+    expect(restContacts({ ...design, build: .8 }, "sleeping", 12)).not.toEqual(contacts)
+  })
+})

--- a/lib/game/base-person/rest-contact.ts
+++ b/lib/game/base-person/rest-contact.ts
@@ -1,0 +1,55 @@
+import * as THREE from "three"
+import { personRecipe, type PersonDesign } from "./design"
+import { BASE_PERSON, type Point3 } from "./pose"
+import { createBasePersonRig } from "./rig"
+
+type RestClip = "sitting" | "sleeping" | "seatedPrayer"
+const contacts = new WeakMap<PersonDesign, Map<string, Point3[]>>()
+
+/** Register the outfit's underside, including proportions and saved pose edits. */
+export function restContacts(design: PersonDesign, clip: RestClip, frames: number): Point3[] {
+  let cached = contacts.get(design)
+  if (!cached) { cached = new Map(); contacts.set(design, cached) }
+  const key = `${clip}:${frames}`
+  const existing = cached.get(key)
+  if (existing) return existing
+  const rig = createBasePersonRig(personRecipe(design))
+  try {
+    const torso = rig.root.getObjectByName(design.garment === "Robe" ? "robe" : design.bodyType === "Female" ? "sleeveless-dress" : "shirt") as THREE.Mesh
+    const pelvis = rig.root.getObjectByName("pelvis")!
+    const body = [torso, ...["head-shape", "left-foot", "right-foot"].map(name => rig.root.getObjectByName(name)!)]
+    const point = new THREE.Vector3(), bounds = new THREE.Box3()
+    const result = Array.from({ length: frames }, (_, frame): Point3 => {
+      rig.pose(frame / frames, clip)
+      rig.root.updateMatrixWorld(true)
+      // The hem/back rests on the top. Feet, hands, pillows and snore marks
+      // must not lower this contact or shift a seat away from the hips.
+      bounds.setFromObject(torso, true)
+      const height = bounds.min.y
+      if (clip === "sleeping") {
+        // Centre head to toe on the mattress. Accessories, breathing hands,
+        // the ground pillow and effects do not move the body's resting place.
+        bounds.makeEmpty()
+        for (const part of body) bounds.expandByObject(part, true)
+        bounds.getCenter(point)
+      } else pelvis.getWorldPosition(point)
+      return [point.x, height, point.z]
+    })
+    cached.set(key, result)
+    return result
+  } finally { rig.dispose() }
+}
+
+/** Undo the baked camera projection, then register color and depth at the live pitch. */
+export function restContactOrigin(target: { x: number; y: number; z: number }, point: Point3,
+  direction: number, yaw: number, pitch: number, scale: number) {
+  const facing = -direction * Math.PI / 4
+  const x = (point[0] * Math.cos(facing) + point[2] * Math.sin(facing)) * scale
+  const z = (-point[0] * Math.sin(facing) + point[2] * Math.cos(facing)) * scale
+  const y = point[1] * scale
+  const tilt = Math.atan(pitch) - BASE_PERSON.camera.pitch * Math.PI / 180
+  const depth = z * Math.cos(tilt) - y * Math.sin(tilt)
+  return { x: target.x - x * Math.cos(yaw) - depth * Math.sin(yaw),
+    y: target.y - y * Math.cos(tilt) - z * Math.sin(tilt),
+    z: target.z + x * Math.sin(yaw) - depth * Math.cos(yaw) }
+}

--- a/lib/game/building-art/early-geometry.ts
+++ b/lib/game/building-art/early-geometry.ts
@@ -194,8 +194,8 @@ export function earlyBuildingParts(recipe: ConstructionRecipe): BuildingPart[] {
     } else panel(name,a,b,(a[2]+b[2])/2>=0)
   }
   function bedding(x: number,z: number,index: number, length: number) {
-    box(`straw-bed-${index}`,"base",[x,floor+.035,z],[.32,.07,length],palette.strawDark,undefined,false)
-    box(`wool-cover-${index}`,"base",[x,floor+.08,z+.06],[.28,.035,length*.65],index%2?"#817864":"#716e57",undefined,false)
+    box(`straw-bed-${index}`,"base",[x,floor+.035,z],[.38,.07,length],palette.strawDark,undefined,false)
+    box(`wool-cover-${index}`,"base",[x,floor+.08,z+.06],[.34,.035,length*.65],index%2?"#817864":"#716e57",undefined,false)
     parts[parts.length - 1].support = { clips: ["sleeping"], anchorOffset: [0, -.06], heading: 0 }
     box(`rolled-blanket-${index}`,"base",[x,floor+.1,z-length*.32],[.3,.11,.12],"#a3987a",undefined,false)
   }
@@ -438,7 +438,7 @@ export function earlyBuildingParts(recipe: ConstructionRecipe): BuildingPart[] {
       const hearth = shelterHearth(width,depth,h,rise)
       const bedLeft = -w+.24, bedRight = hearth.x-.285*hearth.scale-.24
       const beds = Math.max(1,Math.min(HOUSE_BEDS,Math.floor((bedRight-bedLeft)/.42)+1))
-      for(let i=0;i<beds;i++) bedding(beds === 1 ? (bedLeft+bedRight)/2 : bedLeft+(bedRight-bedLeft)*i/(beds-1),-depth*.15,i,Math.min(.7,depth*.6))
+      for(let i=0;i<beds;i++) bedding(beds === 1 ? (bedLeft+bedRight)/2 : bedLeft+(bedRight-bedLeft)*i/(beds-1),-depth*.15,i,Math.min(.9,depth*.6))
     }
     if(variant === "hall") {
       bench("hall-bench",0,-depth*.25,width*.65,.3,0)
@@ -457,7 +457,8 @@ export function earlyBuildingParts(recipe: ConstructionRecipe): BuildingPart[] {
     if(variant === "monk-shelter" || variant === "shelter") {
       if (variant === "shelter") {
         // Leave the rear-right hearth and front table clear of bedding.
-        for(let i=0;i<2;i++) bedding(-width*.3,-depth*.18+i*depth*.35,i,Math.min(.58,depth*.28))
+        // Full-length bodies share a column, with a gap between the two beds.
+        for(let i=0;i<2;i++) bedding(-width*.3,-depth*.24+i*depth*.48,i,Math.min(.9,depth*.44))
         bench("pilgrim-bench",width*.1,depth*.43,width*.4,.23,Math.PI)
         parts.push(...furnishingParts("shelter",width,depth,h,rise))
       } else {
@@ -465,7 +466,7 @@ export function earlyBuildingParts(recipe: ConstructionRecipe): BuildingPart[] {
         // Keep every bed left of the fireplace, including one-tile recipe previews.
         const hearth = shelterHearth(width,depth,h,rise)
         const left = -w+.22, right = hearth.x-.285*hearth.scale-.24
-        for(let i=0;i<beds;i++) bedding(beds === 1 ? (left+right)/2 : left+(right-left)*i/(beds-1),-depth*.08,i,Math.min(.72,depth*.6))
+        for(let i=0;i<beds;i++) bedding(beds === 1 ? (left+right)/2 : left+(right-left)*i/(beds-1),-depth*.08,i,Math.min(.9,depth*.6))
       }
     } else if (variant === "market") {
       bench("stall-counter",0,depth*.23,width*.72,.38)


### PR DESCRIPTION
Seated and sleeping characters now align their rig contact points and facing with benches and beds across character proportions, animation frames, and camera angles, with seated legs retaining correct depth below benches.
Bedding is wider and longer, and the pilgrim shelter's beds are spaced to fit reclining characters at the shared sprite scale.
Validation: targeted contact, furniture, construction, and activity tests passed, as did TypeScript checking and visual checks of benches, beds, and selection outlines from multiple camera views.
The broader hospitality suite had one failure in its shrine visit-count assertion (9 visits, expected fewer than 9), observed before the bedding changes.
