### PR TITLE
Let NPCs drink from nearby streams and lakes

### DIFF
--- a/lib/game/base-person/activity.test.ts
+++ b/lib/game/base-person/activity.test.ts
@@ -13,7 +13,7 @@ describe("simulation sprite poses", () => {
   it.each([
     ["preaching", "preaching"], ["praying", "praying"], ["hoisting", "hoisting"], ["procession", "procession"], ["vigil", "praying"], ["resting", "praying"], ["walking", "idle"], ["flying", "idle"],
     ["begging", "sitting"], ["givingAlms", "idle"], ["camping", "sleeping"], ["idle", "sitting"], ["visiting", "praying"],
-    ["working", "treeFelling"], ["gathering", "woodcutting"], ["vending", "idle"],
+    ["drinking", "gathering"], ["working", "treeFelling"], ["gathering", "woodcutting"], ["vending", "idle"],
   ] as const)("shows %s as %s", (activity, clip) => {
     expect(activityClip(activity, false)).toBe(clip)
   })

--- a/lib/game/base-person/activity.ts
+++ b/lib/game/base-person/activity.ts
@@ -25,6 +25,7 @@ export function activityClip(activity: Activity | MonkActivity | undefined, movi
     // Resident monks rest on open ground, so use their existing kneeling pose.
     case "resting":
     case "vigil": return "praying"
+    case "drinking": return "gathering"
     case "working": return "treeFelling"
     // This simulation state processes fallen timber; the gathering pose is reserved for harvesting.
     case "gathering": return "woodcutting"

--- a/lib/game/natural-water.test.ts
+++ b/lib/game/natural-water.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest"
+import { naturalWaterStop, WATER_DETOUR_LIMIT } from "./natural-water"
+import { parseAsciiMap } from "./map/prototype-map"
+import { TILE_HEIGHT } from "./map/terrain"
+import { tileAt, tileToWorldX, tileToWorldZ, worldToTileX, worldToTileZ, type GameMap } from "./map/types"
+
+const from = (map: GameMap, x = 1, z = 2) => ({ x: tileToWorldX(map, x), y: TILE_HEIGHT, z: tileToWorldZ(map, z) })
+
+describe("reachable drinking banks", () => {
+  it("limits the actual detour, including routing around obstacles", () => {
+    const map = parseAsciiMap(["............", "............", "..........~~", "............", "............"])
+    expect(naturalWaterStop(map, from(map))).toBeNull()
+    const stop = naturalWaterStop(map, from(map, 5))!
+    expect(stop).not.toBeNull()
+    let previous = from(map, 5), distance = 0
+    for (const p of stop.route) { distance += Math.hypot(p.x - previous.x, p.z - previous.z); previous = p }
+    expect(distance).toBeLessThanOrEqual(WATER_DETOUR_LIMIT)
+  })
+
+  it("routes around buildings and woods without entering the water", () => {
+    const map = parseAsciiMap(["........", "........", ".....~~~", "........", "........"])
+    map.tiles[2 * map.width + 3] = "forest"
+    map.buildings.push({ id: "wall", x: 2, z: 2, w: 1, d: 1, label: "Wall", height: 1, color: "", roofColor: "" })
+    const stop = naturalWaterStop(map, from(map))!
+    expect(stop).not.toBeNull()
+    for (const p of stop.route) {
+      const x = worldToTileX(map, p.x), z = worldToTileZ(map, p.z)
+      expect(tileAt(map, x, z)).not.toBe("water")
+      expect(tileAt(map, x, z)).not.toBe("forest")
+      expect(x === 2 && z === 2).toBe(false)
+    }
+    // Water is close in a straight line, but the wall makes the walk too long.
+    map.buildings = [{ ...map.buildings[0], z: 0, d: map.depth }]
+    expect(naturalWaterStop(map, from(map))).toBeNull()
+  })
+
+  it("rejects bridge decks, waterfalls and banks far above the surface", () => {
+    const map = parseAsciiMap(["~~~~~", "~~~~~", "~~~~~", "~~~~~", "~~~~~"])
+    map.tiles[2 * map.width + 1] = "bridge"
+    expect(naturalWaterStop(map, from(map))).toBeNull()
+    map.tiles[2 * map.width + 1] = "grass"
+    expect(naturalWaterStop(map, from(map))).not.toBeNull()
+    map.water = { depth: map.tiles.map(() => 1), flow: {}, surface: map.tiles.map(() => -3) }
+    expect(naturalWaterStop(map, from(map))).toBeNull()
+    map.water.surface = map.tiles.map(() => 0)
+    map.water.motion = map.tiles.map(() => "waterfall")
+    expect(naturalWaterStop(map, from(map))).toBeNull()
+  })
+})

--- a/lib/game/natural-water.ts
+++ b/lib/game/natural-water.ts
@@ -1,0 +1,70 @@
+import { buildingSpatialQuery } from "./building-spatial"
+import { elevationStep } from "./map/elevation"
+import { shorelineCorners, shorelineInset } from "./map/shoreline"
+import { ROUTE_DIRS } from "./map/route"
+import { TERRAIN, TILE_HEIGHT } from "./map/terrain"
+import { walkingSurface } from "./map/walking-surface"
+import { tileAt, tileToWorldX, tileToWorldZ, worldToTileX, worldToTileZ, type GameMap } from "./map/types"
+import type { WanderSpot } from "./monk-wander"
+
+/** Maximum actual walk from the path to a bank, in tiles. */
+export const WATER_DETOUR_LIMIT = 6
+export const WATER_THIRST_THRESHOLD = 20
+export const WATER_DRINK_SECONDS = 3
+
+export interface WaterStop {
+  spot: WanderSpot
+  route: WanderSpot[]
+}
+
+/** A bounded dry-ground search: nearby water across a wall or cliff is no source. */
+export function naturalWaterStop(map: GameMap, from: WanderSpot): WaterStop | null {
+  const start = { x: worldToTileX(map, from.x), z: worldToTileZ(map, from.z) }
+  const nearby = buildingSpatialQuery(map.buildings)
+  const clear = (x: number, z: number) => {
+    const ground = tileAt(map, x, z)
+    return !!ground && TERRAIN[ground].passable && !nearby({ x, z }).some(b =>
+      x >= b.x && x < b.x + b.w && z >= b.z && z < b.z + b.d)
+  }
+  if (!clear(start.x, start.z)) return null
+  const point = (x: number, z: number): WanderSpot => {
+    const wx = tileToWorldX(map, x), wz = tileToWorldZ(map, z)
+    return { x: wx, z: wz, y: walkingSurface(map, wx, wz).height }
+  }
+  const centre = point(start.x, start.z)
+  const alignment = Math.abs(centre.x - from.x) + Math.abs(centre.z - from.z)
+  const nodes = [{ ...start, parent: -1, distance: alignment }]
+  const seen = new Set([start.z * map.width + start.x])
+  for (let head = 0; head < nodes.length; head++) {
+    const node = nodes[head], index = node.z * map.width + node.x
+    // Drink from dry land, never from a bridge deck above the river.
+    if (map.tiles[index] !== "bridge" && node.distance + .3 <= WATER_DETOUR_LIMIT) {
+      for (const [dx, dz] of ROUTE_DIRS) {
+        const x = node.x + dx, z = node.z + dz
+        if (tileAt(map, x, z) !== "water") continue
+        const water = z * map.width + x
+        if (map.water?.motion?.[water] === "waterfall") continue
+        if (shorelineInset(.5 + dx * .3, .5 + dz * .3, shorelineCorners(map, node.x, node.z)) > 0) continue
+        const bank = point(node.x, node.z)
+        const spot = { x: bank.x + dx * .3, z: bank.z + dz * .3, y: bank.y }
+        spot.y = walkingSurface(map, spot.x, spot.z).height
+        const level = TILE_HEIGHT + (map.water?.surface?.[water] ?? 0)
+        if (Math.abs(spot.y - level) > .6 || Math.abs(spot.y - bank.y) > .6) continue
+        const route: WanderSpot[] = []
+        for (let i = head; i >= 0; i = nodes[i].parent) route.push(point(nodes[i].x, nodes[i].z))
+        route.reverse()
+        return { spot, route: [{ x: centre.x, y: from.y, z: from.z }, ...route, spot] }
+      }
+    }
+    if (node.distance + 1 + .3 > WATER_DETOUR_LIMIT) continue
+    for (const [dx, dz] of ROUTE_DIRS) {
+      const x = node.x + dx, z = node.z + dz, next = z * map.width + x
+      if (seen.has(next) || !clear(x, z)) continue
+      if (map.tiles[index] !== "bridge" && map.tiles[next] !== "bridge" &&
+        !Number.isFinite(elevationStep(map.elevation, index, next))) continue
+      seen.add(next)
+      nodes.push({ x, z, parent: head, distance: node.distance + 1 })
+    }
+  }
+  return null
+}

--- a/lib/game/sim.test.ts
+++ b/lib/game/sim.test.ts
@@ -1,7 +1,7 @@
 import { TILES_PER_DAY } from "./calendar"
 import { MIN_WEARY_SPEED } from "./traveler-weariness"
 import { DEFAULT_WALK_SPEED, BASE_CHARACTER_SCALE } from "./base-person/gait"
-import { knightLoadout, knightTravelSpeed } from "./knights"
+import { knightLoadout, knightTravelSpeed, knightMounted } from "./knights"
 import { describe, expect, it } from "vitest"
 import { DEFAULT_BALANCE } from "./balance"
 import { SIMULATION_SPEEDS, simulationFrameStep } from "./simulation-store"
@@ -1101,5 +1101,102 @@ describe("roadside generosity", () => {
     stepSim(sim, travelers, map, 1, 0.1)
     expect(beggar.activity).toBe("walking")
     expect(beggar.spot).toBeNull()
+  })
+})
+
+
+describe("natural water stops", () => {
+  function waterMap(flowing: boolean) {
+    const map = makeMap()
+    const index = 7 * map.width + 12
+    map.tiles[index] = "water"
+    map.water = { depth: map.tiles.map(t => t === "water" ? 1 : 0), flow: flowing ? { [index]: [1, 0] } : {} }
+    return map
+  }
+
+  it.each(["lake", "stream"])("walks to a %s, drinks free and returns to the same road position", source => {
+    const map = waterMap(source === "stream")
+    const travelers = [makeTraveler(0, "peasant", { thirst: 5, gold: 0, hunger: 50, stamina: 70 })]
+    const sim = createSim(travelers, map), s = sim.travelers.get(0)!
+    Object.assign(sim.balance.rules, { hungerDecay: 0, thirstDecay: 0, staminaDecay: 0 })
+    const start = { x: s.x, z: s.z, progress: s.progress, direction: s.direction }
+    stepSim(sim, travelers, map, 1, .1)
+    expect(s.activity).toBe("toWater")
+    expect(s.thirst).toBe(5)
+    expect(runUntil(sim, travelers, map, () => {
+      expect(tileAt(map, worldToTileX(map, s.x), worldToTileZ(map, s.z))).not.toBe("water")
+      return s.activity === "drinking"
+    }, 60)).toBe(true)
+    expect(s.thirst).toBe(5)
+    expect(Math.hypot(s.x - tileToWorldX(map, 12), s.z - tileToWorldZ(map, 7))).toBeCloseTo(.7)
+    stepSim(sim, travelers, map, 1, 1)
+    expect(s.activity).toBe("drinking")
+    expect(s.thirst).toBe(5)
+    expect(runUntil(sim, travelers, map, () => s.activity === "fromWater", 5)).toBe(true)
+    expect([s.thirst, s.gold, s.hunger, s.stamina]).toEqual([100, 0, 50, 70])
+    expect(runUntil(sim, travelers, map, () => s.activity === "walking", 30)).toBe(true)
+    expect(s).toMatchObject(start)
+    expect(s.waterVisit).toBeUndefined()
+    stepSim(sim, travelers, map, 1, .1)
+    expect(s.progress).toBeGreaterThan(start.progress)
+  })
+
+  it.each([1, -1] as const)("preserves a forest track in direction %s through a drink stop", direction => {
+    const map = makeTrackMap(), travelers = [makeTraveler(0, "pilgrim", { thirst: 5 })]
+    map.tiles[2 * map.width + 14] = "water"
+    const sim = createSim(travelers, map), s = sim.travelers.get(0)!
+    Object.assign(s, { direction, track: { index: 0, progress: 9 }, progress: 8,
+      x: tileToWorldX(map, 14), z: tileToWorldZ(map, 1) })
+    const track = { ...s.track! }
+    expect(runUntil(sim, travelers, map, () => s.activity === "drinking", 20)).toBe(true)
+    expect(runUntil(sim, travelers, map, () => s.activity === "walking", 20)).toBe(true)
+    expect(s).toMatchObject({ direction, track, progress: 8 })
+    expect(s.thirst).toBeGreaterThan(90)
+    stepSim(sim, travelers, map, 1, .1)
+    expect(direction * (s.track!.progress - track.progress)).toBeGreaterThan(0)
+  })
+
+  it("lets a knight dismount for water and resume riding afterwards", () => {
+    const map = waterMap(true), travelers = [makeTraveler(0, "knight", { thirst: 5 })]
+    const sim = createSim(travelers, map), s = sim.travelers.get(0)!
+    stepSim(sim, travelers, map, 1, .1)
+    expect(s.activity).toBe("toWater")
+    expect(knightMounted(s.activity, s.horseRest)).toBe(false)
+    expect(runUntil(sim, travelers, map, () => s.activity === "walking", 60)).toBe(true)
+    expect(knightMounted(s.activity, s.horseRest)).toBe(true)
+    expect(s.thirst).toBeGreaterThan(90)
+  })
+
+  it("does not interrupt a supplied traveler or someone fleeing", () => {
+    const map = waterMap(false), travelers = [makeTraveler(0, "peasant", { thirst: 80 })]
+    const sim = createSim(travelers, map), s = sim.travelers.get(0)!
+    stepSim(sim, travelers, map, 1, .1)
+    expect(s.activity).toBe("walking")
+    Object.assign(s, { activity: "fleeing", fleeTimer: 10, thirst: 0 })
+    stepSim(sim, travelers, map, 1, .1)
+    expect(s.activity).toBe("fleeing")
+    expect(s.waterVisit).toBeUndefined()
+  })
+
+  it("lets a settler return to work after drinking", () => {
+    const map = waterMap(false), travelers = [makeTraveler(0, "peasant", { thirst: 5 })]
+    const sim = createSim(travelers, map), s = sim.travelers.get(0)!
+    Object.assign(s, { activity: "idle", employer: "woodcutter", home: null })
+    const start = { x: s.x, z: s.z }
+    expect(runUntil(sim, travelers, map, () => s.activity === "drinking", 60)).toBe(true)
+    expect(runUntil(sim, travelers, map, () => s.activity === "idle", 30)).toBe(true)
+    expect(s).toMatchObject({ ...start, employer: "woodcutter" })
+    expect(s.thirst).toBeGreaterThan(90)
+  })
+
+  it("leaves a thirsty traveler moving when water is unreachable", () => {
+    const map = waterMap(false)
+    for (let x = 0; x < map.width; x++) map.tiles[5 * map.width + x] = "forest"
+    const travelers = [makeTraveler(0, "peasant", { thirst: 0 })]
+    const sim = createSim(travelers, map), s = sim.travelers.get(0)!, progress = s.progress
+    stepSim(sim, travelers, map, 1, .1)
+    expect(s.activity).toBe("walking")
+    expect(s.thirst).toBe(0)
+    expect(s.progress).toBeGreaterThan(progress)
   })
 })

--- a/lib/game/sim.ts
+++ b/lib/game/sim.ts
@@ -1,3 +1,4 @@
+import { naturalWaterStop, WATER_THIRST_THRESHOLD, WATER_DRINK_SECONDS } from "./natural-water"
 import { tavernWalkingRoute } from "./tavern-navigation"
 import { townResidents } from "./town-residents"
 import { placeResident } from "./jobs/residents"
@@ -122,6 +123,9 @@ export type Activity =
   | "building"
   | "walking"
   | "seeking"
+  | "toWater"
+  | "drinking"
+  | "fromWater"
   | "toBegging"
   | "begging"
   | "fromBegging"
@@ -175,6 +179,9 @@ export const ACTIVITY_LABELS: Record<Activity, string> = {
   building: "Building a structure",
   walking: "On the road",
   seeking: "Seeking food & drink",
+  toWater: "Walking to the water",
+  drinking: "Drinking from the water",
+  fromWater: "Returning from the water",
   toBegging: "Finding a place to ask for alms",
   begging: "Sitting beside the road, asking for alms",
   fromBegging: "Moving to another place",
@@ -328,6 +335,9 @@ export interface SimTraveler {
   jobSlot: number
   /** The house they sleep in. Settlers move in when they take work. */
   home: string | null
+  /** Bound repeated searches while passing inaccessible water. */
+  waterRetry?: number
+  waterVisit?: { spot: WorldPoint; back: WorldPoint; route: WorldPoint[]; buildings: GameMap["buildings"] }
   /** A trip to a counter: where to pay, where to sit, and where to go after. */
   tavernVisit?: {
     plan: TavernPlan
@@ -809,7 +819,7 @@ function findNearbySpot(
 const STALL_ACTIVITIES: readonly Activity[] = ["toShop", "openingShop", "vending", "packingShop"]
 /** Activities that hold someone in place; their speed stays at zero. */
 const STILL_ACTIVITIES: readonly Activity[] = ["offering", "working", "building", "browsing", "performing", "listening", "begging", "givingAlms",
-  "openingShop", "packingShop", "vending", "idle", "posted", "sleeping", "buying", "sitting"]
+  "openingShop", "packingShop", "vending", "idle", "posted", "sleeping", "buying", "sitting", "drinking"]
 const CAMP_ACTIVITIES: readonly Activity[] = ["toCamp", "camping"]
 
 /** World-space pitch on the nearest clearing to `anchor`, or in place if none. */
@@ -907,6 +917,19 @@ function startCamping(sim: SimState, s: SimTraveler, traveler: Traveler, map: Ga
       : null
   s.spot = pitchSpot(map, s, stall ?? campmates ?? s)
   startOffRoadWalk(s, "toCamp")
+}
+
+/** Keep the exact departure point and return route, including a track's lane. */
+function startWaterTrip(s: SimTraveler, map: GameMap): boolean {
+  if (s.thirst > WATER_THIRST_THRESHOLD || (s.waterRetry ?? 0) > 0) return false
+  s.waterRetry = 2
+  const stop = naturalWaterStop(map, s)
+  if (!stop) return false
+  const back = { x: s.x, y: s.y, z: s.z }
+  s.waterVisit = { spot: stop.spot, back, route: [back, ...stop.route].reverse(), buildings: map.buildings }
+  startOffRoadWalk(s, "toWater")
+  s.offRoadRoute = stop.route
+  return true
 }
 
 /** Camps and stalls use the same four-neighbour routing as settlement work. */
@@ -1405,6 +1428,7 @@ export function stepSim(
       if (dt > 0 && sim.procession) blessByProcession(sim.procession, `traveler:${s.id}`, s)
       s.moveSpeed = 0; continue
     }
+    s.waterRetry = Math.max(0, (s.waterRetry ?? 0) - dt)
     s.visitCooldown = Math.max(0, s.visitCooldown - dt)
     s.musicCooldown = Math.max(0, (s.musicCooldown ?? 0) - dt)
     const camping = s.activity === "camping"
@@ -1419,7 +1443,7 @@ export function stepSim(
     s.thirst = Math.max(0, s.thirst - sim.balance.rules.thirstDecay * needFactor * hours)
     if (camping || abed) s.stamina = Math.min(100, s.stamina + CAMP_STAMINA_REGEN * hours)
     // Standing at a stall, a post or a performance neither drains nor restores the legs.
-    else if (!["vending", "performing", "listening", "begging", "givingAlms", "posted", "sitting", "buying"].includes(s.activity)) {
+    else if (!["vending", "performing", "listening", "begging", "givingAlms", "posted", "sitting", "buying", "drinking"].includes(s.activity)) {
       s.stamina = Math.max(0, s.stamina - sim.balance.rules.staminaDecay * hours)
     }
 
@@ -1664,6 +1688,7 @@ export function stepSim(
         }
         // The counter is the quick answer to hunger and thirst; home is the
         // slow one, and the only rest a settler gets. Work comes after both.
+        if (!isVendor && startWaterTrip(s, map)) break
         if (hungry && startTavernTrip(sim, s, map, counters, workplaceReturn(sim, s, map))) break
         if (Math.min(s.hunger, s.thirst, s.stamina) < SETTLER_FED_AT) {
           if (!s.home) s.home = findHome(sim, s, map)
@@ -1768,6 +1793,41 @@ export function stepSim(
         }
         break
       }
+      case "toWater": {
+        const visit = s.waterVisit!
+        if (visit.buildings !== map.buildings) {
+          // A new construction site may close the bank during the detour.
+          startOffRoadWalk(s, "fromWater")
+          break
+        }
+        if (stepOffRoadWalk(s, visit.spot, worldSpeed, dt, map)) {
+          s.activity = "drinking"
+          s.timer = WATER_DRINK_SECONDS
+        }
+        break
+      }
+      case "drinking": {
+        s.timer -= dt
+        if (s.timer <= 0) {
+          s.thirst = 100
+          const visit = s.waterVisit!
+          startOffRoadWalk(s, "fromWater")
+          if (visit.buildings === map.buildings) s.offRoadRoute = [...visit.route]
+        }
+        break
+      }
+      case "fromWater": {
+        const visit = s.waterVisit!
+        if (visit.buildings !== map.buildings) {
+          s.offRoadRoute = null
+          visit.buildings = map.buildings
+        }
+        if (stepOffRoadWalk(s, visit.back, worldSpeed, dt, map)) {
+          s.waterVisit = undefined
+          finishErrand(s)
+        }
+        break
+      }
       case "walking":
       case "seeking":
       case "fleeing": {
@@ -1785,6 +1845,7 @@ export function stepSim(
           s.fleeTimer -= dt
           if (s.fleeTimer <= 0) s.activity = "walking"
         }
+        if ((s.activity === "walking" || s.activity === "seeking") && !isVendor && startWaterTrip(s, map)) break
         // Independent taverns welcome road walkers by need, without shrine attraction.
         if ((s.activity === "walking" || s.activity === "seeking") && !s.track && !s.roadShortcut &&
           !isVendor && t.type.id !== "knight" && s.visitCooldown <= 0 && Math.min(s.hunger, s.thirst) < SERVING_THRESHOLD) {


### PR DESCRIPTION
Thirsty travelers and settlers can now walk up to six tiles to a reachable stream or lake bank, drink for three seconds to refill thirst for free, and return to their journey or work.
The search avoids blocked routes, cliffs, waterfalls, bridge decks and submerged shoreline corners; drinking uses the existing gathering pose and preserves road or track progress, including knights dismounting and remounting.
Validation: 221 tests across seven affected suites passed, along with TypeScript and diff checks.
The full test run was stopped after timeouts in several unrelated suites.
