### PR TITLE
Keep deployed vendor stalls anchored during map rotation

### DIFF
--- a/components/game/transport-sprite.tsx
+++ b/components/game/transport-sprite.tsx
@@ -29,11 +29,11 @@ import { KNIGHT } from "@/lib/game/knight/design"
 import manifest from "@/public/textures/transport/v25/manifest.json"
 import type { FigureClickHandler } from "./traveler-figure"
 
-export function TransportSprite({ knight, map: terrain, kind, coat, variant = 0, horseVariant = "common", cargo = "produce", puller = "hand", awning = false, characterScale = 1,
+export function TransportSprite({ knight, map: terrain, kind, coat, variant = 0, horseVariant = "common", cargo = "produce", puller = "hand", awning = false, worldStall = false, characterScale = 1,
   selected = false, outlineColor, onClick, position = [0, 0, 0] }: {
   knight?: "mounted" | "saddled"
   map?: GameMap; kind: "cart" | "merchant" | Animal; coat?: string; variant?: number; horseVariant?: HorseVariant; cargo?: Cargo; puller?: Puller; awning?: boolean; characterScale?: number
-  selected?: boolean; outlineColor?: [number, number, number]; onClick?: FigureClickHandler; position?: [number, number, number]
+  selected?: boolean; outlineColor?: [number, number, number]; onClick?: FigureClickHandler; position?: [number, number, number]; worldStall?: boolean
 }) {
   const animal = kind === "donkey" || kind === "horse"
   const edits = useAnimalRigStore(state => state.designs[kind])
@@ -97,6 +97,8 @@ export function TransportSprite({ knight, map: terrain, kind, coat, variant = 0,
     const heading = typeof data.heading === "number" ? data.heading : (parent.getWorldDirection(vectors.facing), Math.atan2(vectors.facing.x, vectors.facing.z))
     const yaw = Math.atan2(camera.matrixWorld.elements[8], camera.matrixWorld.elements[10]), row = spriteRow(heading, yaw, kind === "cart" ? CART.directions : 8)
     const shop = data.activity === undefined ? awning : ["vending", "openingShop", "packingShop"].includes(data.activity)
+    group.visible = !(worldStall && kind === "cart" && shop)
+    if (!group.visible) return
     const moving = data.moving === true, distance = data.playbackRate === 0 ? 0 : data.distance ?? 0
     const stride = animal ? animalStride(kind, characterScale, horseVariant) : manifest.wheelCycleRadians * TRANSPORT.wheelRadius * RIG_TO_WORLD * characterScale
     if (moving) phase.current = transportPhase(phase.current, Math.abs(distance), stride, data.reversing === true)

--- a/components/game/traveler-figure.tsx
+++ b/components/game/traveler-figure.tsx
@@ -19,6 +19,7 @@ import { CharacterSprite } from "./character-sprite"
 import { CartReins } from "./cart-reins"
 import { KnightFigure } from "./knight-figure"
 import { TransportSprite } from "./transport-sprite"
+import { VendorStall } from "./vendor-stall"
 import type { TravelerAppearance } from "@/lib/game/base-person/population"
 import { pullingVisual } from "@/lib/game/transport/visual"
 import { cartOffset, type Cargo, type Puller, type HorseVariant } from "@/lib/game/transport/assets"
@@ -184,7 +185,9 @@ export function TravelerFigure({ map, age, job, type, onClick, idColor, selected
     </group>}
     {vendor && <>
       <group ref={cart}><TransportSprite map={map} kind="cart" variant={variant} cargo={cargo} puller={puller} awning={awning} characterScale={characterScale}
-        selected={selected} outlineColor={color} onClick={onClick} /></group>
+        worldStall selected={selected} outlineColor={color} onClick={onClick} /></group>
+      <VendorStall cart={cart} cargo={cargo} puller={puller} awning={awning} characterScale={characterScale}
+        selected={selected} outlineColor={color} onClick={onClick} />
       <group ref={setup} visible={false}><TransportSprite map={map} kind="merchant" variant={variant} characterScale={characterScale * (appearance?.scale ?? 1)} selected={selected} outlineColor={color} onClick={onClick} /></group>
     </>}
     {animal && <group ref={beast}><TransportSprite map={map} kind={puller as "donkey" | "horse"} coat={coat} horseVariant={horseVariant} characterScale={characterScale} selected={selected} outlineColor={color} onClick={onClick} /></group>}

--- a/components/game/vendor-stall.tsx
+++ b/components/game/vendor-stall.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import { useEffect, useMemo, useRef, type RefObject } from "react"
+import { createPortal, useFrame, useThree } from "@react-three/fiber"
+import * as THREE from "three"
+import { isWorldVisible } from "@/lib/game/render/visibility"
+import { OUTLINE_ID_LAYER_MASK, SELECTED_CHARACTER_LAYER } from "@/lib/game/render/outline"
+import { RIG_TO_WORLD, type Cargo, type Puller } from "@/lib/game/transport/assets"
+import { acquireStallGeometry } from "@/lib/game/transport/stall-geometry"
+import type { FigureClickHandler } from "./traveler-figure"
+
+/** The deployed cart and its ground display belong to the world, while the
+ * keeper remains a sprite. Use the existing scenery pass and shared selection ID. */
+export function VendorStall({ cart, cargo, puller, characterScale, awning, selected, outlineColor, onClick }: {
+  cart: RefObject<THREE.Group | null>; cargo: Cargo; puller: Puller; characterScale: number
+  awning: boolean; selected: boolean; outlineColor?: [number, number, number]; onClick?: FigureClickHandler
+}) {
+  const scene = useThree(state => state.scene)
+  const root = useRef<THREE.Group>(null), body = useRef<THREE.Mesh>(null), ids = useRef<THREE.Mesh>(null)
+  const frames = useRef<ReturnType<typeof acquireStallGeometry> | null>(null)
+  const materials = useMemo(() => [
+    new THREE.MeshLambertMaterial({ vertexColors: true, side: THREE.DoubleSide }),
+    new THREE.MeshBasicMaterial({ color: new THREE.Color(...outlineColor ?? [0, 0, 0]), toneMapped: false, side: THREE.DoubleSide }),
+  ], [outlineColor?.[0], outlineColor?.[1], outlineColor?.[2]])
+  useEffect(() => () => materials.forEach(material => material.dispose()), [materials])
+  useEffect(() => () => { frames.current?.dispose(); frames.current = null }, [cargo, puller])
+  useFrame(() => {
+    const group = root.current, wagon = cart.current
+    if (!group || !body.current || !wagon) return
+    const data = wagon.userData
+    group.visible = isWorldVisible(wagon) && (data.activity === undefined ? awning
+      : ["vending", "openingShop", "packingShop"].includes(data.activity))
+    if (!group.visible) return
+    const geometry = (frames.current ??= acquireStallGeometry(cargo, puller === "hand")).frame(data.shopProgress ?? 1)
+    body.current.geometry = geometry
+    if (ids.current) ids.current.geometry = geometry
+    wagon.getWorldPosition(group.position)
+    group.rotation.y = data.heading ?? 0
+    const unit = RIG_TO_WORLD * characterScale
+    group.scale.set(unit * (data.shopSide ?? 1), unit, unit)
+  })
+  // A scene portal keeps this out of the enclosing PixelCharacters root, so
+  // scenery pixels, ground projection and occlusion follow the map exactly.
+  return createPortal(<group ref={root} visible={false}>
+    <mesh ref={body} name="vendor-stall" onClick={onClick} dispose={null} material={materials[0]}
+      layers-mask={selected ? 1 | (1 << SELECTED_CHARACTER_LAYER) : 1} />
+    {outlineColor && <mesh ref={ids} name="vendor-stall-ids" layers-mask={OUTLINE_ID_LAYER_MASK} dispose={null} material={materials[1]} />}
+  </group>, scene)
+}

--- a/lib/game/transport/rig.ts
+++ b/lib/game/transport/rig.ts
@@ -4,7 +4,7 @@ import { stallLayout, KEEPER_SEAT } from "./stall"
 import { model } from "./geometry"
 export { createAnimalRig } from "./animal-rig"
 
-/** Source geometry is baked, never mounted as game scenery. */
+/** Shared source for transport atlases and merged, world-grounded stalls. */
 export function createCartRig(cargo: Cargo, mode: CartMode, compact = false) {
   const layout = stallLayout(compact || mode === "hand" ? "hand" : "horse")
   const itemCount = compact || mode === "hand" ? 3 : 6

--- a/lib/game/transport/stall-geometry.test.ts
+++ b/lib/game/transport/stall-geometry.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest"
+import * as THREE from "three"
+import { acquireStallGeometry } from "./stall-geometry"
+import { CARGO, RIG_TO_WORLD } from "./assets"
+import { stallLayout, stallPoint } from "./stall"
+
+describe("world-grounded vendor stalls", () => {
+  it.each(CARGO)("retains deployment poses and shares %s geometry between vendors", cargo => {
+    const first = acquireStallGeometry(cargo, false), second = acquireStallGeometry(cargo, false)
+    try {
+      const packed = first.frame(0), open = first.frame(1)
+      expect(open).toBe(second.frame(1))
+      expect(first.frame(0.999)).toBe(open)
+      expect(open).not.toBe(packed)
+      open.computeBoundingBox(); packed.computeBoundingBox()
+      expect(open.boundingBox!.max.y).toBeGreaterThan(packed.boundingBox!.max.y)
+      expect(open.boundingBox!.min.x).toBeLessThan(packed.boundingBox!.min.x)
+      expect(open.getAttribute("color").count).toBe(open.getAttribute("position").count)
+      expect(open.getAttribute("normal").count).toBe(open.getAttribute("position").count)
+      first.dispose()
+      expect(second.frame(1)).toBe(open)
+    } finally { second.dispose() }
+  })
+
+  it.each([true, false])("keeps the display on its map footprint at every heading and side (compact %s)", compact => {
+    const frames = acquireStallGeometry("bread", compact)
+    const material = new THREE.MeshBasicMaterial({ side: THREE.DoubleSide })
+    try {
+      const mesh = new THREE.Mesh(frames.frame(1), material), scale = 1.5, axle = { x: 3.4, z: -1.2 }
+      const display = stallLayout(compact ? "hand" : "horse").display
+      for (const side of [-1, 1]) for (const heading of [0, 0.17, Math.PI / 2, 2.7, Math.PI, -1.3]) {
+        mesh.position.set(axle.x, 0.2, axle.z); mesh.rotation.y = heading
+        mesh.scale.set(side * RIG_TO_WORLD * scale, RIG_TO_WORLD * scale, RIG_TO_WORLD * scale)
+        mesh.updateMatrixWorld(true)
+        const ground = stallPoint(axle, heading, side, scale, display)
+        const hit = new THREE.Raycaster(new THREE.Vector3(ground.x, 5, ground.z), new THREE.Vector3(0, -1, 0)).intersectObject(mesh)
+        expect(hit.length).toBeGreaterThan(0)
+        // A ground display surface remains within its authored height above the map.
+        expect(hit[0].point.y).toBeGreaterThan(0.2)
+        expect(hit[0].point.y).toBeLessThan(0.2 + 0.6 * RIG_TO_WORLD * scale)
+      }
+    } finally { material.dispose(); frames.dispose() }
+  })
+})

--- a/lib/game/transport/stall-geometry.ts
+++ b/lib/game/transport/stall-geometry.ts
@@ -1,0 +1,48 @@
+import * as THREE from "three"
+import { mergeGeometries } from "three/examples/jsm/utils/BufferGeometryUtils.js"
+import { TRANSPORT, type Cargo } from "./assets"
+import { createCartRig } from "./rig"
+
+/** Share the existing deployment frames as world geometry, one draw per stall.
+ * Build each pose only when used; rotating the camera never rebuilds it. */
+const stalls = new Map<string, { users: number; frames: Map<number, THREE.BufferGeometry> }>()
+
+export function acquireStallGeometry(cargo: Cargo, compact: boolean) {
+  const key = `${cargo}:${compact}`
+  let entry = stalls.get(key)
+  if (!entry) { entry = { users: 0, frames: new Map() }; stalls.set(key, entry) }
+  const shared = entry
+  shared.users++
+  return {
+    frame(progress: number) {
+      const frame = Math.round(THREE.MathUtils.clamp(progress, 0, 1) * (TRANSPORT.shopFrames - 1))
+      let geometry = shared.frames.get(frame)
+      if (geometry) return geometry
+      const rig = createCartRig(cargo, "shop", compact), parts: THREE.BufferGeometry[] = []
+      try {
+        rig.pose(0, frame / (TRANSPORT.shopFrames - 1))
+        rig.root.updateMatrixWorld(true)
+        rig.root.traverseVisible(object => {
+          if (!(object instanceof THREE.Mesh)) return
+          const part = object.geometry.clone().applyMatrix4(object.matrixWorld)
+          const color = (object.material as THREE.MeshLambertMaterial).color
+          const colors = new Float32Array(part.getAttribute("position").count * 3)
+          for (let i = 0; i < colors.length; i += 3) color.toArray(colors, i)
+          part.setAttribute("color", new THREE.BufferAttribute(colors, 3))
+          // The cloth has no UVs; all of these surfaces use authored colors.
+          part.deleteAttribute("uv")
+          parts.push(part)
+        })
+        geometry = mergeGeometries(parts)!
+        geometry.computeBoundingSphere()
+        shared.frames.set(frame, geometry)
+        return geometry
+      } finally { parts.forEach(part => part.dispose()); rig.dispose() }
+    },
+    dispose() {
+      if (--shared.users) return
+      for (const geometry of shared.frames.values()) geometry.dispose()
+      stalls.delete(key)
+    },
+  }
+}


### PR DESCRIPTION
Deployed vendor stalls now stay anchored during map rotation by rendering the existing cart, goods, and sign geometry in the scenery pass. Deployment poses are cached and shared between vendors, preserving opening/packing animation, compact carts, mirrored layouts, and selection outlines while travelling carts retain their sprites.

Validated with `npm run typecheck`, 26 targeted transport tests, and Playwright checks covering all three pullers, four viewing angles, animated in-game rotation, selection behind trees, and returning to travel.
