### PR TITLE
Fix road cutbacks and space seeded taverns by a 192-tile radius

### DIFF
--- a/lib/game/map/generate-map.test.ts
+++ b/lib/game/map/generate-map.test.ts
@@ -705,6 +705,22 @@ describe("generateMap", () => {
     )
   }, SWEEP_TIMEOUT)
 
+  it("continues east after clearing the grove in seed 1377249436", () => {
+    const map = generateMap({ seed: 1377249436, width: 512, depth: 512 })
+    const road = map.road!
+    const flank = road.findIndex(p => p.x >= 124)
+    const glade = road.findIndex(p => p.x >= 200)
+    expect(flank).toBeGreaterThan(0)
+    expect(glade).toBeGreaterThan(flank)
+    // The old forced forest exit dragged the road back to x=67 after it had
+    // already rounded the eastern flank, then east again across open land.
+    expect(Math.min(...road.slice(flank, glade).map(p => p.x))).toBeGreaterThanOrEqual(124)
+    expect(new Set(road.map(p => `${p.x},${p.z}`)).size).toBe(road.length)
+    for (let i = 1; i < road.length; i++) {
+      expect(Math.abs(road[i].x - road[i - 1].x) + Math.abs(road[i].z - road[i - 1].z)).toBe(1)
+    }
+  }, SWEEP_TIMEOUT)
+
   it("keeps the road at a sane length — it seeks open ground, it doesn't wander the map for it", () => {
     // Glade-seeking plus a detour around each dark forest can add up, but the
     // road still reads as a way across the map, not a maze.

--- a/lib/game/map/generate-map.ts
+++ b/lib/game/map/generate-map.ts
@@ -177,12 +177,6 @@ const DARK_EDGE_KEEP_Z = 8
 
 /** A track is only worth cutting if it's at most this fraction of the detour. */
 const TRACK_MAX_RATIO = 0.85
-/** The direct route is "in the dark" where the dark shade is at least this. */
-const TRACK_DARK_SHADE = 0.5
-/** Dark stretches of the direct route closer than this merge into one crossing. */
-const TRACK_MERGE_GAP = 8
-/** A track's ends sit this many tiles beyond the dark shade on the direct route. */
-const TRACK_MARGIN = 4
 
 // --- Founding site -----------------------------------------------------------
 
@@ -633,52 +627,12 @@ export function generateMap(options: GenerateMapOptions): GameMap {
     if (tiles[i] === "darkwood") walkable[i] = WATER_KIND_LAKE
   }
 
-  // --- Where the direct route crosses the dark forest ------------------------
-  // The provisional road is the direct route; where it runs through the dark
-  // shade is a crossing. Each crossing gets a pair of waypoints on the direct
-  // route just outside the shade (on dry land, so every road segment can be
-  // routed water-aware). The real road is routed *through* those waypoints,
-  // so after skirting the old growth it must come back to the direct line —
-  // a genuine detour, not a road that merely drifted past one end.
-  const crossings: Array<[number, number]> = []
-  for (let p = 0; p < provisional.length; p++) {
-    if (darkShade[provisional[p]] < TRACK_DARK_SHADE) continue
-    const last = crossings[crossings.length - 1]
-    if (last && p - last[1] <= TRACK_MERGE_GAP) last[1] = p
-    else crossings.push([p, p])
-  }
-  const spans: Array<[number, number]> = []
-  for (const [pa, pb] of crossings) {
-    let a = pa - TRACK_MARGIN
-    let b = pb + TRACK_MARGIN
-    while (a > 0 && kind[provisional[a]] !== 0) a--
-    while (b < provisional.length - 1 && kind[provisional[b]] !== 0) b++
-    const prev = spans[spans.length - 1]
-    if (a <= 0 || b >= provisional.length - 1 || (prev && a <= prev[1])) continue
-    spans.push([a, b])
-  }
-
   // --- Road: west edge to east edge ------------------------------------------
-  // Routed over land with lake water impassable and rivers crossable only via
-  // straight bridges, so forest in the way gets carved but water is
-  // respected. The fallbacks keep the road guarantee even on hostile seeds.
-  // The route comes back as an ordered walk, west edge to east edge; keep
-  // that order on the map (`road`) so travelers know which way along is.
-  const stops = [provisional[0]]
-  for (const [a, b] of spans) stops.push(provisional[a], provisional[b])
-  stops.push(provisional[provisional.length - 1])
-  const roadRoute: number[] = []
-  for (let st = 0; st < stops.length - 1; st++) {
-    const segment = straightenRoad({ width, depth, tiles, buildings: [], elevation }, routeRoad(
-      { x: stops[st] % width, z: Math.floor(stops[st] / width) },
-      { x: stops[st + 1] % width, z: Math.floor(stops[st + 1] / width) },
-      roadCost,
-    ))
-    // Reserve these crossings before the next segment chooses a bridge.
-    for (const i of segment) if (kind[i]) passKind[i] = 0
-    // Consecutive segments share their junction tile; keep it once.
-    for (let k = st === 0 ? 0 : 1; k < segment.length; k++) roadRoute.push(segment[k])
-  }
+  // Route the whole road together. Pinning it to the provisional forest exits
+  // can force a return around a grove after the road has already cleared it,
+  // followed by a cutback toward the destination through the same open glade.
+  const roadRoute = straightenRoad({ width, depth, tiles, buildings: [], elevation },
+    routeRoad(start, goal, roadCost))
 
   const roadTiles: number[] = []
   const road: TilePos[] = []
@@ -733,7 +687,11 @@ export function generateMap(options: GenerateMapOptions): GameMap {
     return false
   }
   const shortcuts: Shortcut[] = []
-  for (const [a, b] of spans) {
+  // Attach dangerous alternatives where the provisional line actually meets
+  // the finished road on dry land; never create a turn off a bridge deck.
+  const joins = provisional.flatMap((tile, index) => roadIndex[tile] >= 0 && kind[tile] === 0 ? [index] : [])
+  for (let j = 1; j < joins.length; j++) {
+    const a = joins[j - 1], b = joins[j]
     const entry = roadIndex[provisional[a]]
     const exit = roadIndex[provisional[b]]
     if (entry < 0 || exit <= entry) continue

--- a/lib/game/map/roadside-towns.test.ts
+++ b/lib/game/map/roadside-towns.test.ts
@@ -4,9 +4,8 @@ import { describe, expect, it } from "vitest"
 import { addRoadsideTowns, TOWN_SPACING, TOWN_CHAPEL_CLEARANCE, TOWN_APPROACH_CLEARANCE } from "./roadside-towns"
 import { generateMap } from "./generate-map"
 import { type GameMap, tileAt } from "./types"
-import { TILES_PER_DAY } from "../calendar"
 import { tavernVisitPlan, servingHouses } from "../tavern"
-import { buildingApproaches } from "../building-rotation"
+import { buildingApproaches, buildingEntry } from "../building-rotation"
 import { settlementRoute } from "../settlement-route"
 import { jobBuildings, settlementRenown } from "../settlement"
 import { enclaveHousing } from "../housing"
@@ -21,21 +20,56 @@ function roadMap(): GameMap {
 }
 
 describe("independent roadside towns", () => {
-  it("spaces complete communities just under a day's walk apart", () => {
+  it("spaces complete communities by a 192-tile radius", () => {
     const map = roadMap()
     addRoadsideTowns(map)
-    expect(map.towns).toHaveLength(3)
+    expect(map.towns).toHaveLength(2)
     for (const [i, town] of map.towns!.entries()) {
       const buildings = map.buildings.filter(b => b.townId === town.id)
       expect(buildings.map(b => b.buildType)).toEqual(["tavern", "house"])
       expect(buildings.every(b => b.owner === "independent" && !b.construction)).toBe(true)
       if (i) {
         expect(town.junction - map.towns![i - 1].junction).toBe(TOWN_SPACING)
-        expect(town.junction - map.towns![i - 1].junction).toBeLessThan(TILES_PER_DAY)
+        expect(TOWN_SPACING).toBe(192)
       }
     }
     expect(map.road!.every(p => tileAt(map, p.x, p.z) === "path")).toBe(true)
     expect(servingHouses(map, () => false)).toHaveLength(0)
+  })
+
+  it("keeps looping roads outside every earlier tavern's radius", () => {
+    const width = 440, depth = 80
+    // Three parallel passes: the third comes back close to the first town,
+    // despite being far from the most recently placed town along the road.
+    const road = [
+      ...Array.from({ length: 421 }, (_, x) => ({ x: x + 10, z: 20 })),
+      ...Array.from({ length: 20 }, (_, z) => ({ x: 430, z: z + 21 })),
+      ...Array.from({ length: 421 }, (_, x) => ({ x: 429 - x, z: 40 })),
+      ...Array.from({ length: 20 }, (_, z) => ({ x: 9, z: z + 41 })),
+      ...Array.from({ length: 421 }, (_, x) => ({ x: x + 10, z: 60 })),
+    ]
+    const map: GameMap = { width, depth, tiles: Array(width * depth).fill("grass"), buildings: [], road }
+    for (const p of road) map.tiles[p.z * width + p.x] = "path"
+    addRoadsideTowns(map)
+    expect(map.towns).toHaveLength(2)
+    const entrances = map.towns!.map(t => buildingEntry(map.buildings.find(b => b.id === t.tavernId)!))
+    for (let i = 0; i < entrances.length; i++) for (let j = 0; j < i; j++) {
+      expect(Math.hypot(entrances[i].x - entrances[j].x, entrances[i].z - entrances[j].z)).toBeGreaterThanOrEqual(192)
+    }
+  })
+
+  it("continues beyond an unsuitable site without shrinking the radius", () => {
+    const map = roadMap()
+    // The nominal second site at x=288 is flooded; the next dry town must
+    // remain outside the first tavern's circle while finding accessible land.
+    for (let z = 0; z < map.depth; z++) for (let x = 280; x < 310; x++) {
+      if (z !== 15) map.tiles[z * map.width + x] = "water"
+    }
+    addRoadsideTowns(map)
+    expect(map.towns).toHaveLength(2)
+    expect(map.road![map.towns![1].junction].x).toBeGreaterThanOrEqual(310)
+    const [a, b] = map.towns!.map(t => buildingEntry(map.buildings.find(b => b.id === t.tavernId)!))
+    expect(Math.hypot(a.x - b.x, a.z - b.z)).toBeGreaterThanOrEqual(192)
   })
 
   it("contributes no jobs, housing, renown or building influence", () => {
@@ -52,6 +86,10 @@ describe("independent roadside towns", () => {
   it.each([1, 7919, 42, 99, 12345])("generates reachable taverns on seeded terrain (%s)", seed => {
     const map = generateMap({ seed })
     expect(map.towns!.length).toBeGreaterThan(0)
+    const entrances = map.towns!.map(t => buildingEntry(map.buildings.find(b => b.id === t.tavernId)!))
+    for (let i = 0; i < entrances.length; i++) for (let j = 0; j < i; j++) {
+      expect(Math.hypot(entrances[i].x - entrances[j].x, entrances[i].z - entrances[j].z)).toBeGreaterThanOrEqual(192)
+    }
     for (const town of map.towns!) {
       const road = map.road![town.junction]
       const tavern = map.buildings.find(b => b.id === town.tavernId)!

--- a/lib/game/map/roadside-towns.ts
+++ b/lib/game/map/roadside-towns.ts
@@ -1,17 +1,13 @@
 import { settlementRoute } from "../settlement-route"
 import { BUILD_CATALOG } from "../balance"
 import { buildingApproaches, buildingEntry, rotatedFootprint, rotateBuildingPoint, type BuildingRotation } from "../building-rotation"
-import { TILES_PER_DAY } from "../calendar"
 import { levelBuildingGround } from "./elevation"
 import { tileAt, type BuildingDef, type GameMap, type RoadsideTown, type TilePos } from "./types"
 
-export const TOWN_SPACING = TILES_PER_DAY - 16
+/** Minimum straight-line distance between seeded tavern entrances, in tiles. */
+export const TOWN_SPACING = 192
 export const TOWN_CHAPEL_CLEARANCE = 48
 export const TOWN_APPROACH_CLEARANCE = 20
-const SEARCH_RADIUS = 8
-// Prefer a slightly shorter leg when the ideal stop falls on water or steep land.
-const SEARCH_OFFSETS = [0, ...Array.from({ length: SEARCH_RADIUS }, (_, i) => [i + 1, -i - 1]).flat(),
-  ...Array.from({ length: 24 }, (_, i) => -SEARCH_RADIUS - i - 1)]
 const NAMES = ["Alderford", "Hazelwick", "Birch End", "Willowbank", "Oakstead", "Ashbrook", "Elm Hollow", "Reedham"]
 
 /** The house sits beside the tavern, with parallel roof ridges and aligned fronts. */
@@ -19,6 +15,13 @@ function townPlan(map: GameMap, junction: number, rotation: BuildingRotation, or
   const road = map.road![junction]
   const outward = rotateBuildingPoint(0, -1, rotation)
   const entry = { x: road.x + outward.x * 2, z: road.z + outward.z * 2 }
+  // A winding road may pass close to an earlier town long after leaving it.
+  // Check every existing tavern in map space, independent of travel duration.
+  if (map.towns?.some(town => {
+    const tavern = map.buildings.find(b => b.id === town.tavernId)!
+    const other = buildingEntry(tavern)
+    return Math.hypot(entry.x - other.x, entry.z - other.z) < TOWN_SPACING
+  })) return null
   const id = `roadside-town-${ordinal}`
   const name = NAMES[((((map.seed ?? 0) >>> 0) % NAMES.length) + ordinal) % NAMES.length]
   const buildings = (["tavern", "house"] as const).map((buildType, index): BuildingDef => {
@@ -65,48 +68,38 @@ function townPlan(map: GameMap, junction: number, rotation: BuildingRotation, or
   return { town, buildings, patch }
 }
 
-/** Mutates only a newly generated map. Distances follow road steps, including bends. */
+/** Mutates only a newly generated map. Each tavern excludes a 192-tile radius. */
 export function addRoadsideTowns(map: GameMap): void {
   map.towns = []
   const road = map.road ?? []
-  let target = Math.min(TOWN_SPACING / 2, Math.floor((road.length - 1) / 2))
-  while (target < road.length - 12) {
-    let placed = false
-    for (const offset of SEARCH_OFFSETS) {
-      if (placed) break
-      const junction = target + offset
-      if (junction < 12 || junction >= road.length - 12) continue
-      for (const rotation of [0, 1, 2, 3] as const) {
-        const plan = townPlan(map, junction, rotation, map.towns.length)
-        if (!plan) continue
-        // Plan on a private copy so a blocked entrance cannot leave half a town behind.
-        const candidate = { ...map, tiles: [...map.tiles], buildings: [...map.buildings, ...plan.buildings] }
-        for (const p of plan.patch) {
-          const i = p.z * map.width + p.x
-          if (candidate.tiles[i] !== "path" && candidate.tiles[i] !== "track") candidate.tiles[i] = "grass"
-        }
-        for (const b of plan.buildings) candidate.elevation = levelBuildingGround(candidate, b)
-        let accessible = true
-        for (const b of plan.buildings) for (const entrance of buildingApproaches(candidate, b)) {
-          const route = settlementRoute(candidate, candidate.buildings, road[junction], entrance)
-          if (!route) { accessible = false; break }
-          for (const p of route) {
-            const i = p.z * map.width + p.x
-            if (candidate.tiles[i] !== "path" && candidate.tiles[i] !== "bridge") candidate.tiles[i] = "track"
-          }
-        }
-        if (!accessible) continue
-        // The generator also retains the original tile array while finishing the world.
-        for (let i = 0; i < map.tiles.length; i++) map.tiles[i] = candidate.tiles[i]
-        map.buildings.push(...plan.buildings)
-        map.elevation = candidate.elevation
-        map.towns.push(plan.town)
-        target = junction + TOWN_SPACING
-        placed = true
-        break
+  const first = Math.max(12, Math.min(TOWN_SPACING / 2, Math.floor((road.length - 1) / 2)))
+  for (let junction = first; junction < road.length - 12; junction++) {
+    for (const rotation of [0, 1, 2, 3] as const) {
+      const plan = townPlan(map, junction, rotation, map.towns.length)
+      if (!plan) continue
+      // Plan on a private copy so a blocked entrance cannot leave half a town behind.
+      const candidate = { ...map, tiles: [...map.tiles], buildings: [...map.buildings, ...plan.buildings] }
+      for (const p of plan.patch) {
+        const i = p.z * map.width + p.x
+        if (candidate.tiles[i] !== "path" && candidate.tiles[i] !== "track") candidate.tiles[i] = "grass"
       }
+      for (const b of plan.buildings) candidate.elevation = levelBuildingGround(candidate, b)
+      let accessible = true
+      for (const b of plan.buildings) for (const entrance of buildingApproaches(candidate, b)) {
+        const route = settlementRoute(candidate, candidate.buildings, road[junction], entrance)
+        if (!route) { accessible = false; break }
+        for (const p of route) {
+          const i = p.z * map.width + p.x
+          if (candidate.tiles[i] !== "path" && candidate.tiles[i] !== "bridge") candidate.tiles[i] = "track"
+        }
+      }
+      if (!accessible) continue
+      // The generator also retains the original tile array while finishing the world.
+      for (let i = 0; i < map.tiles.length; i++) map.tiles[i] = candidate.tiles[i]
+      map.buildings.push(...plan.buildings)
+      map.elevation = candidate.elevation
+      map.towns.push(plan.town)
+      break
     }
-    // Unsuitable terrain advances the search; never place a town in water or on a cliff.
-    if (!placed) target += SEARCH_RADIUS * 2 + 1
   }
 }


### PR DESCRIPTION
Route the main road end to end so it continues around dark forest without returning to forced exit waypoints, fixing the cutback in seed 1377249436.
Attach forest shortcuts at actual dry-land intersections with the finished road, and space seeded taverns by a 192-tile straight-line radius from every existing tavern entrance.
Add regression coverage for the reported seed, looping roads, unsuitable town sites, and tavern separation.

Validation: all 208 map tests and TypeScript checking passed; the corrected seed was also checked in the browser without runtime errors.
