### PR TITLE
Add staffed roadside towns and a day-based calendar

### DIFF
--- a/components/game/game-hud.css
+++ b/components/game/game-hud.css
@@ -69,7 +69,7 @@
 .hud-minimap-north { position: absolute; top: var(--hud-space); right: var(--hud-space); color: #ecdfb7; font-size: 12px; }
 .hud-clock { gap: var(--hud-control-gap); padding: 3px; white-space: nowrap; }
 .hud-day { margin-left: var(--hud-control-gap); font-family: var(--font-cinzel), serif; color: #d4c297; font-size: 12px; }
-.hud-time { margin-right: var(--hud-control-gap); font-size: 18px; font-variant-numeric: tabular-nums; line-height: 24px; }
+.hud-date { margin-left: 4px; margin-right: var(--hud-control-gap); font-size: 14px; font-variant-numeric: tabular-nums; line-height: 24px; }
 .hud-pause { width: 28px; height: 28px; display: flex; align-items: center; justify-content: center; cursor: pointer; }
 .hud-speeds { display: flex; gap: var(--hud-control-gap); }
 .hud-speeds button { min-width: 28px; height: 28px; padding: 0 4px; font-size: 12px; cursor: pointer; }
@@ -170,7 +170,7 @@
   .hud-header-button { width: 44px; height: 44px; }
   .hud-clock { grid-column: 2; grid-row: 2; justify-self: end; gap: 2px; padding: 0; height: 46px; }
   .hud-day { font-size: 10px; margin-left: 4px; }
-  .hud-time { font-size: 15px; margin-right: 2px; }
+  .hud-date { font-size: 11px; margin-right: 2px; }
   .hud-pause { width: 44px; height: 44px; }
   .hud-speeds { display: none; }
   .hud-mobile-speed { display: block; width: 52px; padding: 0 3px; font-size: 16px; }

--- a/components/game/game-hud.tsx
+++ b/components/game/game-hud.tsx
@@ -1107,6 +1107,7 @@ export function GameHud({
             <div className="flex items-center justify-between gap-4"><Label>{selectedDefinition?.category === "scenery" ? "Scenery" : "Building"}</Label><button type="button" aria-label="Dismiss building" onClick={() => useCameraStore.getState().select(null)} className="pointer-events-auto text-xs text-ink-light">✕</button></div>
             <p className="mt-1 font-display text-xs text-ink">{selectedBuilding.label}</p>
             <ConstructionStatus building={selectedBuilding} />
+            {selectedBuilding.owner === "independent" && <p className="mt-2 max-w-56 text-[11px] text-ink-light">Independent roadside town. {selectedBuilding.buildType === "tavern" ? "Locally run tavern serving food and drink to passing travelers." : "Home to the townspeople."} Joins your settlement when your influence reaches this building; until then, it earns you no income or renown.</p>}
             {isMonkShelter(selectedBuilding) && isComplete(selectedBuilding) && <p className="mt-1 text-[11px] text-ink-light">{brothersAtHome} / {housingBeds(selectedBuilding)} monks · {Math.max(0, housingBeds(selectedBuilding) - brothersAtHome)} spaces available. Tired monks sleep here until their stamina recovers.</p>}
             {isHouse(selectedBuilding) && isComplete(selectedBuilding) && <p className="mt-1 text-[11px] text-ink-light">
               {household} / {housingBeds(selectedBuilding)} settlers · {Math.max(0, housingBeds(selectedBuilding) - household)} spaces available. They come back here to sleep and eat.
@@ -1129,7 +1130,7 @@ export function GameHud({
               {FOOD_TYPES.map(type => <p key={type}>{FOOD_LABELS[type]} · {foodStock[type]}</p>)}
               <p className="mt-1 italic">Food supplies start empty; food gathering is still to come.</p>
             </div>}
-            {selectedDefinition && isComplete(selectedBuilding) && <>
+            {selectedBuilding.owner !== "independent" && selectedDefinition && isComplete(selectedBuilding) && <>
               <p className="mt-2 text-[11px] text-ink-light">Contributes +{selectedDefinition.renown} shrine renown</p>
               <p className="mt-1 max-w-56 text-[11px] italic text-ink-light">{selectedDefinition.description}</p>
               <p className="mt-1 text-[11px] text-ink-light">{buildingIncomeLabel(selectedDefinition, economy.balance)}</p>

--- a/components/game/game-shell.tsx
+++ b/components/game/game-shell.tsx
@@ -1,5 +1,7 @@
 "use client"
 
+import { townResidents } from "@/lib/game/town-residents"
+
 import { DEFAULT_SCENE_VISIBILITY, VISIBILITY_TOGGLES, type SceneVisibility } from "@/lib/game/scene-visibility"
 import { DEFAULT_ELEVATION, type ElevationSettings } from "@/lib/game/map/elevation"
 import dynamic from "next/dynamic"
@@ -304,7 +306,8 @@ export function GameShell({
   useEffect(() => { footpaths.paved = ROAD_TIERS[settings.road]?.paved ?? false }, [footpaths, settings.road])
   // Keep one live map for the canvas and HUD readers, including roadside preaching.
   const map = useMemo(() => economy.map ? { ...economy.map, footpaths } : null, [economy.map, footpaths])
-  const travelers = useMemo(() => JOB_PREVIEW && map ? [...roadTravelers, ...previewResidents(map).map(resident => resident.traveler)] : roadTravelers,
+  const travelers = useMemo(() => map ? [...roadTravelers, ...townResidents(map).map(resident => resident.traveler),
+      ...(JOB_PREVIEW ? previewResidents(map).map(resident => resident.traveler) : [])] : roadTravelers,
     [roadTravelers, map])
   const renown = economy.renown
   const [evangelism, setEvangelism] = useState(0)

--- a/components/game/hud-controls.tsx
+++ b/components/game/hud-controls.tsx
@@ -170,9 +170,10 @@ export function HudClock() {
     const timer = setInterval(read, 250)
     return () => clearInterval(timer)
   }, [])
-  const [day, clock] = time === null ? ["Day —", "—:—"] : formatGameTime(time).split(" — ")
+  const day = time === null ? "Day —" : `Day ${Math.floor(time) + 1}`
+  const date = time === null ? "March 1, 825 AD" : formatGameTime(time)
   return <section className="hud-clock" aria-label="Simulation time">
-    <span className="hud-day">{day}</span><span className="hud-time">{clock}</span>
+    <span className="hud-day">{day}</span><span className="hud-date">{date}</span>
     <button type="button" className="hud-pause" aria-label={paused ? "Resume simulation" : "Pause simulation"}
       aria-pressed={paused} onClick={() => useSimulationStore.getState().togglePaused()}>
       {paused ? <Play size={14} /> : <Pause size={14} />}

--- a/components/game/minimap.tsx
+++ b/components/game/minimap.tsx
@@ -102,7 +102,7 @@ export function Minimap({ map }: { map: GameMap }) {
       ctx.setTransform(transform)
       ctx.drawImage(base, -map.width / 2, -map.depth / 2)
       for (const building of map.buildings) {
-        ctx.fillStyle = building.id === map.site?.hovelId ? "#e1c777" : "#d4975b"
+        ctx.fillStyle = building.id === map.site?.hovelId ? "#e1c777" : building.owner === "independent" ? "#b6b4a1" : "#d4975b"
         ctx.fillRect(building.x - map.width / 2, building.z - map.depth / 2, building.w, building.d)
       }
       ctx.restore()

--- a/components/game/signpost.tsx
+++ b/components/game/signpost.tsx
@@ -14,7 +14,7 @@ import { encodeObjectId, SIGNPOST_OBJECT_ID } from "@/lib/game/render/outline"
 
 /**
  * The wayside marker where the shrine's track forks from the road: a riven
- * post in the crook of the junction, a pointed board turned onto the shrine's
+ * post on the verge opposite a T junction, a pointed board turned onto the shrine's
  * bearing, and a small cross above it. Placement is decided on the map (see
  * lib/game/map/signpost.ts); this only stands the timber up.
  */

--- a/components/game/travelers.tsx
+++ b/components/game/travelers.tsx
@@ -148,7 +148,7 @@ export const Travelers = memo(function Travelers({
     }
   }, [sim, travelers, map, relic])
 
-  const camps = useMemo(() => jobBuildings(map), [map])
+  const camps = useMemo(() => jobBuildings(map, true), [map])
 
   // Publish the running sim so the HUD's traveler panel can poll live stats.
   useEffect(() => {

--- a/hooks/use-settlement.ts
+++ b/hooks/use-settlement.ts
@@ -7,7 +7,7 @@ import type { GameMap, TilePos } from "@/lib/game/map/types"
 import type { Monk } from "@/lib/game/monks"
 import type { Relic } from "@/lib/game/relic"
 import { useBuildStore } from "@/lib/game/build-store"
-import { createSettlement, purchaseStructure, creditTimber, creditAdmission, creditTrade, syncTimberSpending, settlementRenown } from "@/lib/game/settlement"
+import { claimTownBuildings, settlementMap, createSettlement, purchaseStructure, creditTimber, creditAdmission, creditTrade, syncTimberSpending, settlementRenown } from "@/lib/game/settlement"
 
 import { useBalanceStore } from "@/lib/game/balance-store"
 import { BUILDING_PREVIEW, buildingPreviewBalance, buildingPreviewSettlement } from "@/lib/game/building-preview"
@@ -59,10 +59,20 @@ export function useSettlement(baseMap: GameMap | null, monks: Monk[], relic: Rel
   const map = useMemo(
     () =>
       world
-        ? { ...world, elevation: session.settlement.elevation ?? world.elevation, buildings: [...world.buildings, ...session.settlement.structures] }
+        ? settlementMap(world, session.settlement)
         : null,
-    [world, session.settlement.elevation, session.settlement.structures],
+    [world, session.settlement.elevation, session.settlement.structures, session.settlement.claimedBuildings],
   )
+
+  useEffect(() => {
+    if (!world) return
+    setSession(current => {
+      if (current.world !== world) return current
+      const settlement = claimTownBuildings(current.settlement, world, balance)
+      return settlement === current.settlement ? current : { ...current, settlement,
+        message: "Roadside buildings have joined your settlement." }
+    })
+  }, [world, map, balance])
 
   useEffect(() => {
     useBuildStore.getState().setTool(session.buildType)

--- a/lib/game/build-influence.ts
+++ b/lib/game/build-influence.ts
@@ -38,7 +38,7 @@ export function buildInfluence(map: GameMap, balance: GameBalance = DEFAULT_BALA
   for (const tile of approach) stamp(tile.x, tile.z, APPROACH_BUILD_WIDTH)
   const catalog = buildCatalog(balance)
   for (const building of map.buildings) {
-    if (!isComplete(building)) continue
+    if (building.owner === "independent" || !isComplete(building)) continue
     const renown = building.id === map.site.hovelId ? balance.rules.hovelRenown
       : catalog.find((def) => def.id === building.buildType)?.renown ?? 0
     if (renown > 0) stamp(building.x + (building.w - 1) / 2,

--- a/lib/game/build-store.ts
+++ b/lib/game/build-store.ts
@@ -60,7 +60,7 @@ export const useBuildStore = create<BuildState>((set) => ({
     const settlers = travelers.flatMap((t) => {
       const live = sim.travelers.get(t.id)
       const job = settlementJob(live?.employer, sim.buildings)
-      return live?.employer ? [{
+      return live?.employer && sim.buildings.find(b => b.id === live.employer)?.owner !== "independent" ? [{
         id: t.id,
         name: t.name,
         duty: job ? SETTLEMENT_JOBS[job].label : "Resident",

--- a/lib/game/building-art/early-geometry.ts
+++ b/lib/game/building-art/early-geometry.ts
@@ -1,3 +1,4 @@
+import { tavernLayout } from "../tavern-layout"
 import { marketLayout } from "../market-layout"
 import { EARLY_MATERIALS as palette } from "./materials"
 import type { BuildingPart, Vec3 } from "./geometry"
@@ -418,8 +419,8 @@ export function earlyBuildingParts(recipe: ConstructionRecipe): BuildingPart[] {
     }
     if(variant === "tavern") {
       // Low drinking tables and benches occupy the left side, clear of the hearth.
-      for(const side of [-1,1]) {
-        const tx=-width*.23,tz=side*depth*.22,tableW=width*.32,tableD=depth*.15
+      for(const table of tavernLayout(width, depth).tables) {
+        const { side, x: tx, z: tz, w: tableW, d: tableD } = table
         for(const a of [-1,1]) for(const b of [-1,1]) pole(`tavern-table-${side}-leg-${a}-${b}`,[tx+a*tableW*.35,0,tz+b*tableD*.32],[tx+a*tableW*.35,.37,tz+b*tableD*.32],.025,"interior")
         box(`tavern-table-${side}-top`,"interior",[tx,.39,tz],[tableW,.045,tableD],palette.paleWood,undefined,false)
         for(const b of [-1,1]) bench(`tavern-bench-${side}-${b}`,tx,tz+b*depth*.11,tableW,.23,b>0 ? Math.PI : 0)
@@ -429,7 +430,8 @@ export function earlyBuildingParts(recipe: ConstructionRecipe): BuildingPart[] {
           box(`tavern-ale-${side}-${a}`,"interior",[mx,.48,tz],[.032,.005,.032],"#614e32",undefined,false)
         }
       }
-      const counterW=width*.27,counterX=width*.2,counterZ=-depth*.14
+      const counter = tavernLayout(width, depth).counter
+      const counterW=counter.w-.035,counterX=counter.x,counterZ=counter.z
       box("tavern-serving-counter", "interior",[counterX,.23,counterZ],[counterW,.46,depth*.14],palette.wood,undefined,false)
       box("tavern-counter-top", "interior",[counterX,.475,counterZ],[counterW+.035,.035,depth*.15],palette.paleWood,undefined,false)
     }

--- a/lib/game/building-navigation.ts
+++ b/lib/game/building-navigation.ts
@@ -1,3 +1,4 @@
+import { tavernFurnitureClear } from "./tavern-layout"
 import { sheepPenLayout } from "./workshop-layout"
 import { buildingEntry, buildingFoldEntry, rotatedFootprint, rotateBuildingPoint } from "./building-rotation"
 import { marketYardContains } from "./market-layout"
@@ -68,6 +69,7 @@ export function buildingStepAllowed(map: GameMap, buildings: readonly BuildingDe
           return false
         }
       }
+      if (building.buildType === "tavern" && !tavernFurnitureClear(building, from, to)) return false
       if (a && b) continue
       const inside = a ? from : to, outside = a ? to : from
       // Cross the wall only in a doorway; the tavern also keeps a back door.

--- a/lib/game/building-preview.ts
+++ b/lib/game/building-preview.ts
@@ -39,7 +39,7 @@ export function buildingPreviewSettlement(world: GameMap, balance: GameBalance, 
   })).sort((a,b) => Math.hypot(a.x-world.site!.door.x,a.z-world.site!.door.z)
     - Math.hypot(b.x-world.site!.door.x,b.z-world.site!.door.z))
   for (const example of examples) {
-    if (world.buildings.some(b => b.buildType === example.buildType && b.id !== world.site?.hovelId)) continue
+    if (world.buildings.some(b => b.owner !== "independent" && b.buildType === example.buildType && b.id !== world.site?.hovelId)) continue
     const map = { ...world, elevation: settlement.elevation ?? world.elevation,
       buildings: [...world.buildings, ...settlement.structures] }
     // The gallery's woodcutter can be inspected even away from harvestable trees.

--- a/lib/game/calendar.test.ts
+++ b/lib/game/calendar.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest"
+import { formatGameTime, gameDate } from "./calendar"
+
+describe("game calendar", () => {
+  it("starts March 1, 825 AD and changes only at day boundaries", () => {
+    expect(formatGameTime(0)).toBe("March 1, 825 AD")
+    expect(formatGameTime(.99999)).toBe("March 1, 825 AD")
+    expect(formatGameTime(1)).toBe("March 2, 825 AD")
+    expect(formatGameTime(31)).toBe("April 1, 825 AD")
+    expect(formatGameTime(306)).toBe("January 1, 826 AD")
+    expect(formatGameTime(365)).toBe("March 1, 826 AD")
+  })
+  it("handles leap days and four-year blocks", () => {
+    expect(formatGameTime(365 * 3 - 1)).toBe("February 28, 828 AD")
+    expect(formatGameTime(365 * 3)).toBe("February 29, 828 AD")
+    expect(formatGameTime(365 * 3 + 1)).toBe("March 1, 828 AD")
+    expect(gameDate(1461)).toEqual({ day: 1, month: 3, year: 829 })
+  })
+})

--- a/lib/game/calendar.ts
+++ b/lib/game/calendar.ts
@@ -1,0 +1,32 @@
+import { DEFAULT_WALK_SPEED } from "./base-person/gait"
+
+export const TILES_PER_DAY = 144
+/** One day at the reference person's uninterrupted walking pace. */
+export const GAME_DAY_SECONDS = TILES_PER_DAY / DEFAULT_WALK_SPEED
+export const GAME_HOUR_SECONDS = GAME_DAY_SECONDS / 24
+export const START_TIME = 0
+
+const MONTHS = ["January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December"]
+
+/** Julian calendar, starting March 1, AD 825; independent of browser timezone. */
+export function gameDate(time: number): { day: number; month: number; year: number } {
+  let remaining = Math.max(0, Math.floor(Number.isFinite(time) ? time : 0)) + 59
+  // Every four-year block beginning in 825 has exactly 1461 days.
+  const cycles = Math.floor(remaining / 1461)
+  let year = 825 + cycles * 4
+  remaining %= 1461
+  while (remaining >= (year % 4 === 0 ? 366 : 365)) {
+    remaining -= year % 4 === 0 ? 366 : 365
+    year++
+  }
+  const lengths = [31, year % 4 === 0 ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+  let month = 0
+  while (remaining >= lengths[month]) remaining -= lengths[month++]
+  return { day: remaining + 1, month: month + 1, year }
+}
+
+export function formatGameTime(time: number): string {
+  const { day, month, year } = gameDate(time)
+  return `${MONTHS[month - 1]} ${day}, ${year} AD`
+}

--- a/lib/game/construction.ts
+++ b/lib/game/construction.ts
@@ -1,3 +1,5 @@
+import { tavernWalkingRoute } from "./tavern-navigation"
+import { tavernWorkStop } from "./tavern-layout"
 import { smoothWalkingRoute, SHORTCUT_EXPLORERS } from "./walking-shortcuts"
 import { buildingEntry, buildingYaw, rotatedFootprint, rotateBuildingPoint } from "./building-rotation"
 import { MALLET_CONTACT_REACH } from "./base-person/building"
@@ -38,6 +40,8 @@ export interface BuildingTask {
   buildingId: string
   purpose: "build" | "rest" | "work"
   slot: number
+  workStop?: number
+  workPause?: number
   heading: number
   route: WanderSpot[]
   destination: WanderSpot
@@ -56,6 +60,9 @@ function constructionCrew(building: BuildingDef): Map<Worker, BuildingTask> {
   return crew
 }
 export function workerRoute(map: GameMap, actor: WanderSpot, goal: TilePos): WanderSpot[] | null {
+  const destination = { x: tileToWorldX(map, goal.x), y: surfaceHeight(map, goal.x, goal.z), z: tileToWorldZ(map, goal.z) }
+  const fine = tavernWalkingRoute(map, actor, destination)
+  if (fine !== undefined) return fine
   const start = { x: worldToTileX(map, actor.x), z: worldToTileZ(map, actor.z) }
   // A footprint may be placed beneath an idle resident. Let them leave that
   // new site before treating it as an obstacle on subsequent trips.
@@ -78,12 +85,13 @@ function buildingWorkPost(building: BuildingDef, slot: number) {
 }
 
 /** Place work and rest positions in the same rotated local space as the building. */
-function taskPosition(map: GameMap, building: BuildingDef, purpose: BuildingTask["purpose"], slot: number, scale?: number) {
+function taskPosition(map: GameMap, building: BuildingDef, purpose: BuildingTask["purpose"], slot: number, scale?: number, workStop = 0) {
   const local = rotatedFootprint(building, building.rotation)
   const beds = purpose === "rest" ? buildingSupports(building).filter(s => s.clips.includes("sleeping")) : []
   const bed = beds[slot % beds.length]
   if (purpose === "rest" && !bed) return null
-  const post = purpose === "work" ? buildingWorkPost(building, slot) : null
+  const post = purpose === "work" ? building.buildType === "tavern"
+    ? tavernWorkStop(slot, workStop, local.w, local.d) : buildingWorkPost(building, slot) : null
   if (purpose === "work" && !post) return null
   const x = purpose === "build" ? (slot % 4 - 1.5) * Math.min(0.45, (local.w - 0.5) / 3)
     : purpose === "work" ? post!.x : bed.anchor.x
@@ -130,12 +138,14 @@ export function assignBuildingTask(actor: Worker, map: GameMap, purpose: Buildin
 }
 
 function routeToDestination(map: GameMap, actor: WanderSpot, destination: WanderSpot): WanderSpot[] | null {
+  const fine = tavernWalkingRoute(map, actor, destination)
+  if (fine !== undefined) return fine
   const route = workerRoute(map, actor, { x: worldToTileX(map, destination.x), z: worldToTileZ(map, destination.z) })
   if (route) route.push(destination)
   return route
 }
 
-export function walkWorker(actor: WanderSpot, route: WanderSpot[], speed: number, dt: number): boolean {
+export function walkWorker(actor: WanderSpot, route: WanderSpot[], speed: number, dt: number, preserveCorners = false): boolean {
   let distance = Math.max(0, speed * dt)
   while (route.length) {
     const goal = route[0], length = Math.hypot(goal.x - actor.x, goal.z - actor.z)
@@ -147,6 +157,7 @@ export function walkWorker(actor: WanderSpot, route: WanderSpot[], speed: number
     Object.assign(actor, goal)
     distance -= length
     route.shift()
+    if (preserveCorners && length > 1e-6 && route.length) return false
   }
   return true
 }
@@ -160,7 +171,7 @@ export function stepBuildingTask(actor: Worker, map: GameMap, speed: number, dt:
     actor.buildingTask = undefined
     return null
   }
-  const target = taskPosition(map, building, task.purpose, task.slot, actor.workScale)
+  const target = taskPosition(map, building, task.purpose, task.slot, actor.workScale, task.workStop)
   if (!target) { actor.buildingTask = undefined; return null }
   const resized = Math.hypot(task.destination.x - target.destination.x, task.destination.z - target.destination.z) > 0.001
   task.destination = target.destination
@@ -186,11 +197,20 @@ export function stepBuildingTask(actor: Worker, map: GameMap, speed: number, dt:
     task.route = route; task.buildings = map.buildings
   }
   if (task.route.length) {
-    walkWorker(actor, task.route, speed, dt)
+    walkWorker(actor, task.route, speed, dt, building.buildType === "tavern")
     return "walking"
   }
   if (task.purpose === "rest") return "sleeping"
-  if (task.purpose === "work") return "posted"
+  if (task.purpose === "work") {
+    if (building.buildType === "tavern") {
+      task.workPause = (task.workPause ?? 3 + task.slot * 1.5) - dt
+      if (task.workPause <= 0) {
+        task.workStop = ((task.workStop ?? 0) + 1) % 4
+        task.workPause = 3 + (task.slot + task.workStop) % 3
+      }
+    }
+    return "posted"
+  }
   const construction = building.construction!
   construction.work = Math.min(construction.required, construction.work + dt)
   return "building"

--- a/lib/game/hospitality.test.ts
+++ b/lib/game/hospitality.test.ts
@@ -810,6 +810,34 @@ describe("woodcutter huts", () => {
 
 
 describe("houses, counters and posts", () => {
+  it.each([1, -1] as const)("serves travelers at an independent town in direction %s without paying the player", direction => {
+    const { map, traveler } = fixture()
+    // An ordinary paid counter, operated locally from the start.
+    const def = BUILD_CATALOG.find(b => b.id === "tavern")!
+    const tavern = { ...def, id: "town-tavern", owner: "independent" as const, townId: "town",
+      buildType: "tavern", x: 13, z: 9, rotation: 0 as const }
+    map.buildings.push(tavern)
+    map.towns = [{ id: "town", name: "Alderford", junction: 10, tavernId: tavern.id, buildingIds: [tavern.id] }]
+    const t = traveler(0, direction)
+    Object.assign(t.attributes, { hunger: 40, thirst: 40, gold: 10 })
+    const sim = createSim([t], map, [], obscure)
+    const s = sim.travelers.get(t.id)!
+    sim.travelers.set(-1, { ...s, id: -1, employer: tavern.id, activity: "posted" })
+    run(sim, [t], map, 200, () => s.activity === "sitting")
+    expect(s.activity).toBe("sitting")
+    expect(s.hunger).toBeGreaterThan(90)
+    expect(s.thirst).toBeGreaterThan(90)
+    expect(s.gold).toBe(5)
+    expect(sim.tradeGold).toBe(0)
+    expect(sim.shrineGold).toBe(0)
+    expect(sim.visits).toBe(0)
+    expect(s.employer).toBeNull()
+    run(sim, [t], map, 200, () => s.activity === "walking")
+    expect(s.activity).toBe("walking")
+    expect(s.direction).toBe(direction)
+    expect(s.tavernVisit).toBeUndefined()
+  })
+
   it("seats a customer on an authored bench and pays the settlement, not the shrine", () => {
     const { map, traveler } = fixture()
     const t = traveler(0)

--- a/lib/game/housing.ts
+++ b/lib/game/housing.ts
@@ -10,7 +10,7 @@ export function housingBeds(building: BuildingDef): number {
 }
 
 export function monkBeds(map: GameMap) {
-  return map.buildings.filter(isMonkShelter).flatMap(building =>
+  return map.buildings.filter(b => b.owner !== "independent" && isMonkShelter(b)).flatMap(building =>
     Array.from({ length: housingBeds(building) }, (_, slot) => ({ home: building.id, slot })))
 }
 
@@ -22,7 +22,7 @@ export function vacantMonkBed(map: GameMap, joined: Iterable<{ home?: string; be
 }
 
 export function enclaveHousing(map: GameMap, settlers: number, monks: number) {
-  const capacity = (test: (b: BuildingDef) => boolean) => map.buildings.filter(test).reduce((sum, b) => sum + housingBeds(b), 0)
+  const capacity = (test: (b: BuildingDef) => boolean) => map.buildings.filter(b => b.owner !== "independent" && test(b)).reduce((sum, b) => sum + housingBeds(b), 0)
   const places = (occupied: number, total: number) => ({ occupied, capacity: total, available: Math.max(0, total - occupied) })
   return { people: places(settlers, capacity(isHouse)), monks: places(monks, capacity(isMonkShelter)) }
 }

--- a/lib/game/jobs/preview.ts
+++ b/lib/game/jobs/preview.ts
@@ -1,18 +1,14 @@
 import { travelerAppearance } from "../base-person/population"
-import { BUILDING_KINDS, type PlacedBuilding } from "../buildings"
-import { buildingEntry } from "../building-rotation"
-import { assignBuildingTask } from "../construction"
+import { BUILDING_KINDS } from "../buildings"
 import { buildingSupports } from "../character-support"
-import { tileToWorldX, tileToWorldZ, type GameMap } from "../map/types"
-import { surfaceHeight } from "../map/bridges"
+import type { GameMap } from "../map/types"
 import { jobBuildings } from "../settlement"
-import type { SimTraveler } from "../sim"
 import { TRAVELER_TYPES, type Traveler } from "../travelers"
 
 /** Extra identities keep the staffed demo independent of the traffic slider. */
 export function previewResidents(map: GameMap) {
   const seen = new Map<string, number>()
-  const homes = map.buildings.filter(b => b.buildType === "house").flatMap(b =>
+  const homes = map.buildings.filter(b => b.owner !== "independent" && b.buildType === "house").flatMap(b =>
     buildingSupports(b).filter(s => s.clips.includes("sleeping")).map(() => b.id))
   let index = 0
   let nextId = 1_000_000
@@ -34,18 +30,4 @@ export function previewResidents(map: GameMap) {
     }))
 }
 
-/** Start at the actual work posts; the normal simulation owns every subsequent action. */
-export function placePreviewResident(actor: SimTraveler, map: GameMap,
-  resident: { building: PlacedBuilding; jobSlot: number; home: string | null }) {
-  const { building, jobSlot, home } = resident
-  const entry = buildingEntry(building)
-  Object.assign(actor, { employer: building.id, jobSlot, home, jobless: false, convoy: false,
-    x: tileToWorldX(map, entry.x) + (jobSlot - 1) * .14, z: tileToWorldZ(map, entry.z),
-    y: surfaceHeight(map, entry.x, entry.z), activity: "idle", timer: 1 + jobSlot, moveSpeed: 0,
-    workSlot: jobSlot, offRoadRoute: null })
-  if (assignBuildingTask(actor, map, "work", building.id)) {
-    Object.assign(actor, actor.buildingTask!.destination)
-    actor.buildingTask!.route = []
-    actor.activity = "posted"
-  }
-}
+export { placeResident as placePreviewResident } from "./residents"

--- a/lib/game/jobs/residents.ts
+++ b/lib/game/jobs/residents.ts
@@ -1,0 +1,22 @@
+import type { PlacedBuilding } from "../buildings"
+import { buildingEntry } from "../building-rotation"
+import { assignBuildingTask } from "../construction"
+import { tileToWorldX, tileToWorldZ, type GameMap } from "../map/types"
+import { surfaceHeight } from "../map/bridges"
+import type { SimTraveler } from "../sim"
+
+/** Start at the actual work posts; the normal simulation owns every subsequent action. */
+export function placeResident(actor: SimTraveler, map: GameMap,
+  resident: { building: PlacedBuilding; jobSlot: number; home: string | null }) {
+  const { building, jobSlot, home } = resident
+  const entry = buildingEntry(building)
+  Object.assign(actor, { employer: building.id, jobSlot, home, jobless: false, convoy: false,
+    x: tileToWorldX(map, entry.x) + (jobSlot - 1) * .14, z: tileToWorldZ(map, entry.z),
+    y: surfaceHeight(map, entry.x, entry.z), activity: "idle", timer: 1 + jobSlot, moveSpeed: 0,
+    workSlot: jobSlot, offRoadRoute: null })
+  if (assignBuildingTask(actor, map, "work", building.id)) {
+    Object.assign(actor, actor.buildingTask!.destination)
+    actor.buildingTask!.route = []
+    actor.activity = "posted"
+  }
+}

--- a/lib/game/map/forest-entrances.ts
+++ b/lib/game/map/forest-entrances.ts
@@ -1,7 +1,7 @@
 import { computeDarkShade } from "./forest-field"
 import { groundHeight } from "./elevation"
 import { isRoadTerrain } from "./road"
-import { signpostPlacement, SIGNPOST_CLEARANCE, type SignpostPlacement } from "./signpost"
+import { signpostPlacement, tJunctionVerge, SIGNPOST_CLEARANCE, type SignpostPlacement } from "./signpost"
 import { tileAt, tileToWorldX, tileToWorldZ, type GameMap, type TilePos } from "./types"
 
 /** Keep broad ancient crowns from covering the warning board and skull. */
@@ -39,6 +39,8 @@ export function forestEntrancePlacements(map: GameMap): SignpostPlacement[] {
       const sides: TilePos[] = [{ x: -dz, z: dx }, { x: dz, z: -dx }]
       sides.sort((a, b) => Number(["forest", "darkwood"].includes(tileAt(map, at.x + a.x, at.z + a.z) ?? ""))
         - Number(["forest", "darkwood"].includes(tileAt(map, at.x + b.x, at.z + b.z) ?? "")))
+      const opposite = tJunctionVerge(map, at)
+      if (opposite) sides.unshift({ x: opposite.x - at.x, z: opposite.z - at.z })
       for (const side of sides) {
         const tile = { x: at.x + side.x, z: at.z + side.z }, terrain = tileAt(map, tile.x, tile.z)
         if (!terrain || isRoadTerrain(terrain) || !["grass", "clearing", "forest", "darkwood", "dirt", "sand"].includes(terrain)) continue

--- a/lib/game/map/generate-map.test.ts
+++ b/lib/game/map/generate-map.test.ts
@@ -137,7 +137,7 @@ describe("generateMap", () => {
   it("founds the shrine and a completed monk shelter beside its gate path", () => {
     for (const seed of SEEDS) {
       const map = mapFor(seed)
-      expect(map.buildings.map((b) => b.id), `seed ${seed} has shrine and shelter`).toEqual([HOVEL_ID, "founding-shelter"])
+      expect(map.buildings.filter(b => b.owner !== "independent").map((b) => b.id), `seed ${seed} has shrine and shelter`).toEqual([HOVEL_ID, "founding-shelter"])
       const shelter = map.buildings[1]
       expect(shelter.construction).toBeUndefined()
       expect(shelter.buildType).toBe("monk-shelter")
@@ -315,7 +315,7 @@ describe("generateMap", () => {
   it("sites the hovel on small maps too, scaling the band down", () => {
     for (const seed of SEEDS.slice(0, 10)) {
       const map = generateMap({ seed, width: 32, depth: 32 })
-      expect(map.buildings).toHaveLength(2)
+      expect(map.buildings.filter(b => b.owner !== "independent")).toHaveLength(2)
       expect(map.site!.branch.length).toBeGreaterThan(1)
     }
   }, SWEEP_TIMEOUT)
@@ -338,7 +338,7 @@ describe("generateMap", () => {
     const map = generateMap({ seed: 99, width: 512, depth: 512 })
     expect(map.tiles).toHaveLength(512 * 512)
     expect(map.tiles.every((t) => t in TERRAIN)).toBe(true)
-    expect(map.buildings.map((b) => b.id)).toEqual([HOVEL_ID, "founding-shelter"])
+    expect(map.buildings.filter(b => b.owner !== "independent").map((b) => b.id)).toEqual([HOVEL_ID, "founding-shelter"])
     const road = reachablePath(map)
     expect([...road].some((key) => key.startsWith(`${map.width - 1},`))).toBe(true)
   }, SWEEP_TIMEOUT)

--- a/lib/game/map/generate-map.ts
+++ b/lib/game/map/generate-map.ts
@@ -1,4 +1,5 @@
 import { straightenRoad } from "./straighten-road"
+import { addRoadsideTowns } from "./roadside-towns"
 import { beachAccess } from "./beaches"
 import { taperRiverBanks, gradeBridgeApproaches } from "./river-banks"
 import { bridgeLayout } from "./bridges"
@@ -902,6 +903,7 @@ export function generateMap(options: GenerateMapOptions): GameMap {
   // Bridge grading and founding can raise a formerly low beach; classify sand last.
   const sandy = beachAccess(map.elevation!, width, depth, kind, waterInfo)
   for (let i = 0; i < tiles.length; i++) if (tiles[i] === "sand" && !sandy[i]) tiles[i] = "grass"
+  addRoadsideTowns(map)
   return map
 }
 

--- a/lib/game/map/roadside-towns.test.ts
+++ b/lib/game/map/roadside-towns.test.ts
@@ -1,0 +1,80 @@
+import { tavernWalkingRoute } from "../tavern-navigation"
+import { tileToWorldX, tileToWorldZ } from "./types"
+import { describe, expect, it } from "vitest"
+import { addRoadsideTowns, TOWN_SPACING, TOWN_CHAPEL_CLEARANCE, TOWN_APPROACH_CLEARANCE } from "./roadside-towns"
+import { generateMap } from "./generate-map"
+import { type GameMap, tileAt } from "./types"
+import { TILES_PER_DAY } from "../calendar"
+import { tavernVisitPlan, servingHouses } from "../tavern"
+import { buildingApproaches } from "../building-rotation"
+import { settlementRoute } from "../settlement-route"
+import { jobBuildings, settlementRenown } from "../settlement"
+import { enclaveHousing } from "../housing"
+import { buildInfluence } from "../build-influence"
+
+function roadMap(): GameMap {
+  const width = 400, depth = 30
+  const map: GameMap = { width, depth, tiles: Array(width * depth).fill("grass"), buildings: [],
+    road: Array.from({ length: width }, (_, x) => ({ x, z: 15 })) }
+  for (const p of map.road!) map.tiles[p.z * width + p.x] = "path"
+  return map
+}
+
+describe("independent roadside towns", () => {
+  it("spaces complete communities just under a day's walk apart", () => {
+    const map = roadMap()
+    addRoadsideTowns(map)
+    expect(map.towns).toHaveLength(3)
+    for (const [i, town] of map.towns!.entries()) {
+      const buildings = map.buildings.filter(b => b.townId === town.id)
+      expect(buildings.map(b => b.buildType)).toEqual(["tavern", "house"])
+      expect(buildings.every(b => b.owner === "independent" && !b.construction)).toBe(true)
+      if (i) {
+        expect(town.junction - map.towns![i - 1].junction).toBe(TOWN_SPACING)
+        expect(town.junction - map.towns![i - 1].junction).toBeLessThan(TILES_PER_DAY)
+      }
+    }
+    expect(map.road!.every(p => tileAt(map, p.x, p.z) === "path")).toBe(true)
+    expect(servingHouses(map, () => false)).toHaveLength(0)
+  })
+
+  it("contributes no jobs, housing, renown or building influence", () => {
+    const map = roadMap()
+    map.site = { junction: 200, branch: [{ x: 200, z: 15 }], door: { x: 200, z: 15 }, hovelId: "absent" }
+    const influence = buildInfluence(map)
+    addRoadsideTowns(map)
+    expect(jobBuildings(map)).toEqual([])
+    expect(enclaveHousing(map, 0, 0).people.capacity).toBe(0)
+    expect(settlementRenown(map, [], []).total).toBe(0)
+    expect(buildInfluence(map)).toEqual(influence)
+  })
+
+  it.each([1, 7919, 42, 99, 12345])("generates reachable taverns on seeded terrain (%s)", seed => {
+    const map = generateMap({ seed })
+    expect(map.towns!.length).toBeGreaterThan(0)
+    for (const town of map.towns!) {
+      const road = map.road![town.junction]
+      const tavern = map.buildings.find(b => b.id === town.tavernId)!
+      const visit = tavernVisitPlan(map, tavern, road)
+      expect(visit, `${town.name} has a reachable counter and seat`).not.toBeNull()
+      expect(tavernWalkingRoute(map, visit!.seat!.point, { x: tileToWorldX(map, road.x), z: tileToWorldZ(map, road.z), y: .2 })).toBeTruthy()
+      for (const id of town.buildingIds) {
+        const building = map.buildings.find(b => b.id === id)!
+        for (const entry of buildingApproaches(map, building)) {
+          const pathMap = { ...map, tiles: map.tiles.map(t => t === "path" || t === "track" || t === "bridge" ? t : "forest" as const) }
+          expect(settlementRoute(pathMap, pathMap.buildings, road, entry), "every entrance has a continuous path").not.toBeNull()
+        }
+        const chapel = map.buildings.find(b => b.id === map.site!.hovelId)!
+        expect(Math.hypot(
+          Math.max(chapel.x - building.x - building.w, building.x - chapel.x - chapel.w, 0),
+          Math.max(chapel.z - building.z - building.d, building.z - chapel.z - chapel.d, 0),
+        )).toBeGreaterThanOrEqual(TOWN_CHAPEL_CLEARANCE)
+        for (const p of map.site!.branch) expect(Math.hypot(building.x - p.x, building.z - p.z)).toBeGreaterThanOrEqual(TOWN_APPROACH_CLEARANCE)
+        for (let z = building.z; z < building.z + building.d; z++) for (let x = building.x; x < building.x + building.w; x++) {
+          expect(tileAt(map, x, z)).toBe("grass")
+          expect(map.water!.depth[z * map.width + x]).toBe(0)
+        }
+      }
+    }
+  }, 20000)
+})

--- a/lib/game/map/roadside-towns.ts
+++ b/lib/game/map/roadside-towns.ts
@@ -1,0 +1,112 @@
+import { settlementRoute } from "../settlement-route"
+import { BUILD_CATALOG } from "../balance"
+import { buildingApproaches, buildingEntry, rotatedFootprint, rotateBuildingPoint, type BuildingRotation } from "../building-rotation"
+import { TILES_PER_DAY } from "../calendar"
+import { levelBuildingGround } from "./elevation"
+import { tileAt, type BuildingDef, type GameMap, type RoadsideTown, type TilePos } from "./types"
+
+export const TOWN_SPACING = TILES_PER_DAY - 16
+export const TOWN_CHAPEL_CLEARANCE = 48
+export const TOWN_APPROACH_CLEARANCE = 20
+const SEARCH_RADIUS = 8
+// Prefer a slightly shorter leg when the ideal stop falls on water or steep land.
+const SEARCH_OFFSETS = [0, ...Array.from({ length: SEARCH_RADIUS }, (_, i) => [i + 1, -i - 1]).flat(),
+  ...Array.from({ length: 24 }, (_, i) => -SEARCH_RADIUS - i - 1)]
+const NAMES = ["Alderford", "Hazelwick", "Birch End", "Willowbank", "Oakstead", "Ashbrook", "Elm Hollow", "Reedham"]
+
+/** The house sits beside the tavern, with parallel roof ridges and aligned fronts. */
+function townPlan(map: GameMap, junction: number, rotation: BuildingRotation, ordinal: number) {
+  const road = map.road![junction]
+  const outward = rotateBuildingPoint(0, -1, rotation)
+  const entry = { x: road.x + outward.x * 2, z: road.z + outward.z * 2 }
+  const id = `roadside-town-${ordinal}`
+  const name = NAMES[((((map.seed ?? 0) >>> 0) % NAMES.length) + ordinal) % NAMES.length]
+  const buildings = (["tavern", "house"] as const).map((buildType, index): BuildingDef => {
+    const def = BUILD_CATALOG.find(b => b.id === buildType)!
+    const size = rotatedFootprint(def, rotation)
+    // Place the house directly against the tavern's side, with both fronts on the road side.
+    const side = rotateBuildingPoint(index === 0 ? 0 : -3, 0, rotation)
+    const origin = { ...size, x: 0, z: 0, rotation, buildType }
+    const door = buildingEntry(origin)
+    return { id: `${id}-${index}`, owner: "independent", townId: id, buildType,
+      label: `${name} ${index === 0 ? "tavern" : "house"}`, rotation, ...size,
+      x: entry.x + side.x - door.x, z: entry.z + side.z - door.z,
+      height: def.height, color: def.color, roofColor: def.roofColor }
+  })
+  const x = Math.min(...buildings.map(b => b.x)) - 1
+  const z = Math.min(...buildings.map(b => b.z)) - 1
+  const right = Math.max(...buildings.map(b => b.x + b.w)) + 1
+  const bottom = Math.max(...buildings.map(b => b.z + b.d)) + 1
+  const patch: TilePos[] = []
+  for (let tz = z; tz < bottom; tz++) for (let tx = x; tx < right; tx++) patch.push({ x: tx, z: tz })
+  patch.push(road, { x: road.x + outward.x, z: road.z + outward.z })
+  const occupied = (p: TilePos, b: BuildingDef, margin = 0) => p.x >= b.x - margin && p.x < b.x + b.w + margin
+    && p.z >= b.z - margin && p.z < b.z + b.d + margin
+  const chapel = map.buildings.find(b => b.id === map.site?.hovelId)
+  if (chapel && buildings.some(b => Math.hypot(
+    Math.max(chapel.x - b.x - b.w, b.x - chapel.x - chapel.w, 0),
+    Math.max(chapel.z - b.z - b.d, b.z - chapel.z - chapel.d, 0),
+  ) < TOWN_CHAPEL_CLEARANCE)) return null
+  if (map.site?.branch.some(p => patch.some(q => Math.hypot(p.x - q.x, p.z - q.z) < TOWN_APPROACH_CLEARANCE))) return null
+  // Keep the shrine, ancient groves, waterways and existing routes intact.
+  if (patch.some(p => {
+    const terrain = tileAt(map, p.x, p.z)
+    return terrain === null || terrain === "water" || terrain === "bridge" || terrain === "darkwood"
+      || !!map.water?.depth[p.z * map.width + p.x]
+      || map.buildings.some(b => occupied(p, b, 2))
+      || map.site?.branch.some(b => b.x === p.x && b.z === p.z)
+  })) return null
+  if (buildings.some(b => patch.some(p => occupied(p, b) && ["path", "track"].includes(tileAt(map, p.x, p.z)!)))) return null
+  if (map.elevation) {
+    const heights = patch.map(p => map.elevation!.height[p.z * map.width + p.x])
+    if (Math.max(...heights) - Math.min(...heights) >= map.elevation.settings.cliffThreshold * .7) return null
+  }
+  const town: RoadsideTown = { id, name, junction, tavernId: buildings[0].id, buildingIds: buildings.map(b => b.id) }
+  return { town, buildings, patch }
+}
+
+/** Mutates only a newly generated map. Distances follow road steps, including bends. */
+export function addRoadsideTowns(map: GameMap): void {
+  map.towns = []
+  const road = map.road ?? []
+  let target = Math.min(TOWN_SPACING / 2, Math.floor((road.length - 1) / 2))
+  while (target < road.length - 12) {
+    let placed = false
+    for (const offset of SEARCH_OFFSETS) {
+      if (placed) break
+      const junction = target + offset
+      if (junction < 12 || junction >= road.length - 12) continue
+      for (const rotation of [0, 1, 2, 3] as const) {
+        const plan = townPlan(map, junction, rotation, map.towns.length)
+        if (!plan) continue
+        // Plan on a private copy so a blocked entrance cannot leave half a town behind.
+        const candidate = { ...map, tiles: [...map.tiles], buildings: [...map.buildings, ...plan.buildings] }
+        for (const p of plan.patch) {
+          const i = p.z * map.width + p.x
+          if (candidate.tiles[i] !== "path" && candidate.tiles[i] !== "track") candidate.tiles[i] = "grass"
+        }
+        for (const b of plan.buildings) candidate.elevation = levelBuildingGround(candidate, b)
+        let accessible = true
+        for (const b of plan.buildings) for (const entrance of buildingApproaches(candidate, b)) {
+          const route = settlementRoute(candidate, candidate.buildings, road[junction], entrance)
+          if (!route) { accessible = false; break }
+          for (const p of route) {
+            const i = p.z * map.width + p.x
+            if (candidate.tiles[i] !== "path" && candidate.tiles[i] !== "bridge") candidate.tiles[i] = "track"
+          }
+        }
+        if (!accessible) continue
+        // The generator also retains the original tile array while finishing the world.
+        for (let i = 0; i < map.tiles.length; i++) map.tiles[i] = candidate.tiles[i]
+        map.buildings.push(...plan.buildings)
+        map.elevation = candidate.elevation
+        map.towns.push(plan.town)
+        target = junction + TOWN_SPACING
+        placed = true
+        break
+      }
+    }
+    // Unsuitable terrain advances the search; never place a town in water or on a cliff.
+    if (!placed) target += SEARCH_RADIUS * 2 + 1
+  }
+}

--- a/lib/game/map/signpost.test.ts
+++ b/lib/game/map/signpost.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import { generateMap, MIN_MAP_SIZE } from "./generate-map"
-import { signpostPlacement, SIGNPOST_CLEARANCE, SIGNPOST_INSET } from "./signpost"
+import { signpostPlacement, tJunctionVerge, SIGNPOST_CLEARANCE, SIGNPOST_INSET } from "./signpost"
 import { placeTrees } from "../trees/placement"
 import { TREE_SPECIES } from "../trees/species"
 import { tileAt, tileToWorldX, tileToWorldZ, type GameMap } from "./types"
@@ -12,6 +12,36 @@ const mapFor = (seed: number) => generateMap({ width: MIN_MAP_SIZE, depth: MIN_M
 /** The post's tile, plus the way its board is turned, on a real generated world. */
 describe("the shrine's wayside signpost", () => {
   const maps = SEEDS.map(mapFor)
+
+  it.each([{ x: 1, z: 0 }, { x: -1, z: 0 }, { x: 0, z: 1 }, { x: 0, z: -1 }])(
+    "stands across the through road from the incoming arm %j", step => {
+      const junction = { x: 6, z: 6 }, side = { x: step.z, z: -step.x }
+      const branch = Array.from({ length: 4 }, (_, i) => ({ x: 6 + step.x * i, z: 6 + step.z * i }))
+      const road = Array.from({ length: 9 }, (_, i) => ({ x: 6 + side.x * (i - 4), z: 6 + side.z * (i - 4) }))
+      const map: GameMap = { width: 13, depth: 13, tiles: Array(169).fill("grass"), road,
+        buildings: [{ id: "shrine", x: branch[3].x + step.x, z: branch[3].z + step.z,
+          w: 1, d: 1, label: "Shrine", height: 1, color: "tan", roofColor: "brown" }],
+        site: { junction: 4, branch, door: branch[3], hovelId: "shrine" } }
+      for (const p of road) map.tiles[p.z * map.width + p.x] = "path"
+      for (const p of branch.slice(1)) map.tiles[p.z * map.width + p.x] = "track"
+      const opposite = { x: junction.x - step.x, z: junction.z - step.z }
+      const post = signpostPlacement(map)!
+      expect(post.tile).toEqual(opposite)
+      expect(post.x).toBeCloseTo(tileToWorldX(map, junction.x) - step.x * (1 - SIGNPOST_INSET))
+      expect(post.z).toBeCloseTo(tileToWorldZ(map, junction.z) - step.z * (1 - SIGNPOST_INSET))
+
+      // A blocked verge uses dry ground beside it, never the incoming lane.
+      map.tiles[opposite.z * map.width + opposite.x] = "water"
+      const fallback = signpostPlacement(map)!
+      expect((fallback.tile.x - junction.x) * step.x + (fallback.tile.z - junction.z) * step.z).toBe(-1)
+
+      // A fourth arm is a crossroads: leave every approach clear.
+      map.tiles[opposite.z * map.width + opposite.x] = "track"
+      expect(tJunctionVerge(map, junction)).toBeNull()
+      const cross = signpostPlacement(map)!
+      expect(["path", "track"]).not.toContain(tileAt(map, cross.tile.x, cross.tile.z))
+    },
+  )
 
   it("stands beside the branch on every generated world, never on the way itself", () => {
     for (const map of maps) {

--- a/lib/game/map/signpost.ts
+++ b/lib/game/map/signpost.ts
@@ -1,5 +1,6 @@
 import { type TerrainId } from "./terrain"
-import { tileToWorldX, tileToWorldZ, type GameMap, type TilePos } from "./types"
+import { isRoadTerrain } from "./road"
+import { tileAt, tileToWorldX, tileToWorldZ, type GameMap, type TilePos } from "./types"
 
 /**
  * The wayside marker at the fork for the shrine. Pure geometry — no three.js,
@@ -9,7 +10,8 @@ import { tileToWorldX, tileToWorldZ, type GameMap, type TilePos } from "./types"
  * the way to it is marked where it leaves the road: a post at a corner of the
  * junction, a board pointing along the branch, and a cross to say what stands
  * at the end of it. The post never stands on the track itself — it takes the
- * open ground in the crook of the fork, set in toward the corner so it reads
+ * verge opposite the incoming arm of a T junction, or an open corner at a
+ * crossroads, set in toward the road so it reads
  * as part of the junction rather than something dropped in the field.
  */
 
@@ -41,6 +43,17 @@ export interface SignpostPlacement {
   yaw: number
 }
 
+/** The empty side of a T faces the incoming arm, across the through road. */
+export function tJunctionVerge(map: GameMap, junction: TilePos): TilePos | null {
+  const neighbors = [{ x: 1, z: 0 }, { x: -1, z: 0 }, { x: 0, z: 1 }, { x: 0, z: -1 }]
+    .map(d => ({ x: junction.x + d.x, z: junction.z + d.z }))
+  const offRoad = neighbors.filter(p => {
+    const terrain = tileAt(map, p.x, p.z)
+    return !isRoadTerrain(terrain) && terrain !== "bridge"
+  })
+  return offRoad.length === 1 ? offRoad[0] : null
+}
+
 function usableCorner(map: GameMap, tile: TilePos, beside: TilePos, wooded: boolean): boolean {
   if (tile.x < 0 || tile.z < 0 || tile.x >= map.width || tile.z >= map.depth) return false
   const index = tile.z * map.width + tile.x
@@ -54,7 +67,8 @@ function usableCorner(map: GameMap, tile: TilePos, beside: TilePos, wooded: bool
 /**
  * Where the signpost stands, or null on a map with no shrine branch to mark.
  *
- * The fork's own two corners come first — the tiles diagonally out from the
+ * A T junction takes the verge opposite its incoming arm. Otherwise the fork's
+ * own two corners come first — the tiles diagonally out from the
  * junction, one either side of the road. Failing those, the search steps along
  * to the outer corners of the branch's next few bends. Open ground wins at
  * each corner in turn, but a corner in the trees is taken before the search
@@ -70,6 +84,12 @@ export function signpostPlacement(map: GameMap): SignpostPlacement | null {
   const corners: { tile: TilePos; beside: TilePos }[][] = []
   const junction = site.branch[0], first = site.branch[1]
   const step = { x: first.x - junction.x, z: first.z - junction.z }
+  const opposite = tJunctionVerge(map, junction)
+  if (opposite) {
+    corners.push([{ tile: opposite, beside: junction }])
+    const side = { x: opposite.z - junction.z, z: junction.x - opposite.x }
+    corners.push([-1, 1].map(sign => ({ tile: { x: opposite.x + sign * side.x, z: opposite.z + sign * side.z }, beside: junction })))
+  }
   corners.push([{ x: step.z, z: -step.x }, { x: -step.z, z: step.x }]
     .map(side => ({ tile: { x: first.x + side.x, z: first.z + side.z }, beside: junction })))
   // Both tiles adjacent to a bend but off the branch sit on the outside of it.

--- a/lib/game/map/types.ts
+++ b/lib/game/map/types.ts
@@ -2,7 +2,10 @@ import type { TerrainId } from "./terrain"
 
 export interface BuildingDef {
   id: string
-  /** Player-built catalogue entry; absent on the founding hovel. */
+  /** Absent on player structures and the founding enclave. */
+  owner?: "independent"
+  townId?: string
+  /** Building catalogue entry; absent on the founding hovel. */
   buildType?: string
   /** Clockwise quarter turns; w/d already describe the rotated footprint. */
   rotation?: import("../building-rotation").BuildingRotation
@@ -75,6 +78,8 @@ export interface DarkForest {
 }
 
 export interface GameMap {
+  /** Independent roadside communities, indexed by distance along the main road. */
+  towns?: RoadsideTown[]
   /** Live walking traffic, shared by navigation and terrain; scoped to the running game. */
   footpaths?: import("../footpaths").Footpaths
   elevation?: import("./elevation").ElevationInfo
@@ -103,6 +108,14 @@ export interface GameMap {
   darkForests?: DarkForest[]
   /** Present on generated maps: the relic's hovel and the branch that reaches it. */
   site?: FoundingSite
+}
+
+export interface RoadsideTown {
+  id: string
+  name: string
+  junction: number
+  tavernId: string
+  buildingIds: string[]
 }
 
 export interface Shortcut {

--- a/lib/game/settlement.ts
+++ b/lib/game/settlement.ts
@@ -3,7 +3,7 @@ import { rotatedFootprint, buildingEntry, buildingApproaches, type BuildingRotat
 import { groundHeight, levelBuildingGround } from "./map/elevation"
 import { buildingKind, placementProblem, PLACEMENT_PROBLEM_LABELS, type PlacedBuilding } from "./buildings"
 import { settlementRoute, shrineRoadHead } from "./settlement-route"
-import { getBuildInfluence, type BuildInfluence } from "./build-influence"
+import { buildInfluence, getBuildInfluence, type BuildInfluence } from "./build-influence"
 import type { SimState } from "./sim"
 import { DEFAULT_ADMISSION_FEE } from "./shrine-visit"
 import { TERRAIN } from "./map/terrain"
@@ -24,6 +24,8 @@ export const STARTING_RESOURCES = {
 export const SETTLEMENT_RADIUS = DEFAULT_BALANCE.rules.buildRadius
 
 export interface Settlement {
+  /** Generated buildings permanently acquired when connected influence reaches them. */
+  claimedBuildings: string[]
   /** Terrain after successful purchases; the generated base map stays immutable. */
   elevation?: GameMap["elevation"]
   resources: Resources
@@ -40,6 +42,7 @@ export interface Settlement {
 
 export function createSettlement(balance: GameBalance = DEFAULT_BALANCE): Settlement {
   return {
+    claimedBuildings: [],
     resources: { gold: balance.rules.startingGold, wood: balance.rules.startingWood },
     structures: [],
     deliveredWood: 0,
@@ -47,6 +50,32 @@ export function createSettlement(balance: GameBalance = DEFAULT_BALANCE): Settle
     shrineAdmission: DEFAULT_ADMISSION_FEE,
     collectedAdmission: 0,
     collectedTrade: 0,
+  }
+}
+
+/** Preserve generated IDs and residents; ownership is a session overlay on the base map. */
+export function settlementMap(baseMap: GameMap, settlement: Settlement): GameMap {
+  const claimed = new Set(settlement.claimedBuildings)
+  return { ...baseMap, elevation: settlement.elevation ?? baseMap.elevation,
+    buildings: [...baseMap.buildings.map(b => claimed.has(b.id) ? { ...b, owner: undefined } : b), ...settlement.structures] }
+}
+
+/** A footprint touching connected influence joins immediately; its renown can reach neighbours. */
+export function claimTownBuildings(settlement: Settlement, baseMap: GameMap, balance: GameBalance = DEFAULT_BALANCE): Settlement {
+  let result = settlement
+  while (true) {
+    const map = settlementMap(baseMap, result)
+    const independent = map.buildings.filter(b => b.owner === "independent")
+    if (!independent.length) return result
+    const influence = buildInfluence(map, balance).connected
+    const reached = independent.filter(b => {
+      for (let z = b.z; z < b.z + b.d; z++) for (let x = b.x; x < b.x + b.w; x++) {
+        if (influence[z * map.width + x]) return true
+      }
+      return false
+    })
+    if (!reached.length) return result
+    result = { ...result, claimedBuildings: [...result.claimedBuildings, ...reached.map(b => b.id)] }
   }
 }
 
@@ -95,7 +124,7 @@ export function individualRenown(monk: Monk, balance: GameBalance = DEFAULT_BALA
 export function settlementEvangelism(map: GameMap): number {
   let chance = 0
   for (const building of map.buildings) {
-    if (!isComplete(building)) continue
+    if (building.owner === "independent" || !isComplete(building)) continue
     const def = BUILD_CATALOG.find(item => item.id === building.buildType)
     chance = Math.max(chance, def?.evangelism ?? 0)
   }
@@ -113,7 +142,7 @@ export function settlementRenown(
   let buildings = 0
   let scenery = 0
   for (const building of map.buildings) {
-    if (!isComplete(building)) continue
+    if (building.owner === "independent" || !isComplete(building)) continue
     if (building.id === map.site?.hovelId) buildings += balance.rules.hovelRenown
     const def = buildCatalog(balance).find((item) => item.id === building.buildType)
     if (def?.category === "buildings") buildings += def.renown
@@ -257,14 +286,14 @@ export function placementError(
 }
 
 export function woodcutterHuts(map: GameMap): PlacedBuilding[] {
-  return map.buildings.filter((b) => b.buildType === "workshop" && isComplete(b))
+  return map.buildings.filter((b) => b.owner !== "independent" && b.buildType === "workshop" && isComplete(b))
     .map((b) => ({ ...b, kind: "workshop" }))
 }
 
 /** Every completed structure with work in it: huts, taverns, folds and stalls. */
-export function jobBuildings(map: GameMap): PlacedBuilding[] {
+export function jobBuildings(map: GameMap, includeIndependent = false): PlacedBuilding[] {
   return map.buildings.flatMap((b) => {
-    const kind = isComplete(b) ? buildingKind(b.buildType) : null
+    const kind = (includeIndependent || b.owner !== "independent") && isComplete(b) ? buildingKind(b.buildType) : null
     return kind ? [{ ...b, kind }] : []
   })
 }
@@ -303,7 +332,7 @@ export function purchaseStructure(
 ): { settlement: Settlement; error: string | null } {
   const def = buildCatalog(balance).find((item) => item.id === type)
   if (!def) return { settlement, error: "Unknown structure." }
-  const map = { ...baseMap, elevation: settlement.elevation ?? baseMap.elevation, buildings: [...baseMap.buildings, ...settlement.structures] }
+  const map = settlementMap(baseMap, settlement)
   if (settlementRenown(map, residents, relics, balance, completedVisits).total < def.requiredRenown)
     return { settlement, error: `Requires ${def.requiredRenown} shrine renown.` }
   if (!canAfford(settlement.resources, def.cost))

--- a/lib/game/sim.test.ts
+++ b/lib/game/sim.test.ts
@@ -1,3 +1,4 @@
+import { TILES_PER_DAY } from "./calendar"
 import { MIN_WEARY_SPEED } from "./traveler-weariness"
 import { DEFAULT_WALK_SPEED, BASE_CHARACTER_SCALE } from "./base-person/gait"
 import { knightLoadout, knightTravelSpeed } from "./knights"
@@ -133,9 +134,8 @@ function runUntil(
 }
 
 describe("game time", () => {
-  it("lasts five real minutes at the displayed normal speed", () => {
-    const normal = SIMULATION_SPEEDS.find(speed => speed.label === 1)!
-    expect(GAME_DAY_SECONDS / normal.rate).toBe(300)
+  it("lasts 144 tiles at the reference walking pace", () => {
+    expect(GAME_DAY_SECONDS * DEFAULT_WALK_SPEED).toBeCloseTo(TILES_PER_DAY)
   })
   it("advances with real time at the configured day length", () => {
     const map = makeMap()
@@ -158,14 +158,14 @@ describe("game time", () => {
       }
       expect(person.progress - before.progress).toBeCloseTo(.5 * rate, 8)
       expect(sim.time - before.time).toBeCloseTo(rate / GAME_DAY_SECONDS, 10)
-      expect(before.hunger - person.hunger).toBeCloseTo(DEFAULT_BALANCE.rules.hungerDecay * rate / 25, 8)
+      expect(before.hunger - person.hunger).toBeCloseTo(DEFAULT_BALANCE.rules.hungerDecay * rate / (GAME_DAY_SECONDS / 24), 8)
       expect(person.activity).toBe("walking")
     }
   })
 
-  it("formats days and hours", () => {
-    expect(formatGameTime(0.25)).toBe("Day 1 — 06:00")
-    expect(formatGameTime(2.5)).toBe("Day 3 — 12:00")
+  it("formats calendar dates", () => {
+    expect(formatGameTime(0.25)).toBe("March 1, 825 AD")
+    expect(formatGameTime(2.5)).toBe("March 3, 825 AD")
   })
 })
 
@@ -245,7 +245,7 @@ describe("stepSim", () => {
     }
     // Legs never bottom out: walkers pitch camp once stamina falls below 20.
     expect(depleted).toEqual({ hunger: 0, thirst: 1, stamina: 0 })
-    expect(sim.time).toBeCloseTo(1.25)
+    expect(sim.time).toBeCloseTo(1)
   })
 
   it("wears travelers down as they walk", () => {

--- a/lib/game/sim.ts
+++ b/lib/game/sim.ts
@@ -1,3 +1,7 @@
+import { tavernWalkingRoute } from "./tavern-navigation"
+import { townResidents } from "./town-residents"
+import { placeResident } from "./jobs/residents"
+import { GAME_DAY_SECONDS, GAME_HOUR_SECONDS, START_TIME } from "./calendar"
 import { wearySpeedScale } from "./traveler-weariness"
 import { housingBeds, vacantMonkBed } from "./housing"
 import { MONK_COUNT, MONK_JOIN_CHANCE, type Monk } from "./monks"
@@ -34,7 +38,7 @@ import { createPasture, stepPasture, type PastureAnimal } from "./transport/past
 import { LINEAR_MOVEMENT, easeSpeed, paceVariation, type MovementTuning } from "./motion"
 import { DEFAULT_BALANCE, type GameBalance } from "./balance"
 import { roadsideEvangelism } from "./monk-evangelism"
-import { buildingAt } from "./settlement"
+import { buildingAt, jobBuildings } from "./settlement"
 import { isComplete, isHouse } from "./construction"
 import { AXE_DAMAGE_PER_HOUR, STUMP_LIFETIME_DAYS, TIMBER_LOAD, stackWood, treeResource, type TreeResource, type WoodPile } from "./trees/timber"
 import { BUILDING_KINDS, buildingCentre, isPostedWork, type PlacedBuilding } from "./buildings"
@@ -199,23 +203,7 @@ export const ACTIVITY_LABELS: Record<Activity, string> = {
 
 // --- Game time ---------------------------------------------------------------
 
-/** Simulation seconds per day: 5 real minutes at the HUD's 1× (2 sim seconds/real second).
- * Roughly one uninterrupted walk along a generated 128×128 map's winding road.
- */
-export const GAME_DAY_SECONDS = 600
-const GAME_HOUR_SECONDS = GAME_DAY_SECONDS / 24
-
-/** The sim opens at dawn on day one. */
-const START_TIME = 0.25
-
-/** `time` is in days since the sim began. */
-export function formatGameTime(time: number): string {
-  const day = Math.floor(time) + 1
-  const minutes = Math.floor((time - Math.floor(time)) * 24 * 60)
-  const h = String(Math.floor(minutes / 60)).padStart(2, "0")
-  const m = String(minutes % 60).padStart(2, "0")
-  return `Day ${day} — ${h}:${m}`
-}
+export { GAME_DAY_SECONDS, formatGameTime } from "./calendar"
 
 // --- Tuning ------------------------------------------------------------------
 // Need rates are per game hour and read from the live balance below. A camp
@@ -705,7 +693,7 @@ export function createSim(
     foodStores: new Map(),
     piles: new Map(),
     resourceRevision: 0,
-    buildings: [],
+    buildings: jobBuildings(map, true),
     trees: [],
   }
   if (!map.road || map.road.length < 2) return sim
@@ -766,6 +754,10 @@ export function createSim(
       timer: t.type.id === "vendor" ? vendWalkSeconds(t.id, 0) : t.type.id === "minstrel" ? minstrelWalkSeconds(t.id, 0) : t.type.id === "beggar" ? beggarWalkSeconds(t.id, 0) : 0,
       cycle: 0,
     })
+  }
+  for (const resident of townResidents(map)) {
+    const actor = sim.travelers.get(resident.traveler.id)
+    if (actor) placeResident(actor, map, resident)
   }
   return sim
 }
@@ -959,6 +951,8 @@ function stepOffRoadWalk(
     s.x = target.x; s.y = target.y; s.z = target.z
     distance -= length
     s.offRoadRoute.shift()
+    // Render the corner before continuing, so a frame cannot cut across furniture.
+    if (length > 1e-6 && s.offRoadRoute.length && (s.activity === "toTavern" || s.activity === "fromTavern")) return false
   }
   s.walkT = 1
   return true
@@ -1032,6 +1026,7 @@ function openSlot(sim: SimState, building: PlacedBuilding): number | null {
 function findJob(sim: SimState, s: SimTraveler, map: GameMap): { building: PlacedBuilding; slot: number } | undefined {
   if (!s.jobless || s.employer) return undefined
   for (const building of sim.buildings) {
+    if (building.owner === "independent") continue
     const def = BUILDING_KINDS[building.kind]
     if (def.vendorKept) continue
     const slot = openSlot(sim, building)
@@ -1051,7 +1046,7 @@ const houseBeds = housingBeds
 
 /** A new settler moves into the nearest house that still has a bed to spare. */
 function findHome(sim: SimState, s: SimTraveler, map: GameMap): string | null {
-  const houses = map.buildings.filter(b => isHouse(b) && isComplete(b))
+  const houses = map.buildings.filter(b => b.owner !== "independent" && isHouse(b) && isComplete(b))
     .sort((a, b) => Math.hypot(tileToWorldX(map, a.x) - s.x, tileToWorldZ(map, a.z) - s.z)
       - Math.hypot(tileToWorldX(map, b.x) - s.x, tileToWorldZ(map, b.z) - s.z))
   for (const house of houses) {
@@ -1067,10 +1062,14 @@ function homeBedSlot(sim: SimState, s: SimTraveler): number {
   return Math.max(0, housemates.indexOf(s.id))
 }
 
-/** Counters able to serve right now: complete, and with a keeper at their post. */
+/** Complete counters with a keeper working, including patrols inside a tavern. */
 function openCounters(sim: SimState, map: GameMap) {
   const staffed = new Set<string>()
-  for (const worker of sim.travelers.values()) if (worker.employer !== null && worker.activity === "posted") staffed.add(worker.employer)
+  for (const worker of sim.travelers.values()) if (worker.employer !== null && (worker.activity === "posted" ||
+    (worker.activity === "toPost" && worker.buildingTask?.purpose === "work" && map.buildings.some(b =>
+      b.id === worker.employer && b.buildType === "tavern" &&
+      worker.x >= tileToWorldX(map, b.x) - .5 && worker.x < tileToWorldX(map, b.x) + b.w - .5 &&
+      worker.z >= tileToWorldZ(map, b.z) - .5 && worker.z < tileToWorldZ(map, b.z) + b.d - .5)))) staffed.add(worker.employer)
   return servingHouses(map, building => staffed.has(building.id))
 }
 
@@ -1089,7 +1088,8 @@ function routeWalk(s: SimTraveler, map: GameMap, route: readonly TilePos[], to: 
  */
 function startTavernTrip(sim: SimState, s: SimTraveler, map: GameMap,
   counters: readonly { id: string; x: number; z: number; w: number; d: number }[], returnTo: WorldPoint | null): boolean {
-  if (!counters.length || s.gold < MEAL_PRICE) return false
+  if (!counters.length || !((s.hunger < SERVING_THRESHOLD && s.gold >= MEAL_PRICE)
+    || (s.thirst < SERVING_THRESHOLD && s.gold >= DRINK_PRICE))) return false
   const from = { x: worldToTileX(map, s.x), z: worldToTileZ(map, s.z) }
   const occupied = new Set([...sim.travelers.values()].flatMap(other => other.tavernVisit?.plan.seat
     ? [`${other.tavernVisit.plan.buildingId}:${other.tavernVisit.plan.seat.id}`] : []))
@@ -1097,21 +1097,23 @@ function startTavernTrip(sim: SimState, s: SimTraveler, map: GameMap,
     - Math.hypot(tileToWorldX(map, b.x) - s.x, tileToWorldZ(map, b.z) - s.z))
   for (const house of nearest) {
     const building = map.buildings.find(b => b.id === house.id)
-    const plan = building && tavernVisitPlan(map, building, from, occupied)
+    const plan = building && tavernVisitPlan(map, building, from, occupied, s)
     if (!plan) continue
     s.tavernVisit = { plan, served: false, returnTo }
-    routeWalk(s, map, plan.route, plan.counter.point)
+    s.walkFrom = { x: s.x, y: s.y, z: s.z }; s.walkT = 0; s.targetId = null
+    s.offRoadRoute = [...plan.route, plan.counter.point]
     s.activity = "toTavern"
     return true
   }
   return false
 }
 
-/** Coin over the counter: the settlement takes it, not the server's own purse. */
-function buyRefreshment(sim: SimState, s: SimTraveler): void {
+/** Only player counters credit the settlement; independent towns keep their takings. */
+function buyRefreshment(sim: SimState, s: SimTraveler, map: GameMap): void {
+  const independent = map.buildings.find(b => b.id === s.tavernVisit?.plan.buildingId)?.owner === "independent"
   const take = (price: number) => {
     s.gold -= price
-    sim.tradeGold += price
+    if (!independent) sim.tradeGold += price
   }
   if (s.hunger < SERVING_THRESHOLD && s.gold >= MEAL_PRICE) { take(MEAL_PRICE); s.hunger = 100 }
   if (s.thirst < SERVING_THRESHOLD && s.gold >= DRINK_PRICE) { take(DRINK_PRICE); s.thirst = 100 }
@@ -1136,10 +1138,16 @@ function finishErrand(s: SimTraveler): void {
 
 /** Head back out of the door to the road, or to the work they left. */
 function leaveTavern(s: SimTraveler, map: GameMap, back: WorldPoint): void {
-  const route = settlementRoute(map, map.buildings, { x: worldToTileX(map, s.x), z: worldToTileZ(map, s.z) },
-    { x: worldToTileX(map, back.x), z: worldToTileZ(map, back.z) }, false, true)
-  if (route) routeWalk(s, map, route, back)
-  else s.offRoadRoute = [{ ...back }]
+  const fine = tavernWalkingRoute(map, s, back)
+  if (fine !== undefined) {
+    if (!fine) return
+    s.offRoadRoute = fine
+  } else {
+    const route = settlementRoute(map, map.buildings, { x: worldToTileX(map, s.x), z: worldToTileZ(map, s.z) },
+      { x: worldToTileX(map, back.x), z: worldToTileZ(map, back.z) }, false, true)
+    if (!route) return
+    routeWalk(s, map, route, back)
+  }
   s.activity = "fromTavern"
 }
 
@@ -1264,7 +1272,8 @@ function tryRoadVisit(sim: SimState, s: SimTraveler, t: Traveler, map: GameMap,
   const renown = sim.shrineRenown + sim.visits * sim.balance.rules.visitRenown
   // Hunger and thirst only draw anyone in while a counter is open:
   // the shrine itself keeps no table (see the tavern and the stall).
-  const served = counters.length > 0
+  const shrineCounters = counters.filter(b => b.owner !== "independent")
+  const served = shrineCounters.length > 0
   const chance = visitChance({ ...t.attributes, piety: s.piety,
     hunger: served ? s.hunger : 100, thirst: served ? s.thirst : 100, stamina: s.stamina },
     sim.relic, renown, sim.balance, 0, t.type.id)
@@ -1276,7 +1285,7 @@ function tryRoadVisit(sim: SimState, s: SimTraveler, t: Traveler, map: GameMap,
   // Wagons and horses stay on the road; only walkers turn aside for a meal.
   if ((ordinaryVisit || persuaded) && served && !needsParking &&
     Math.min(s.hunger, s.thirst) < hospitalityNeedThreshold(renown, sim.balance) &&
-    startTavernTrip(sim, s, map, counters, null)) return true
+    startTavernTrip(sim, s, map, shrineCounters, null)) return true
   const wantsVisit = ordinaryVisit || persuaded
   const occupiedSeats = new Set([...sim.travelers.values()].flatMap(other =>
     other.shrineSeat && ["toParking","toRelic","visiting","fromRelic","offering"].includes(other.activity) ? [other.shrineSeat] : []))
@@ -1737,11 +1746,11 @@ export function stepSim(
         s.timer -= dt
         if (s.timer > 0) break
         const visit = s.tavernVisit!
-        buyRefreshment(sim, s)
+        buyRefreshment(sim, s, map)
         visit.served = true
         const seat = visit.plan.seat
-        const onward = seat && settlementRoute(map, map.buildings, visit.plan.counter.tile, seat.tile, false, true)
-        if (seat && onward) { routeWalk(s, map, onward, seat.point); s.activity = "toTavern" }
+        const onward = seat && tavernWalkingRoute(map, s, seat.point, seat.id)
+        if (seat && onward) { s.offRoadRoute = onward; s.walkT = 0; s.activity = "toTavern" }
         else leaveTavern(s, map, visit.returnTo ?? currentRoutePoint(map, s))
         break
       }
@@ -1775,6 +1784,13 @@ export function stepSim(
         if (s.activity === "fleeing") {
           s.fleeTimer -= dt
           if (s.fleeTimer <= 0) s.activity = "walking"
+        }
+        // Independent taverns welcome road walkers by need, without shrine attraction.
+        if ((s.activity === "walking" || s.activity === "seeking") && !s.track && !s.roadShortcut &&
+          !isVendor && t.type.id !== "knight" && s.visitCooldown <= 0 && Math.min(s.hunger, s.thirst) < SERVING_THRESHOLD) {
+          const nearby = map.towns?.find(town => Math.abs(town.junction - s.progress) <= 3)
+          const counter = nearby && counters.find(b => b.id === nearby.tavernId)
+          if (counter && startTavernTrip(sim, s, map, [counter], null)) break
         }
         // An empty market stall on the shrine's ground draws a passing vendor
         // to settle: they leave the road, take the stall, and keep it for good.

--- a/lib/game/tavern-layout.ts
+++ b/lib/game/tavern-layout.ts
@@ -1,0 +1,60 @@
+import { shelterHearth } from "./building-art/furnishings"
+import { rotateBuildingPoint, rotatedFootprint } from "./building-rotation"
+import type { BuildingDef, TilePos } from "./map/types"
+
+export interface TavernObstacle { id: string; x: number; z: number; w: number; d: number }
+export const TAVERN_CLEARANCE = .1
+
+/** The renderer and navigation use the same tabletops, benches, counter and hearth. */
+export function tavernLayout(w: number, d: number) {
+  const tables = [-1, 1].map(side => ({ id: `tavern-table-${side}-top`, side,
+    x: -w * .23, z: side * d * .22, w: w * .32, d: d * .15 }))
+  const benches = tables.flatMap(table => [-1, 1].map(side => ({
+    id: `tavern-bench-${table.side}-${side}-seat`, x: table.x, z: table.z + side * d * .11,
+    w: table.w, d: .18,
+  })))
+  const counter = { id: "tavern-counter-top", x: w * .2, z: -d * .14, w: w * .27 + .035, d: d * .15 }
+  const hearth = shelterHearth(w, d, 0, 0)
+  return { tables, benches, counter, obstacles: [...tables, ...benches, counter,
+    { id: "hearth", x: hearth.x, z: hearth.z, w: .57 * hearth.scale, d: .57 * hearth.scale }] }
+}
+
+export function tavernLocalPoint(building: BuildingDef, tile: TilePos): TilePos {
+  return rotateBuildingPoint(tile.x - building.x - (building.w - 1) / 2,
+    tile.z - building.z - (building.d - 1) / 2, -(building.rotation ?? 0))
+}
+
+/** Swept body clearance, rather than checking only the endpoints of a move. */
+export function tavernSegmentClear(obstacles: readonly TavernObstacle[], a: TilePos, b: TilePos,
+  allowedBench?: string): boolean {
+  return obstacles.every(rect => {
+    if (rect.id === allowedBench) return true
+    let low = 0, high = 1
+    for (const axis of ["x", "z"] as const) {
+      const half = (axis === "x" ? rect.w : rect.d) / 2 + TAVERN_CLEARANCE
+      const delta = b[axis] - a[axis], start = a[axis] - rect[axis]
+      if (Math.abs(delta) < 1e-8) {
+        if (Math.abs(start) > half) return true
+      } else {
+        const u = (-half - start) / delta, v = (half - start) / delta
+        low = Math.max(low, Math.min(u, v)); high = Math.min(high, Math.max(u, v))
+        if (low > high) return true
+      }
+    }
+    return false
+  })
+}
+
+export function tavernFurnitureClear(building: BuildingDef, from: TilePos, to: TilePos): boolean {
+  const { w, d } = rotatedFootprint(building, building.rotation)
+  return tavernSegmentClear(tavernLayout(w, d).obstacles, tavernLocalPoint(building, from), tavernLocalPoint(building, to))
+}
+
+/** Pauses at the counter, in the service aisle and near the drinking tables. */
+export function tavernWorkStop(slot: number, stop: number, w: number, d: number): TilePos {
+  const stops = slot % 2 === 0
+    ? [[.06, -.30], [0, -.39], [0, 0], [.17, .25]]
+    : [[.34, -.30], [.41, -.23], [.32, .10], [.10, .36]]
+  const [x, z] = stops[stop % stops.length]
+  return { x: x * w, z: z * d }
+}

--- a/lib/game/tavern-navigation.test.ts
+++ b/lib/game/tavern-navigation.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest"
+import { BUILD_CATALOG } from "./balance"
+import { rotatedFootprint, type BuildingRotation, buildingEntry, rotateBuildingPoint } from "./building-rotation"
+import { tavernLayout, tavernLocalPoint, tavernSegmentClear, tavernWorkStop } from "./tavern-layout"
+import { tavernInteriorRoute, tavernWalkingRoute, tavernWorldPoint } from "./tavern-navigation"
+import { servingCounter, tavernSeats, tavernVisitPlan } from "./tavern"
+import { buildingStepAllowed } from "./building-navigation"
+import { createSim, stepSim } from "./sim"
+import { townResidents } from "./town-residents"
+import { TRAVELER_TYPES } from "./travelers"
+import { type GameMap, type TilePos, tileToWorldX, tileToWorldZ } from "./map/types"
+
+function fixture(rotation: BuildingRotation = 0) {
+  const def = BUILD_CATALOG.find(b => b.id === "tavern")!
+  const tavern = { ...def, id: "tavern", townId: "town", buildType: "tavern", x: 10, z: 10,
+    ...rotatedFootprint(def, rotation), rotation }
+  const house = { ...BUILD_CATALOG.find(b => b.id === "house")!, id: "house", townId: "town", buildType: "house", x: 5, z: 5 }
+  const map: GameMap = { width: 30, depth: 30, tiles: Array(900).fill("grass"), buildings: [tavern, house],
+    road: Array.from({ length: 30 }, (_, x) => ({ x, z: 20 })),
+    towns: [{ id: "town", name: "Hazelwick", junction: 11, tavernId: "tavern", buildingIds: ["tavern", "house"] }] }
+  const local = (p: TilePos) => tavernLocalPoint(tavern, { x: p.x + map.width / 2 - .5, z: p.z + map.depth / 2 - .5 })
+  return { map, tavern, local }
+}
+
+describe("tavern aisles", () => {
+  it("serves a road traveler while both keepers are walking inside, then seats them and lets them leave", () => {
+    const { map, local } = fixture()
+    const people = townResidents(map).map(r => r.traveler), sim = createSim(people, map)
+    for (let tick = 0; tick < 400 && ![...sim.travelers.values()].every(s => s.activity === "toPost"); tick++) {
+      stepSim(sim, people, map, 1, .05)
+    }
+    expect([...sim.travelers.values()].every(s => s.activity === "toPost")).toBe(true)
+    const traveler = { ...people[0], id: 7, type: TRAVELER_TYPES.peasant, offset: 11 / 29,
+      attributes: { ...people[0].attributes, hunger: 40, thirst: 40, gold: 20 } }
+    const customer = createSim([traveler], map).travelers.get(traveler.id)!
+    sim.travelers.set(traveler.id, customer)
+    people.push(traveler)
+    stepSim(sim, people, map, 1, .05)
+    expect(customer.activity).toBe("toTavern")
+    const obstacles = tavernLayout(3, 4).obstacles
+    let seated = false
+    for (let tick = 0; tick < 2400 && customer.tavernVisit; tick++) {
+      const before = { x: customer.x, z: customer.z }, seat = customer.tavernVisit.plan.seat!
+      stepSim(sim, people, map, 1, .05)
+      expect(tavernSegmentClear(obstacles, local(before), local(customer), seat.id),
+        JSON.stringify({ tick, from: local(before), to: local(customer), activity: customer.activity })).toBe(true)
+      if (customer.activity === "sitting") seated = true
+    }
+    expect(seated).toBe(true)
+    expect(customer.tavernVisit).toBeUndefined()
+    expect(customer.gold).toBe(15)
+    expect(customer.activity).toBe("walking")
+  })
+
+  it.each([0, 1, 2, 3] as const)("reaches every bench and both doors without crossing furniture at rotation %s", rotation => {
+    const { map, tavern, local } = fixture(rotation), counter = servingCounter(map, tavern)
+    const { obstacles } = tavernLayout(3, 4)
+    for (const seat of tavernSeats(map, tavern)) {
+      const route = tavernWalkingRoute(map, counter.point, seat.point, seat.id)
+      expect(route).toBeTruthy()
+      for (let i = 1; i < route!.length; i++) {
+        expect(tavernSegmentClear(obstacles, local(route![i - 1]), local(route![i]), i === route!.length - 1 ? seat.id : undefined)).toBe(true)
+      }
+      expect(route!.at(-1)!.x).toBeCloseTo(seat.point.x)
+      expect(route!.at(-1)!.z).toBeCloseTo(seat.point.z)
+      for (const side of [1, -1] as const) {
+        const door = buildingEntry(tavern, false, side)
+        const outside = { x: tileToWorldX(map, door.x), y: 0.2, z: tileToWorldZ(map, door.z) }
+        const exit = tavernWalkingRoute(map, seat.point, outside)
+        expect(exit).toBeTruthy()
+        for (let i = 1; i < exit!.length; i++) expect(tavernSegmentClear(obstacles, local(exit![i - 1]), local(exit![i]), i === 1 ? seat.id : undefined)).toBe(true)
+        expect(tavernVisitPlan(map, tavern, door)).not.toBeNull()
+      }
+    }
+  })
+
+  it.each([0, 1, 2, 3] as const)("blocks coarse tile routes and diagonals across tables at rotation %s", rotation => {
+    const { map, tavern } = fixture(rotation)
+    const tile = (x: number, z: number) => {
+      const p = rotateBuildingPoint(x, z, rotation)
+      return { x: tavern.x + (tavern.w - 1) / 2 + p.x, z: tavern.z + (tavern.d - 1) / 2 + p.z }
+    }
+    expect(buildingStepAllowed(map, map.buildings, tile(-1.35, .88), tile(0, .88), true)).toBe(false)
+    expect(buildingStepAllowed(map, map.buildings, tile(0, -.2), tile(0, .2), true)).toBe(true)
+    expect(tavernInteriorRoute(tavern, { x: 0, z: 0 }, { x: -.69, z: .88 })).toBeNull()
+  })
+
+  it.each([0, 1, 2, 3] as const)("keeps workers walking through clear aisles with their jobs intact at rotation %s", rotation => {
+    const { map, tavern, local } = fixture(rotation)
+    const residents = townResidents(map), people = residents.map(r => r.traveler), sim = createSim(people, map)
+    const obstacles = tavernLayout(3, 4).obstacles, distance = [0, 0], pauses = [0, 0]
+    for (let tick = 0; tick < 400; tick++) {
+      const before = people.map(t => ({ ...sim.travelers.get(t.id)! }))
+      stepSim(sim, people, map, 1, .05)
+      people.forEach((t, i) => {
+        const s = sim.travelers.get(t.id)!
+        expect(s.employer).toBe("tavern")
+        expect(["toPost", "posted"]).toContain(s.activity)
+        expect(tavernSegmentClear(obstacles, local(before[i]), local(s))).toBe(true)
+        distance[i] += Math.hypot(s.x - before[i].x, s.z - before[i].z)
+        if (s.activity === "posted") pauses[i]++
+      })
+    }
+    for (let i = 0; i < 2; i++) { expect(distance[i]).toBeGreaterThan(2); expect(pauses[i]).toBeGreaterThan(20) }
+    for (let slot = 0; slot < 2; slot++) for (let stop = 0; stop < 4; stop++) {
+      expect(tavernWalkingRoute(map, tavernWorldPoint(map, tavern, tavernWorkStop(slot, stop, 3, 4)), servingCounter(map, tavern).point)).toBeTruthy()
+    }
+  })
+})

--- a/lib/game/tavern-navigation.ts
+++ b/lib/game/tavern-navigation.ts
@@ -1,0 +1,92 @@
+import { buildingEntry, rotateBuildingPoint, rotatedFootprint, buildingDoorOffset } from "./building-rotation"
+import { tavernLayout, tavernLocalPoint, tavernSegmentClear, TAVERN_CLEARANCE } from "./tavern-layout"
+import { tileToWorldX, tileToWorldZ, worldToTileX, worldToTileZ, type BuildingDef, type GameMap, type TilePos } from "./map/types"
+import { surfaceHeight } from "./map/bridges"
+import { settlementRoute } from "./settlement-route"
+
+export interface TavernWalkPoint { x: number; y: number; z: number }
+const same = (a: TilePos, b: TilePos) => Math.hypot(a.x - b.x, a.z - b.z) < 1e-6
+
+/** A small visibility graph resolves aisles narrower than a world tile. */
+export function tavernInteriorRoute(building: BuildingDef, from: TilePos, to: TilePos, seat?: string): TilePos[] | null {
+  const { w, d } = rotatedFootprint(building, building.rotation)
+  const { obstacles, benches } = tavernLayout(w, d)
+  const inside = (p: TilePos) => Math.abs(p.x) <= w / 2 - .13 && Math.abs(p.z) <= d / 2 - .13
+  if (!inside(from) || !inside(to)) return null
+  const startingBench = benches.find(b => Math.abs(from.x - b.x) <= b.w / 2 + .01 && Math.abs(from.z - b.z) <= b.d / 2 + .01)?.id
+  const clear = (a: TilePos, b: TilePos) => tavernSegmentClear(obstacles, a, b,
+    same(a, from) && startingBench ? startingBench : same(b, to) ? seat : undefined)
+  const nodes = [from, to]
+  for (const rect of obstacles) for (const sx of [-1, 1]) for (const sz of [-1, 1]) {
+    const p = { x: rect.x + sx * (rect.w / 2 + TAVERN_CLEARANCE + .005),
+      z: rect.z + sz * (rect.d / 2 + TAVERN_CLEARANCE + .005) }
+    if (inside(p) && tavernSegmentClear(obstacles, p, p)) nodes.push(p)
+  }
+  const distance = nodes.map(() => Infinity), previous = nodes.map(() => -1), visited = new Set<number>()
+  distance[0] = 0
+  for (let step = 0; step < nodes.length; step++) {
+    let current = -1
+    for (let i = 0; i < nodes.length; i++) if (!visited.has(i) && (current < 0 || distance[i] < distance[current])) current = i
+    if (current < 0 || !Number.isFinite(distance[current])) return null
+    if (current === 1) {
+      const path: TilePos[] = []
+      for (let i = 1; i !== -1; i = previous[i]) path.push(nodes[i])
+      return path.reverse()
+    }
+    visited.add(current)
+    for (let i = 0; i < nodes.length; i++) {
+      if (visited.has(i) || !clear(nodes[current], nodes[i])) continue
+      const candidate = distance[current] + Math.hypot(nodes[current].x - nodes[i].x, nodes[current].z - nodes[i].z)
+      if (candidate < distance[i]) { distance[i] = candidate; previous[i] = current }
+    }
+  }
+  return null
+}
+
+function local(map: GameMap, building: BuildingDef, p: TilePos): TilePos {
+  return tavernLocalPoint(building, { x: p.x + map.width / 2 - .5, z: p.z + map.depth / 2 - .5 })
+}
+export function tavernWorldPoint(map: GameMap, building: BuildingDef, p: TilePos): TavernWalkPoint {
+  const offset = rotateBuildingPoint(p.x, p.z, building.rotation)
+  const x = tileToWorldX(map, building.x) + (building.w - 1) / 2 + offset.x
+  const z = tileToWorldZ(map, building.z) + (building.d - 1) / 2 + offset.z
+  return { x, z, y: surfaceHeight(map, worldToTileX(map, x), worldToTileZ(map, z)) }
+}
+function tavernAt(map: GameMap, p: TilePos) {
+  return map.buildings.find(b => b.buildType === "tavern" && (!b.construction || b.construction.work >= b.construction.required)
+    && Math.abs(local(map, b, p).x) < rotatedFootprint(b, b.rotation).w / 2
+    && Math.abs(local(map, b, p).z) < rotatedFootprint(b, b.rotation).d / 2)
+}
+
+/** Undefined delegates ordinary travel; null means the tavern trip is blocked. */
+export function tavernWalkingRoute(map: GameMap, from: TavernWalkPoint, to: TavernWalkPoint, seat?: string): TavernWalkPoint[] | null | undefined {
+  const start = tavernAt(map, from), end = tavernAt(map, to)
+  if (!start && !end) return undefined
+  if (start && start === end) return tavernInteriorRoute(start, local(map, start, from), local(map, start, to), seat)
+    ?.map(p => tavernWorldPoint(map, start, p)) ?? null
+  const options = (building: BuildingDef | undefined, point: TavernWalkPoint, leaving: boolean) => {
+    if (!building) return [{ outside: point, route: [point] }]
+    const { w, d } = rotatedFootprint(building, building.rotation)
+    return ([1, -1] as const).flatMap(side => {
+      const door = { x: buildingDoorOffset(w, "tavern"), z: side * (d / 2 - .16) }
+      const path = tavernInteriorRoute(building, leaving ? local(map, building, point) : door,
+        leaving ? door : local(map, building, point), leaving ? undefined : seat)
+      if (!path) return []
+      const entry = buildingEntry(building, false, side)
+      const outside = { x: tileToWorldX(map, entry.x), z: tileToWorldZ(map, entry.z), y: surfaceHeight(map, entry.x, entry.z) }
+      const route = path.map(p => tavernWorldPoint(map, building, p))
+      return [{ outside, route: leaving ? [...route, outside] : [outside, ...route] }]
+    })
+  }
+  let best: TavernWalkPoint[] | null = null, length = Infinity
+  for (const a of options(start, from, true)) for (const b of options(end, to, false)) {
+    const path = settlementRoute(map, map.buildings,
+      { x: worldToTileX(map, a.outside.x), z: worldToTileZ(map, a.outside.z) },
+      { x: worldToTileX(map, b.outside.x), z: worldToTileZ(map, b.outside.z) }, false, true)
+    if (!path) continue
+    const route = [...a.route, ...path.map(p => ({ x: tileToWorldX(map, p.x), z: tileToWorldZ(map, p.z), y: surfaceHeight(map, p.x, p.z) })), ...b.route]
+    const distance = route.reduce((sum, p, i) => sum + (i ? Math.hypot(p.x - route[i - 1].x, p.z - route[i - 1].z) : 0), 0)
+    if (distance < length) { best = route; length = distance }
+  }
+  return best
+}

--- a/lib/game/tavern.ts
+++ b/lib/game/tavern.ts
@@ -1,15 +1,17 @@
+import { tavernWalkingRoute, type TavernWalkPoint } from "./tavern-navigation"
+import { tavernLayout } from "./tavern-layout"
 import { rotateBuildingPoint, rotatedFootprint, buildingEntry } from "./building-rotation"
 import { buildingSupports, placedSupport } from "./character-support"
 import { isComplete } from "./construction"
 import { surfaceHeight } from "./map/bridges"
 import { settlementRoute } from "./settlement-route"
 import { tileToWorldX, tileToWorldZ, worldToTileX, worldToTileZ, type BuildingDef, type GameMap, type TilePos } from "./map/types"
-import { workPost } from "./work-posts"
 
 /**
  * Where the settlement sells food and drink. The shrine no longer feeds anyone:
  * a meal and a cup are bought with coin at a counter, and the takings belong to
- * the settlement (see `SimState.tradeGold`).
+ * the settlement (see `SimState.tradeGold`). Independent roadside towns run
+ * their own counters and retain all their takings.
  *
  * Two counters exist. The tavern serves inside, and its customers carry the
  * cup to a table and sit down. A market stall kept by a settled vendor serves
@@ -28,7 +30,7 @@ export interface TavernSeat {
   heading: number
 }
 
-/** Completed places with a counter; a stall only counts once a keeper holds it. */
+/** All counters, including town taverns, require a keeper at their post. */
 export function servingHouses(map: GameMap, staffed: (building: BuildingDef) => boolean): BuildingDef[] {
   return map.buildings.filter(b => isComplete(b)
     && (b.buildType === "tavern" || b.buildType === "market") && staffed(b))
@@ -52,8 +54,8 @@ export function servingCounter(map: GameMap, building: BuildingDef): { tile: Til
     return { tile, point: { x: tileToWorldX(map, tile.x), y: surfaceHeight(map, tile.x, tile.z), z: tileToWorldZ(map, tile.z) } }
   }
   const local = rotatedFootprint(building, building.rotation)
-  const post = workPost("tavern", 0, local.w, local.d)!
-  const point = localPoint(map, building, post.x, post.z + local.d * 0.22)
+  const counter = tavernLayout(local.w, local.d).counter
+  const point = localPoint(map, building, counter.x, counter.z + counter.d / 2 + .16)
   const tile = { x: worldToTileX(map, point.x), z: worldToTileZ(map, point.z) }
   return { tile, point: { ...point, y: surfaceHeight(map, tile.x, tile.z) } }
 }
@@ -75,8 +77,8 @@ export interface TavernPlan {
   buildingId: string
   counter: { tile: TilePos; point: { x: number; y: number; z: number } }
   seat: TavernSeat | null
-  /** Tiles from the customer's own position to the counter. */
-  route: TilePos[]
+  /** World-space aisle route from the customer to the counter. */
+  route: TavernWalkPoint[]
 }
 
 /**
@@ -88,14 +90,18 @@ export function tavernVisitPlan(
   building: BuildingDef,
   from: TilePos,
   occupied: ReadonlySet<string> = new Set(),
+  fromWorld?: TavernWalkPoint,
 ): TavernPlan | null {
   const counter = servingCounter(map, building)
-  const route = settlementRoute(map, map.buildings, from, counter.tile, false, true)
+  const start = fromWorld ?? { x: tileToWorldX(map, from.x), z: tileToWorldZ(map, from.z), y: surfaceHeight(map, from.x, from.z) }
+  const fine = tavernWalkingRoute(map, start, counter.point)
+  const route = fine === undefined ? settlementRoute(map, map.buildings, from, counter.tile, false, true)
+    ?.map(p => ({ x: tileToWorldX(map, p.x), z: tileToWorldZ(map, p.z), y: surfaceHeight(map, p.x, p.z) })) : fine
   if (!route) return null
   const seats = tavernSeats(map, building).filter(seat => !occupied.has(`${building.id}:${seat.id}`))
   if (building.buildType !== "tavern") return { buildingId: building.id, counter, seat: null, route }
   for (const seat of seats) {
-    if (settlementRoute(map, map.buildings, counter.tile, seat.tile, false, true)) {
+    if (tavernWalkingRoute(map, counter.point, seat.point, seat.id)) {
       return { buildingId: building.id, counter, seat, route }
     }
   }

--- a/lib/game/town-residents.test.ts
+++ b/lib/game/town-residents.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it } from "vitest"
+import { BUILD_CATALOG } from "./balance"
+import { type GameMap, tileToWorldX, tileToWorldZ } from "./map/types"
+import { townResidents } from "./town-residents"
+import { createSim, stepSim, GAME_DAY_SECONDS } from "./sim"
+import { claimTownBuildings, createSettlement, jobBuildings, settlementMap, settlementRenown, creditTrade } from "./settlement"
+import { enclaveHousing } from "./housing"
+import { buildInfluence } from "./build-influence"
+import { servingHouses } from "./tavern"
+import { useBuildStore } from "./build-store"
+import { buildingEntry } from "./building-rotation"
+import { tavernVisitPlan } from "./tavern"
+
+function fixture(): GameMap {
+  const width = 80, depth = 35
+  const building = (type: "tavern" | "house", x: number, z: number) => ({
+    ...BUILD_CATALOG.find(b => b.id === type)!, id: `town-${type}`, buildType: type, x, z,
+    owner: "independent" as const, townId: "town",
+  })
+  return { width, depth, tiles: Array(width * depth).fill("grass"), seed: 42,
+    road: Array.from({ length: width }, (_, x) => ({ x, z: 20 })),
+    site: { junction: 10, branch: Array.from({ length: 11 }, (_, i) => ({ x: 10, z: 20 - i })),
+      door: { x: 10, z: 10 }, hovelId: "chapel" },
+    buildings: [
+      { id: "chapel", label: "Chapel", x: 8, z: 6, w: 3, d: 3, height: 1, color: "tan", roofColor: "brown" },
+      building("tavern", 25, 16), building("house", 25, 10),
+    ],
+    towns: [{ id: "town", name: "Hazelwick", junction: 26, tavernId: "town-tavern", buildingIds: ["town-tavern", "town-house"] }],
+  }
+}
+
+afterEach(() => useBuildStore.getState().reset())
+
+describe("town households", () => {
+  it("starts with two employed residents in distinct posts and a shared home, without adding player settlers", () => {
+    const map = fixture(), residents = townResidents(map), travelers = residents.map(r => r.traveler)
+    const sim = createSim(travelers, map)
+    expect(residents).toHaveLength(2)
+    expect(new Set(travelers.map(t => t.id)).size).toBe(2)
+    for (const resident of residents) {
+      expect(sim.travelers.get(resident.traveler.id)).toMatchObject({
+        employer: "town-tavern", home: "town-house", jobless: false, activity: "posted", jobSlot: resident.jobSlot,
+      })
+    }
+    const staffed = (id: string) => [...sim.travelers.values()].some(s => s.employer === id && s.activity === "posted")
+    expect(servingHouses(map, b => staffed(b.id))).toHaveLength(1)
+    useBuildStore.getState().syncResources(sim, travelers)
+    expect(useBuildStore.getState().settlers).toEqual([])
+    expect(jobBuildings(map)).toEqual([])
+    expect(enclaveHousing(map, 0, 0).people.capacity).toBe(0)
+    expect(townResidents({ ...map, buildings: map.buildings.map(b => ({ ...b, owner: undefined })) }).map(r => r.traveler.id))
+      .toEqual(travelers.map(t => t.id))
+  })
+
+  it("lets workers go home, recover in separate beds and return to their posts", () => {
+    const map = fixture(), travelers = townResidents(map).map(r => r.traveler), sim = createSim(travelers, map)
+    for (const s of sim.travelers.values()) { s.stamina = 10; s.gold = 0 }
+    const slept = new Set<number>(), beds = new Set<number>()
+    for (let elapsed = 0; elapsed < GAME_DAY_SECONDS; elapsed += .2) {
+      stepSim(sim, travelers, map, 1, .2)
+      for (const s of sim.travelers.values()) if (s.activity === "sleeping") { slept.add(s.id); beds.add(s.workSlot!) }
+      if (slept.size === 2 && [...sim.travelers.values()].every(s => s.activity === "posted")) break
+    }
+    expect(slept.size).toBe(2)
+    expect(beds.size).toBe(2)
+    for (const s of sim.travelers.values()) expect(s).toMatchObject({ activity: "posted", employer: "town-tavern", home: "town-house" })
+  })
+})
+
+describe("acquiring town buildings", () => {
+  it("claims on connected footprint contact, propagates influence, and preserves ownership and residents", () => {
+    const base = fixture(), original = createSettlement()
+    expect(claimTownBuildings(original, base)).toBe(original)
+    const cross = { ...BUILD_CATALOG.find(b => b.id === "cross")!, id: "player-cross", buildType: "cross", x: 18, z: 15 }
+    const expanded = { ...original, structures: [cross] }
+    const before = settlementMap(base, expanded)
+    const field = buildInfluence(before).connected
+    expect(field[16 * base.width + 25]).toBe(1)
+    expect(field[10 * base.width + 25]).toBe(0)
+    const acquired = claimTownBuildings(expanded, base)
+    expect(acquired.claimedBuildings.sort()).toEqual(["town-house", "town-tavern"])
+    const map = settlementMap(base, acquired)
+    expect(map.buildings.filter(b => b.owner === "independent")).toEqual([])
+    expect(base.buildings.filter(b => b.owner === "independent")).toHaveLength(2)
+    expect(claimTownBuildings(acquired, base)).toBe(acquired)
+    expect(claimTownBuildings({ ...acquired, structures: [] }, base).claimedBuildings).toEqual(acquired.claimedBuildings)
+    expect(jobBuildings(map)).toHaveLength(1)
+    expect(enclaveHousing(map, 2, 0).people.capacity).toBe(2)
+    expect(settlementRenown(map, [], []).total).toBeGreaterThan(settlementRenown(before, [], []).total)
+    const travelers = townResidents(base).map(r => r.traveler), sim = createSim(travelers, base)
+    const people = [...sim.travelers.values()]
+    sim.buildings = jobBuildings(map, true)
+    useBuildStore.getState().syncResources(sim, travelers)
+    expect(useBuildStore.getState().settlers).toHaveLength(2)
+    expect([...sim.travelers.values()]).toEqual(people)
+  })
+
+  it("does not claim disconnected influence across water", () => {
+    const base = fixture()
+    for (let z = 0; z < base.depth; z++) base.tiles[z * base.width + 20] = "water"
+    const cross = { ...BUILD_CATALOG.find(b => b.id === "cross")!, id: "cross", buildType: "cross", x: 18, z: 15 }
+    const settlement = { ...createSettlement(), structures: [cross] }
+    expect(claimTownBuildings(settlement, base)).toBe(settlement)
+  })
+
+  it("credits only sales after acquisition, including a customer already at the counter", () => {
+    const base = fixture(), travelers = townResidents(base).map(r => r.traveler), sim = createSim(travelers, base)
+    const customer = sim.travelers.get(travelers[0].id)!, tavern = base.buildings[1]
+    const entry = buildingEntry(tavern), plan = tavernVisitPlan(base, tavern, entry)!
+    const buy = (map: GameMap) => {
+      Object.assign(customer, { activity: "buying", timer: 0, hunger: 40, thirst: 100, gold: 20,
+        x: tileToWorldX(map, entry.x), z: tileToWorldZ(map, entry.z), tavernVisit: { plan, served: false, returnTo: null } })
+      stepSim(sim, travelers, map, 1, .01)
+    }
+    buy(base)
+    expect(sim.tradeGold).toBe(0)
+    const owned = { ...createSettlement(), claimedBuildings: [tavern.id] }, map = settlementMap(base, owned)
+    sim.buildings = jobBuildings(map, true)
+    buy(map)
+    expect(sim.tradeGold).toBe(2)
+    expect(creditTrade(owned, sim.tradeGold).resources.gold).toBe(owned.resources.gold + 2)
+  })
+})

--- a/lib/game/town-residents.ts
+++ b/lib/game/town-residents.ts
@@ -1,0 +1,28 @@
+import { BUILDING_KINDS, type PlacedBuilding } from "./buildings"
+import { travelerAppearance } from "./base-person/population"
+import type { GameMap } from "./map/types"
+import { TRAVELER_TYPES, type Traveler } from "./travelers"
+
+/** Towns keep their founding household through traffic changes and annexation. */
+export function townResidents(map: GameMap) {
+  return (map.towns ?? []).flatMap((town, index) => {
+    const tavern = map.buildings.find(b => b.id === town.tavernId)
+    const house = map.buildings.find(b => b.townId === town.id && b.buildType === "house")
+    if (!tavern || !house) return []
+    const building: PlacedBuilding = { ...tavern, kind: "tavern" }
+    return Array.from({ length: BUILDING_KINDS.tavern.jobs }, (_, jobSlot) => {
+      let id = 2_000_000 + index * 100 + jobSlot * 50
+      const body = jobSlot === 0 ? "Male" : "Female"
+      while (travelerAppearance(map.seed ?? 0, id).bodyType !== body) id++
+      const traveler: Traveler = {
+        id, name: `${jobSlot === 0 ? "Aldwin" : "Edith"} of ${town.name}`,
+        type: TRAVELER_TYPES.peasant, pace: 1, direction: 1,
+        offset: town.junction / Math.max(1, (map.road?.length ?? 1) - 1),
+        attributes: { age: 28 + jobSlot * 5, gold: 40, piety: 30, status: 25,
+          hunger: 100 - jobSlot * 20, thirst: 100 - jobSlot * 20, stamina: 100 - jobSlot * 15,
+          jobless: false, skills: [...BUILDING_KINDS.tavern.trades] },
+      }
+      return { traveler, building, jobSlot, home: house.id }
+    })
+  })
+}


### PR DESCRIPTION
Adds staffed roadside towns about 128 road tiles apart and well away from the chapel, with a house directly beside each tavern and paths to every entrance.
Town buildings remain independent and earn the player nothing until connected influence reaches them; tavern keepers patrol clear aisles, and customers walk around furniture to sit on benches.
Starts the calendar on March 1, 825 AD with a day set to 144 tiles of walking, and places T-junction signs across from incoming roads.

Validated with the full 1,463-test suite, subsequent placement and sign regression tests, TypeScript, production build, asset checks, and local browser checks.
