### PR TITLE
Open the altar when selecting the relic

### DIFF
--- a/components/building-lab/building-model.tsx
+++ b/components/building-lab/building-model.tsx
@@ -75,7 +75,7 @@ export function batchDetails(parts: BuildingPart[]): BuildingPart[] {
 }
 
 /** Game buildings keep their authored surfaces in two color/ID draws. */
-function MergedParts({ parts, idColor, onClick, terrainFloors, surfaceMaterial, batchable }: { batchable: boolean; parts: BuildingPart[]; idColor?: THREE.Color; onClick?: (event: ThreeEvent<MouseEvent>) => void; terrainFloors: boolean; surfaceMaterial?: THREE.MeshLambertMaterial }) {
+function MergedParts({ parts, idColor, onClick, terrainFloors, surfaceMaterial, batchable, dynamic }: { batchable: boolean; dynamic: boolean; parts: BuildingPart[]; idColor?: THREE.Color; onClick?: (event: ThreeEvent<MouseEvent>) => void; terrainFloors: boolean; surfaceMaterial?: THREE.MeshLambertMaterial }) {
   const levels = useMemo(() => buildingGeometryLevels(parts.filter(p => !p.surface)), [parts])
   const body = useRef<THREE.Mesh>(null), ids = useRef<THREE.Mesh>(null)
   const batches = useBuildingBatches()
@@ -89,7 +89,7 @@ function MergedParts({ parts, idColor, onClick, terrainFloors, surfaceMaterial, 
     if (body.current) body.current.geometry = geometry
     if (ids.current) ids.current.geometry = geometry
   })
-  return <StaticBlock>
+  return <StaticBlock enabled={!dynamic}>
     <mesh ref={body} name="building-surfaces" geometry={levels[0]} onClick={onClick}>
       {material ? <primitive object={material} attach="material" /> : <meshLambertMaterial vertexColors side={THREE.DoubleSide} />}
     </mesh>
@@ -109,7 +109,9 @@ export function BuildingModel({ recipe, cutaway = false, idColor, onClick, ink =
 }
 
 /** Ghosts retain every surface, with frame lines only on structural parts. */
-export function StructureModel({ parts, idColor, ghostColor, ink = true, cutaway = false, onClick, terrainFloors = false, surfaceMaterial }: {
+export function StructureModel({ parts, idColor, ghostColor, ink = true, cutaway = false, onClick, terrainFloors = false, surfaceMaterial, dynamic = false }: {
+  /** Moving furnishings must keep their world transforms live. */
+  dynamic?: boolean
   parts: BuildingPart[]; onClick?: (event: ThreeEvent<MouseEvent>) => void; idColor?: THREE.Color; ghostColor?: string; ink?: boolean; cutaway?: boolean; terrainFloors?: boolean; surfaceMaterial?: THREE.MeshLambertMaterial
 }) {
   const rendered = useMemo(() => batchDetails(parts), [parts])
@@ -131,6 +133,6 @@ export function StructureModel({ parts, idColor, ghostColor, ink = true, cutaway
   })
   const visible = useMemo(() => visibleStructureParts(rendered, cutaway && !distant, direction), [rendered, cutaway, distant, direction])
   return <group ref={root} userData={{ cutaway: cutaway && !distant }}>{!ink && !ghostColor
-    ? <MergedParts batchable={!cutaway} parts={visible} idColor={idColor} onClick={onClick} terrainFloors={terrainFloors} surfaceMaterial={surfaceMaterial} />
+    ? <MergedParts batchable={!cutaway && !dynamic} dynamic={dynamic} parts={visible} idColor={idColor} onClick={onClick} terrainFloors={terrainFloors} surfaceMaterial={surfaceMaterial} />
     : visible.map((part) => <Part key={part.name} part={part} terrainFloors={terrainFloors} idColor={idColor} ghostColor={ghostColor} onClick={onClick} ink={ink} />)}</group>
 }

--- a/components/game/monks.tsx
+++ b/components/game/monks.tsx
@@ -333,9 +333,14 @@ export function Monks({ map, monks, relic, flying = false, characterScale = 1 }:
         const id = new THREE.Color(...encodeObjectId(residentObjectId(index)))
         const selected = isSelected(selection, { kind: "monk", id: monk.id })
         const select = (event: { delta: number; stopPropagation: () => void; intersections?: Array<{ object: THREE.Object3D }> }) => {
-          // The generous body hit target overlaps the raised hands. Give the
-          // visible reliquary priority when the ray also hits its actual mesh.
-          const relicHit = event.intersections?.some(hit => hit.object.name === "relic")
+          // Generous body targets overlap both the carried relic and the altar
+          // in front of its keeper. Their actual surfaces take click priority.
+          const relicHit = event.intersections?.some(hit => {
+            for (let object: THREE.Object3D | null = hit.object; object; object = object.parent) {
+              if (object.name === "relic" || object.name === "relic-altar") return true
+            }
+            return false
+          })
           selectElement(relicHit ? { kind: "relic" } : { kind: "monk", id: monk.id }, event)
         }
         const equipped = index !== 0 && (flying || airborneIds.has(monk.id))

--- a/components/game/shrine.tsx
+++ b/components/game/shrine.tsx
@@ -32,20 +32,21 @@ export function Shrine({ map, relic, showInteriors = false }: { map: GameMap; re
   const relicGroup = useRef<THREE.Group>(null)
   const veilGroup = useRef<THREE.Group>(null)
   const lights = useRef<THREE.Group>(null)
+  const relicSelected = useCameraStore(s => isSelected(s.selection, { kind: "relic" }))
+  const buildingSelected = useCameraStore(s => isSelected(s.selection, { kind: "building", id: map.site?.hovelId ?? "" }))
   useFrame(({ scene }) => {
     const near = sceneryDetail(scene) === 0
     if (lights.current) lights.current.visible = near
     const sim = simRegistry.current
     const available = !processionRegistry.current || !relicIsCarried(processionRegistry.current)
-    const showing = available && sim && sim.world.road === map.road && sim.shrineKeeperReady
-      && [...sim.travelers.values()].some(s => s.activity === "visiting" && s.shrineSeat?.startsWith("queue-"))
-    if (relicGroup.current) relicGroup.current.visible = near && !!showing
+    const showing = relicSelected || (available && sim && sim.world.road === map.road && sim.shrineKeeperReady
+      && [...sim.travelers.values()].some(s => s.activity === "visiting" && s.shrineSeat?.startsWith("queue-")))
+    if (relicGroup.current) relicGroup.current.visible = near && available && !!showing
     if (veilGroup.current) {
       veilGroup.current.scale.y = showing ? .16 : 1
       veilGroup.current.position.y = RELIC_TABLE_TOP * (1 - veilGroup.current.scale.y)
     }
   })
-  const selected = useCameraStore(s => isSelected(s.selection, { kind: "relic" }) || isSelected(s.selection, { kind: "building", id: map.site?.hovelId ?? "" }))
   const hovelIndex = map.buildings.findIndex((b) => b.id === map.site?.hovelId)
   const hovel = hovelIndex >= 0 ? map.buildings[hovelIndex] : null
 
@@ -53,9 +54,12 @@ export function Shrine({ map, relic, showInteriors = false }: { map: GameMap; re
     if (!hovel || !map.site) return null
     const shape = shrineLayout(hovel, map.site.door)
     const parts = shrineStructureParts(shape.width, shape.depth)
+    const isAltar = (name: string) => name === "relic-table" || name === "relic-shelf"
+      || name === "altar-linen-top" || name.startsWith("table-trestle-")
     return {
       ...shape,
-      parts: parts.filter(p => !p.name.startsWith("relic-veil-")),
+      parts: parts.filter(p => !p.name.startsWith("relic-veil-") && !isAltar(p.name)),
+      altar: parts.filter(p => isAltar(p.name)),
       veil: parts.filter(p => p.name.startsWith("relic-veil-")),
       centreX: tileToWorldX(map, hovel.x) + (hovel.w - 1) / 2,
       centreZ: tileToWorldZ(map, hovel.z) + (hovel.d - 1) / 2,
@@ -76,8 +80,11 @@ export function Shrine({ map, relic, showInteriors = false }: { map: GameMap; re
   return (
     <group position={[layout.centreX, layout.baseY, layout.centreZ]}>
       <group rotation={[0, layout.rotation, 0]} onClick={event => selectElement({ kind: "building", id: hovel.id }, event)}>
-        <StructureModel terrainFloors parts={layout.parts} cutaway={showInteriors || selected || unitInterior === hovel.id} idColor={shrineId} ink={false} />
-        <group ref={veilGroup}><StructureModel parts={layout.veil} cutaway idColor={shrineId} ink={false} /></group>
+        <StructureModel terrainFloors parts={layout.parts} cutaway={showInteriors || relicSelected || buildingSelected || unitInterior === hovel.id} idColor={shrineId} ink={false} />
+        <group name="relic-altar">
+          <StructureModel parts={layout.altar} cutaway idColor={relicId} onClick={select} ink={false} />
+          <group ref={veilGroup}><StructureModel parts={layout.veil} cutaway dynamic idColor={relicId} onClick={select} ink={false} /></group>
+        </group>
         <group ref={lights} name="shrine-lights">{[-1,1].map(side => <pointLight key={side} position={[side*.73,.8,layout.altarZ+.08]} color="#ffd184" intensity={.18} distance={1.8} decay={2} />)}</group>
       </group>
       <group ref={relicGroup} position={[layout.offset.x,0,layout.offset.z]}><RelicDisplay groundGlow={false} color={relic.color} idColor={relicId} onClick={select} /></group>


### PR DESCRIPTION
Clicking the altar now selects the relic, opens its panel, and lifts the veil while selected; clicking again clears the selection.
The altar shares the relic outline and takes click priority over overlapping monk hit targets.
Moving structure parts can opt out of static transforms and batching so the veil visibly opens, while procession availability and visitor reveals remain intact.

Validated with TypeScript, 86 passing tests across selection, relics, processions, shrine geometry, and static blocks, plus an in-game browser check of opening and deselection.
