### PR TITLE
Allow roadside vendors to open shops without nearby trees

### DIFF
--- a/lib/game/sim.test.ts
+++ b/lib/game/sim.test.ts
@@ -466,16 +466,17 @@ describe("stepSim", () => {
     ).toBe(true)
   })
 
-  it("briefly opens and packs animal-drawn shops, waiting for recall before departure", () => {
+  it("opens animal-drawn shops without trees, lets animals graze, and recalls them before departure", () => {
     for (const id of [4, 8]) { // donkey and horse
       const map = makeMap(), travelers = [makeTraveler(id, "vendor", { stamina: 100, hunger: 100, thirst: 100 })]
       const sim = createSim(travelers, map), vendor = sim.travelers.get(id)!
       // Leave room for the animal's head through the return turn.
       for (let x = 0; x < map.width; x++) map.tiles[3 * map.width + x] = "grass"
-      sim.trees = Array.from({ length: map.width }, (_, x) => ({ x: tileToWorldX(map, x), y: 0.2, z: tileToWorldZ(map, 8), species: "oak" as const }))
+      sim.trees = []
       vendor.timer = 0
       expect(runUntil(sim, travelers, map, () => vendor.activity === "openingShop", 60)).toBe(true)
-      expect(vendor.pasture?.tether).toBeDefined()
+      expect(vendor.pasture).toBeDefined()
+      expect(vendor.pasture!.tether).toBeUndefined()
       expect(Math.abs(worldToTileZ(map, vendor.z) - 4)).toBe(2)
       const originalProgress = vendor.progress, returnProgress = vendor.stallRoute!.returnProgress
       expect((returnProgress - originalProgress) * vendor.direction).toBeGreaterThan(0)
@@ -486,6 +487,7 @@ describe("stepSim", () => {
       expect(runUntil(sim, travelers, map, () => vendor.activity === "vending", 5)).toBe(true)
       vendor.timer = 100
       for (let i = 0; i < 30; i++) stepSim(sim, travelers, map, 1, 0.1)
+      expect(Math.hypot(vendor.pasture!.x - vendor.pasture!.home.x, vendor.pasture!.z - vendor.pasture!.home.z)).toBeGreaterThan(0)
       vendor.timer = 0
       stepSim(sim, travelers, map, 1, 0.1)
       expect(runUntil(sim, travelers, map, () => vendor.activity === "packingShop", 25)).toBe(true)

--- a/lib/game/sim.ts
+++ b/lib/game/sim.ts
@@ -2150,7 +2150,6 @@ export function stepSim(
           s.timer = SHOP_SECONDS
           if (cartLoadout(s.id).puller !== "hand") {
             s.pasture = createPasture(s, s.stallRoute?.obstacles, animalClearance(cartLoadout(s.id).puller, characterScale), s.stallRoute?.heading ?? 0)
-            s.pasture.tether = s.stallRoute?.tree
           }
 
         }

--- a/lib/game/transport/navigation.test.ts
+++ b/lib/game/transport/navigation.test.ts
@@ -91,12 +91,12 @@ describe("merchant shrine parking", () => {
     const map = fixture(), pose = alignCart({ x: tileToWorldX(map, 15), z: tileToWorldZ(map, 3) }, Math.PI / 2, 0)
     expect(parkingTree(map, pose, [{ x: pose.x, z: tileToWorldZ(map, 5), y: 0.2, species: "oak" }])).toBeUndefined()
   })
-  it("tries the other market verge when the first has no tree", () => {
-    const map = fixture(), from = convoyPoint(map, 10), context = { trees: trees(map) }
-    const pitch = stallParking(map, from, 10, 1, -cartOffset("horse") * 1.5, 1.5, "horse", context)
+  it.each(["hand", "donkey", "horse"] as const)("parks a roadside %s shop without a tree", puller => {
+    const map = fixture(), from = convoyPoint(map, 10), context = { trees: [] }
+    const pitch = stallParking(map, from, 10, 1, -cartOffset(puller) * 1.5, 1.5, puller, context)
     expect(pitch).not.toBeNull()
-    expect(pitch!.tree).toBeDefined()
-    expect(pitch!.park.z).toBeLessThan(from.z)
+    const parked = alignCart(pitch!.park, pitch!.heading, -cartOffset(puller) * 1.5)
+    expect(parkingClear(map, parked, puller, 1.5, context, true)).toBe(true)
   })
   it("declines parking when the verge is water or buildings", () => {
     const map = fixture(); map.tiles = map.tiles.map(t => t === "grass" ? "water" : t)

--- a/lib/game/transport/navigation.ts
+++ b/lib/game/transport/navigation.ts
@@ -190,12 +190,11 @@ export function shrineParking(map: GameMap, progress: number, direction: 1 | -1,
   return null
 }
 
-/** Market stops use the same clearance and tree requirement, trying either verge. */
+/** Roadside shops need convoy clearance on either verge; animals graze without a tether. */
 export function stallParking(map: GameMap, from: Point, progress: number, direction: 1 | -1, wheelbase: number, scale: number, puller: Puller, context: ParkingContext) {
   return roadsideStall(map, from, progress, direction, wheelbase, scale, puller, pitch => {
     const parked = alignCart(pitch.park, pitch.heading, wheelbase)
-    pitch.tree = puller === "hand" ? undefined : parkingTree(map, parked, context.trees)
-    if (!parkingClear(map, parked, puller, scale, context, true) || (puller !== "hand" && !pitch.tree)) return false
+    if (!parkingClear(map, parked, puller, scale, context, true)) return false
     let pose = alignCart(from, pitch.heading, wheelbase)
     for (const route of [pitch.entry, pitch.exit]) {
       const length = routeLength(route)

--- a/lib/game/transport/roadside.ts
+++ b/lib/game/transport/roadside.ts
@@ -6,7 +6,6 @@ export interface Point { x: number; z: number }
 import { STALL, stallPoint, stallObstacles, type StallObstacle } from "./stall"
 
 export interface StallRoute {
-  tree?: import("../trees/placement").TreePlacement
   entry: Point[]; exit: Point[]; park: Point; heading: number; side: 1 | -1; returnProgress: number
   frontage: Point; entranceProgress: number; obstacles: StallObstacle[]
 }


### PR DESCRIPTION
Roadside vendors can now open shops without a nearby tethering tree, making more clear roadside locations eligible while preserving cart and route clearance checks. Horses and donkeys graze nearby and are recalled before departure.

Validation: 96 tests passed across simulation, transport navigation, and grazing; `npm run typecheck` passed.
