### PR TITLE
Halve hunger and stamina drain rates

### DIFF
--- a/lib/game/balance.test.ts
+++ b/lib/game/balance.test.ts
@@ -96,6 +96,21 @@ describe("balance presets", () => {
     old.balance.rules.thirstDecay = 10
     expect(importBalance(JSON.stringify(old)).balance?.rules).toMatchObject({ hungerDecay: 8, thirstDecay: 10 })
   })
+  it("halves previous default rates in saved presets while preserving custom tuning", () => {
+    const old = JSON.parse(exportBalance(DEFAULT_BALANCE))
+    old.version = 4
+    Object.assign(old.balance.rules, { hungerDecay: 3, staminaDecay: 2.1, thirstDecay: 25 })
+    old.balance.buildings.tavern.goldIncome = 10
+    const result = importBalance(JSON.stringify(old))
+    expect(result.error).toBeNull()
+    expect(result.balance?.rules).toMatchObject({ hungerDecay: 1.5, staminaDecay: 1.05, thirstDecay: 25 })
+    expect(result.balance?.buildings.tavern.goldIncome).toBe(10)
+    Object.assign(old.balance.rules, { hungerDecay: 8, staminaDecay: 7 })
+    expect(importBalance(JSON.stringify(old)).balance?.rules).toMatchObject({ hungerDecay: 8, staminaDecay: 7 })
+    const current = fresh()
+    Object.assign(current.rules, { hungerDecay: 3, staminaDecay: 2.1 })
+    expect(importBalance(exportBalance(current)).balance).toEqual(current)
+  })
   it.each([NaN, Infinity, -1, 1.5, 100001, "200", null])(
     "rejects invalid starting supplies: %s",
     (value) => {

--- a/lib/game/balance.ts
+++ b/lib/game/balance.ts
@@ -430,8 +430,8 @@ export const RULE_FIELDS = [
   },
   {
     key: "hungerDecay", group: "Traveler needs", label: "Hunger drain per game hour",
-    description: "Fullness lost per game hour. Default: 72 points per day, with a full bar lasting about 33 hours. Camping halves this rate; shrine hospitality restores it.",
-    default: 3, min: 0, max: 50, step: 0.1,
+    description: "Fullness lost per game hour. Default: 36 points per day, with a full bar lasting about 67 hours. Camping halves this rate; shrine hospitality restores it.",
+    default: 1.5, min: 0, max: 50, step: 0.1,
   },
   {
     key: "thirstDecay", group: "Traveler needs", label: "Thirst drain per game hour",
@@ -440,8 +440,8 @@ export const RULE_FIELDS = [
   },
   {
     key: "staminaDecay", group: "Traveler needs", label: "Stamina drain per game hour",
-    description: "Energy lost per game hour. Default: a full bar lasts about 48 hours, with travelers looking for lodging once it falls below 20. Camping restores stamina and tending a parked stall holds it steady; drinking does not restore energy.",
-    default: 2.1, min: 0, max: 50, step: 0.1,
+    description: "Energy lost per game hour. Default: a full bar lasts about 95 hours, with travelers looking for lodging once it falls below 20. Camping restores stamina and tending a parked stall holds it steady; drinking does not restore energy.",
+    default: 1.05, min: 0, max: 50, step: 0.05,
   },
 ] as const
 export type RuleKey = (typeof RULE_FIELDS)[number]["key"]
@@ -602,7 +602,7 @@ export function validateBalance(
   }
   return { balance: clean, error: null }
 }
-export const BALANCE_VERSION = 4
+export const BALANCE_VERSION = 5
 export function exportBalance(balance: GameBalance): string {
   return JSON.stringify({ version: BALANCE_VERSION, balance }, null, 2)
 }
@@ -610,8 +610,8 @@ export function importBalance(json: string): ReturnType<typeof validateBalance> 
   try {
     const preset = record(JSON.parse(json))
     const version = preset?.version
-    if (version !== 1 && version !== 2 && version !== 3 && version !== BALANCE_VERSION)
-      return { balance: null, error: "Unsupported preset version. Expected version 1, 2, 3 or 4." }
+    if (version !== 1 && version !== 2 && version !== 3 && version !== 4 && version !== BALANCE_VERSION)
+      return { balance: null, error: "Unsupported preset version. Expected version 1, 2, 3, 4 or 5." }
     // Add defaults for new structures while retaining all authored settings.
     const saved = record(preset?.balance)
     const rules = record(saved?.rules)
@@ -629,8 +629,9 @@ export function importBalance(json: string): ReturnType<typeof validateBalance> 
         hospitalityRenownBonus: DEFAULT_BALANCE.rules.hospitalityRenownBonus,
         ...rules,
         // Adopt slower defaults in old saves without overwriting custom rates.
-        ...(version !== BALANCE_VERSION && rules.hungerDecay === 12.5 ? { hungerDecay: DEFAULT_BALANCE.rules.hungerDecay } : {}),
-        ...(version !== BALANCE_VERSION && rules.thirstDecay === 25 ? { thirstDecay: DEFAULT_BALANCE.rules.thirstDecay } : {}),
+        ...((version < 4 && rules.hungerDecay === 12.5 || version < 5 && rules.hungerDecay === 3) ? { hungerDecay: DEFAULT_BALANCE.rules.hungerDecay } : {}),
+        ...(version < 4 && rules.thirstDecay === 25 ? { thirstDecay: DEFAULT_BALANCE.rules.thirstDecay } : {}),
+        ...(version < 5 && rules.staminaDecay === 2.1 ? { staminaDecay: DEFAULT_BALANCE.rules.staminaDecay } : {}),
       },
       buildings: {
         ...DEFAULT_BALANCE.buildings,
@@ -642,7 +643,7 @@ export function importBalance(json: string): ReturnType<typeof validateBalance> 
           workshop: { ...record(buildings.workshop), woodIncome: 0 },
         } : {}),
         // The tavern now earns at the counter; retire its old passive payment.
