### PR TITLE
Preserve character detail under frame pressure

### DIFF
--- a/components/game/character-batches.tsx
+++ b/components/game/character-batches.tsx
@@ -11,7 +11,6 @@ import { isWorldVisible } from "@/lib/game/render/visibility"
 import { frameProfile } from "@/lib/game/render/frame-profile"
 import { SpriteFrames } from "./sprite-frames"
 import { benchmarkWork } from "@/lib/game/benchmark-work"
-import { frameQuality } from "@/lib/game/render/frame-quality"
 
 interface AtlasGroup {
   entries: CharacterBatchEntry[]
@@ -72,7 +71,7 @@ export function CharacterBatches({ children }: { children: ReactNode }) {
     for (const group of groups.values()) group.entries.length = 0
     candidates.clear()
   }, -1)
-  useFrame(({ camera, scene, clock }, delta) => {
+  useFrame(({ camera, scene, clock }) => {
     // This interval also contains wildlife's independently reported callback.
     frameProfile.end("animationAndWildlife", phaseStart.current)
     const started = frameProfile.start()
@@ -96,7 +95,6 @@ export function CharacterBatches({ children }: { children: ReactNode }) {
         root.current.add(batch.root)
       }
       group.entries.sort((a, b) => a.sprite.renderOrder - b.sprite.renderOrder)
-      batch?.setSimplified(frameQuality(scene) === 2, delta)
       batch?.write(group.entries, camera, true)
     }
     updateBatchSourceVisibility(scene, candidates, clock.elapsedTime)

--- a/components/game/character-sprite.tsx
+++ b/components/game/character-sprite.tsx
@@ -189,17 +189,16 @@ export function CharacterSprite({ map: suppliedMap, type, onClick, outlineColor,
   const batchEntries = useCharacterBatches()
   const batchEntry = useRef<CharacterBatchEntry | null>(null)
   const batchUv = useMemo(() => new THREE.Vector4(), [])
-  const simpleColor = useMemo(() => visual.design ? new THREE.Color(visual.design.tunicColor) : undefined, [visual.design])
   useLayoutEffect(() => {
     if (!batchEntries || !sprite.current || !idSprite.current || !outlineColor || name !== "traveler") return
-    const entry = { sprite: sprite.current, ids: idSprite.current, publishesPose: true, complexion: complexionValues, palette: characterPalette(complexionValues), simpleColor, ground: groundPlane,
+    const entry = { sprite: sprite.current, ids: idSprite.current, publishesPose: true, complexion: complexionValues, palette: characterPalette(complexionValues), ground: groundPlane,
       fixedAttributes: Float32Array.from([center.x, center.y, ...outlineColor]), depth: poseDepth, id: new THREE.Vector3(...outlineColor) }
     batchEntry.current = entry
     const unregisterEntry = registerCharacterBatchEntry(entry)
     batchEntries.add(entry)
     const unregister = registerSimpleBatchSource(entry.sprite, entry.ids)
     return () => { batchEntry.current = null; unregisterEntry(); unregister(); batchEntries.delete(entry); entry.sprite.visible = entry.ids.visible = true }
-  }, [batchEntries, complexionValues, simpleColor, groundPlane, poseDepth, name, center, outlineColor?.[0], outlineColor?.[1], outlineColor?.[2]])
+  }, [batchEntries, complexionValues, groundPlane, poseDepth, name, center, outlineColor?.[0], outlineColor?.[1], outlineColor?.[2]])
 
   const crowdWalk = useMemo<CrowdWalk | null>(() => map && rig && !attachment && walkTuning?.sync !== false ? {
     map, rig, walk: visual.walk, weary: visual.actions.wearyWalk, wearyIndex: actionIndices.wearyWalk,

--- a/components/game/debug-handle.tsx
+++ b/components/game/debug-handle.tsx
@@ -143,8 +143,7 @@ export function DebugHandle({ map, travelers, speed, movement, speedScales, begg
         missingVisibleUnits: namedRoot("travelers")?.userData.missingVisibleUnits ?? 0 }),
       adaptiveStatus: () => ({ ...crowdRenderStatus, quality: frameQuality(scene), detail: sceneryDetailStatus(scene)?.current,
         treeDensity: namedRoot("foliage-prototype")?.children[0]?.userData.treeDensity,
-        wildlife: namedRoot("wildlife")?.visible, waterDetail: namedRoot("water-shimmer")?.visible,
-        simpleBatches: namedRoot("character-batches")?.children.filter(child => child.visible && child.userData.simplified).length ?? 0 }),
+        wildlife: namedRoot("wildlife")?.visible, waterDetail: namedRoot("water-shimmer")?.visible }),
       hiddenTraveler: () => {
         const root = namedRoot("travelers")
         let hidden: { id: number; x: number; z: number } | null = null

--- a/lib/game/render/character-batch.ts
+++ b/lib/game/render/character-batch.ts
@@ -21,8 +21,6 @@ export interface CharacterBatchEntry {
   /** Immutable palette snapshot, replaced when appearance changes. Omit for
    * callers that edit complexion uniforms in place. */
   palette?: Float32Array
-  /** Representative authored cloth colour for the lowest visual quality. */
-  simpleColor?: THREE.Color
   ground: { value: THREE.Vector4 }
   depth: SpritePoseDepth
   id: THREE.Vector3
@@ -47,7 +45,8 @@ export function characterPalette(complexion: ComplexionUniforms): Float32Array {
 }
 
 /** Shared atlases, with per-instance pose UVs, ground planes, IDs and palettes.
- * The same billboard and depth equations as CharacterSprite remain in use. */
+ * The same billboard and depth equations as CharacterSprite remain in use.
+ * Keep authored colors and complexion detail at every adaptive quality level. */
 export class CharacterBatch {
   readonly root = new THREE.Group()
   private capacity = 0
@@ -61,7 +60,6 @@ export class CharacterBatch {
   private viewport = new THREE.Vector4()
   private paletteUniform = { value: null as THREE.DataTexture | null }
   private paletteHeight = { value: 1 }
-  private simplified = { value: 0 }
   private materials: THREE.MeshBasicMaterial[]
 
   constructor(entry: CharacterBatchEntry, worldTexel: { value: number }, order: number) {
@@ -73,8 +71,6 @@ export class CharacterBatch {
       material.onBeforeCompile = shader => {
         shader.uniforms.characterPalette = this.paletteUniform
         shader.uniforms.characterPaletteHeight = this.paletteHeight
-        shader.uniforms.characterSimplified = this.simplified
-        shader.uniforms.characterSimpleColor = { value: entry.simpleColor ?? new THREE.Color() }
         shader.vertexShader = `attribute vec4 characterUv;
           attribute vec4 characterView;
           attribute vec4 characterGround;
@@ -99,37 +95,25 @@ export class CharacterBatch {
           flat varying float vCharacterIndex;
           uniform sampler2D characterPalette;
           uniform float characterPaletteHeight;
-          uniform float characterSimplified;
-          uniform vec3 characterSimpleColor;
         ` + shader.fragmentShader.replace("#include <map_fragment>", ids
           ? "#include <map_fragment>\ndiffuseColor.rgb = vCharacterId;"
           : `#include <map_fragment>
-            if (characterSimplified >= 1.0) diffuseColor.rgb = characterSimpleColor;
-            else { ${!entry.complexion ? "" : `
+            ${!entry.complexion ? "" : `
             for (int i = 0; i < ${COMPLEXION_SLOTS}; i++) {
               vec2 at = vec2((float(i) + .5) / ${COMPLEXION_SLOTS * 2}.0, (vCharacterIndex + .5) / characterPaletteHeight);
               vec3 from = texture2D(characterPalette, at).rgb;
               if (all(lessThan(abs(diffuseColor.rgb - from), vec3(${MATCH_TOLERANCE})))) {
                 diffuseColor.rgb = texture2D(characterPalette, at + vec2(.5, 0.0)).rgb; break;
               }
-            }`}
-            diffuseColor.rgb = mix(diffuseColor.rgb, characterSimpleColor, characterSimplified); }`)
+            }`}`)
       }
       material.onBeforeRender = renderer => { renderer.getCurrentViewport(this.viewport) }
-      material.customProgramCacheKey = () => ids ? "character-batch-id-v2" : `character-batch-color-v2-${!!entry.complexion}`
+      material.customProgramCacheKey = () => ids ? "character-batch-id-v3" : `character-batch-color-v3-${!!entry.complexion}`
       return material
     })
     this.root.name = "character-atlas-batch"
     this.root.userData.order = order
     this.root.userData.viewMatrix = new THREE.Matrix4()
-    this.root.userData.canSimplify = !!entry.simpleColor
-  }
-
-  setSimplified(enabled: boolean, delta = Infinity): void {
-    const target = enabled && this.root.userData.canSimplify ? 1 : 0
-    const step = Math.max(0, delta) / .24
-    this.simplified.value += Math.max(-step, Math.min(step, target - this.simplified.value))
-    this.root.userData.simplified = this.simplified.value > 0
   }
 
   write(entries: CharacterBatchEntry[], camera: THREE.Camera, parentsReady = false): void {

--- a/scripts/benchmark-game.mjs
+++ b/scripts/benchmark-game.mjs
@@ -328,7 +328,7 @@ try {
     assert.equal(before.quality, 2)
     assert.ok(!before.active && before.budget >= before.population, "adaptive visual quality must retain the full crowd budget")
     assert.ok(count === 0 || before.rendered > 0)
-    assert.ok(before.simpleBatches > 0 && !before.wildlife && !before.waterDetail)
+    assert.ok(!before.wildlife && !before.waterDetail)
     const hidden = await page.evaluate(() => window.__pilgrimage.hiddenTraveler())
     const selected = hidden ?? await page.evaluate(() => window.__pilgrimage.sim()[0])
     assert.ok(selected, "adaptive selection test requires a traveler")
@@ -336,12 +336,12 @@ try {
     await page.waitForFunction(() => window.__pilgrimage.selectionVisuals().sprites > 0, undefined, { timeout: 30000 })
     assert.equal(await page.evaluate(() => window.__pilgrimage.selectionVisuals().reducedWalking), 0)
     await page.evaluate(() => { const g = window.__pilgrimage; g.camera().select(null); g.setAdaptiveQuality(false); g.setZoom(36); g.setPaused(true) })
-    await page.waitForFunction(() => { const s = window.__pilgrimage.adaptiveStatus(); return s.quality === 0 && !s.active && s.detail === 0 && s.simpleBatches === 0 && s.wildlife && s.waterDetail }, undefined, { timeout: 30000 })
+    await page.waitForFunction(() => { const s = window.__pilgrimage.adaptiveStatus(); return s.quality === 0 && !s.active && s.detail === 0 && s.wildlife && s.waterDetail }, undefined, { timeout: 30000 })
     const after = await page.evaluate(() => window.__pilgrimage.adaptiveStatus())
     assert.equal(after.treeDensity, 1)
     assert.equal(await page.evaluate(() => window.__pilgrimage.populationStatus().total), count)
     await writeFile(`${output}/adaptive-smoke.json`, JSON.stringify({ before, selected, after }, null, 2))
-    console.log("Adaptive smoke passed: full crowd budget, solid colours, hidden wildlife/water detail, full selected NPC and restored detail")
+    console.log("Adaptive smoke passed: full crowd budget, hidden wildlife/water detail, full selected NPC and restored detail")
   }
   if (["BENCH_SMOKE", "BENCH_DETAIL_SMOKE", "BENCH_CITY_SMOKE"].some(key => process.env[key] === "1")) {
     await page.evaluate(() => window.__pilgrimage.setAdaptiveQuality(false))

--- a/scripts/test-sprite-depth.mjs
+++ b/scripts/test-sprite-depth.mjs
@@ -653,11 +653,11 @@ test("sprites preserve overlaps, terrain contact, scenery occlusion, and aligned
           } else originals.add(sprite)
           return sprite
         })
-        return { sprite: sprites[0], ids: sprites[1], complexion, simpleColor: new THREE.Color("#657b50"), ground, depth: pose, id }
+        return { sprite: sprites[0], ids: sprites[1], complexion, ground, depth: pose, id }
       })
       let batch = new CharacterBatch(entries[0], worldTexel, 1)
       scene.add(batch.root)
-      let compared = 0, mismatches = 0, visible = 0, simplifiedCompared = 0, simplifiedMismatches = 0
+      let compared = 0, mismatches = 0, visible = 0, detailedColorCases = 0
       const examples = [], byLayer = [0, 0]
       for (const recolor of [true, false]) {
         if (!recolor) {
@@ -706,16 +706,14 @@ test("sprites preserve overlaps, terrain contact, scenery occlusion, and aligned
                 camera.layers.set(layer)
                 originals.visible = true; batch.root.visible = false; const reference = capture()
                 originals.visible = false; batch.root.visible = true; const actual = capture()
-                if (size === 192 && direction === 0 && frame === 0) {
-                  batch.setSimplified(true)
-                  const simplified = capture(), colours = new Set()
+                if (layer === 0) {
+                  const colours = new Set()
                   for (let i = 0; i < actual.length; i += 4) {
-                    if (actual[i + 3] !== simplified[i + 3]) simplifiedMismatches++
-                    if (layer === 1 && [0, 1, 2].some(c => actual[i + c] !== simplified[i + c])) simplifiedMismatches++
-                    if (simplified[i + 3]) { simplifiedCompared++; colours.add(simplified.slice(i, i + 3).join(",")) }
+                    if (actual[i + 3]) colours.add(actual.slice(i, i + 3).join(","))
                   }
-                  if (layer === 0 && colours.size !== 1) simplifiedMismatches++
-                  batch.setSimplified(false)
+                  // Even unselected crowd batches must retain authored shading,
+                  // skin and clothing instead of becoming a single-color shape.
+                  if (colours.size > 1) detailedColorCases++
                 }
                 for (let i = 0; i < actual.length; i += 4) {
                   if (reference[i + 3]) visible++
@@ -735,7 +733,7 @@ test("sprites preserve overlaps, terrain contact, scenery occlusion, and aligned
       batch.write(entries.slice(0, 2), camera); batch.write([], camera); batch.dispose()
       originals.traverse(sprite => { if (sprite instanceof THREE.Sprite) { sprite.material.map.dispose(); sprite.material.dispose() } })
       color.dispose(); depth.dispose(); gl.dispose()
-      return { compared, visible, mismatches, simplifiedCompared, simplifiedMismatches, byLayer, examples }
+      return { compared, visible, mismatches, detailedColorCases, byLayer, examples }
     }, poseClips.walk)
     const buildings = await page.evaluate(async () => {
       const THREE = await import("/three.module.js")
@@ -1086,8 +1084,7 @@ test("sprites preserve overlaps, terrain contact, scenery occlusion, and aligned
     assert.ok(uploads.preserved && uploads.changed > 0, `real atlas changes must still upload: ${JSON.stringify(uploads)}`)
     assert.ok(scenery.compared > 10000, JSON.stringify(scenery))
     assert.equal(scenery.mismatches, 0, `visible scenery batches must preserve lighting and overlap pixels: ${JSON.stringify(scenery)}`)
-    assert.ok(batched.simplifiedCompared > 1000, JSON.stringify(batched))
-    assert.equal(batched.simplifiedMismatches, 0, "solid colour must preserve silhouette, depth ordering and selection IDs")
+    assert.equal(batched.detailedColorCases, 96, "all crowd views must retain authored color detail")
     assert.ok(batched.visible > 10000, JSON.stringify(batched))
     assert.equal(batched.mismatches, 0, `batched color and ID pixels must match individual sprites: ${JSON.stringify(batched)}`)
     for (const foliage of foliageResults) {


### PR DESCRIPTION
Sustained frame pressure turned crowd characters into single-color shapes, hiding faces, clothing, and shading. Remove that fallback so authored colors and complexion detail remain visible at every adaptive quality level while preserving batching and CPU optimizations. Remove the obsolete debug metric and benchmark expectations, and check detailed character colors across 96 browser-rendered views.

Validation passed: `npm run typecheck`, all 78 renderer tests (`npm test -- lib/game/render`), and `node --test scripts/test-sprite-depth.mjs` covering pixel comparisons, overlaps, terrain contact, and outlines.