-        ...(version !== BALANCE_VERSION && record(buildings.tavern)?.goldIncome === 10 ? {
+        ...(version < 4 && record(buildings.tavern)?.goldIncome === 10 ? {
           tavern: { ...record(buildings.tavern), goldIncome: 0 },
         } : {}),
       },

--- a/lib/game/monk-evangelism.ts
+++ b/lib/game/monk-evangelism.ts
@@ -71,7 +71,7 @@ export function stepMonkEvangelism(s: EvangelizingMonk, map: GameMap, requested:
     }
     if (!assigned) { stopEvangelizing(s); return false }
   }
-  s.stamina = Math.max(0, s.stamina - dt * 0.25)
+  s.stamina = Math.max(0, s.stamina - dt * 0.125)
   s.activity = walkWorker(s, s.route, speed, dt) ? "preaching" : "toEvangelize"
   return true
 }

--- a/lib/game/monk-work.ts
+++ b/lib/game/monk-work.ts
@@ -12,7 +12,7 @@ export function createMonkNeeds(index: number): MonkNeeds { return { workSlot: i
 /** Finish assigned construction before resting; tired monks cannot take new work. */
 export function stepMonkWork(s: MonkRoutine & MonkNeeds, map: GameMap, speed: number, dt: number): boolean {
   if (dt <= 0) return !!s.buildingTask
-  if (s.activity !== "sleeping") s.stamina = Math.max(0, s.stamina - dt * (s.activity === "building" ? 0.8 : 0.25))
+  if (s.activity !== "sleeping") s.stamina = Math.max(0, s.stamina - dt * (s.activity === "building" ? 0.4 : 0.125))
   s.jobSearch = Math.max(0, s.jobSearch - dt)
   if (s.stamina <= MONK_TIRED_AT && !s.buildingTask && s.jobSearch === 0) {
     const workSlot = s.workSlot

--- a/lib/game/sim.test.ts
+++ b/lib/game/sim.test.ts
@@ -216,16 +216,16 @@ describe("stepSim", () => {
     const s = sim.travelers.get(0)!
     const hour = GAME_DAY_SECONDS / 24
     stepSim(sim, travelers, map, 1, hour)
-    expect([s.hunger, s.thirst, s.stamina]).toEqual([77, 74, 77.9])
+    expect([s.hunger, s.thirst, s.stamina]).toEqual([78.5, 74, 78.95])
 
     Object.assign(sim.balance.rules, { hungerDecay: 2, thirstDecay: 6, staminaDecay: 0 })
     stepSim(sim, travelers, map, 1, hour)
-    expect([s.hunger, s.thirst, s.stamina]).toEqual([75, 68, 77.9])
+    expect([s.hunger, s.thirst, s.stamina]).toEqual([76.5, 68, 78.95])
 
     s.activity = "camping"
     s.stamina = 0
     stepSim(sim, travelers, map, 1, hour)
-    expect([s.hunger, s.thirst, s.stamina]).toEqual([74, 65, 60])
+    expect([s.hunger, s.thirst, s.stamina]).toEqual([75.5, 65, 60])
   })
 
   it("keeps food and water supplied longer over an active day", () => {


### PR DESCRIPTION
Halves default hunger and stamina drain for travelers and settlers, and halves monks’ stamina drain during ordinary work, construction, and evangelism.
Updates tuning descriptions and stamina increments, migrates older presets using previous defaults while preserving custom tuning, and updates simulation and preset tests.
Validation: typecheck passed and 227 of 228 targeted tests passed; the hospitality test “earns more actual visits on generated worlds as the shrine becomes known” also fails with the original balance rates (9 visits against a strict <9 assertion).
