### PR TITLE
Add two-finger twist camera rotation on mobile

### DIFF
--- a/components/game/camera-rig.tsx
+++ b/components/game/camera-rig.tsx
@@ -100,23 +100,33 @@ export function CameraRig({ map, onPlace }: { map: GameMap; onPlace?: (at: TileP
         return
       }
       if (gesture.dragged) {
+        if (useCameraStore.getState().inputLocked) {
+          event.stopPropagation()
+          setHovered(null)
+          return
+        }
         canvas.style.cursor = "grabbing"
         const rect = canvas.getBoundingClientRect()
         const oldScale = worldPerPixel(displayViewSize.current, rect.height)
+        const oldYaw = displayYaw.current
         if (gesture.pinching) {
-          // Touch follows the fingers directly, including during a wheel tween.
-          useCameraStore.setState({ viewSize: displayViewSize.current })
+          // Touch follows the fingers directly, including during camera tweens.
+          // Clockwise fingers turn the ground clockwise, so camera yaw decreases.
+          displayYaw.current -= movement.rotation
+          useCameraStore.setState({
+            viewIndex: (displayYaw.current - yawForView(0)) / (Math.PI / 2),
+            viewSize: displayViewSize.current,
+          })
           useCameraStore.getState().zoomBy(movement.zoom)
           displayViewSize.current = useCameraStore.getState().viewSize
         }
         const newScale = worldPerPixel(displayViewSize.current, rect.height)
         const cx = rect.left + rect.width / 2, cy = rect.top + rect.height / 2
-        // Preserve the ground point under the moving pinch midpoint, even when
-        // zoom reaches its limits. A one-finger drag is the same transform.
-        const dx = (movement.after.x - cx) * newScale - (movement.before.x - cx) * oldScale
-        const dy = (movement.after.y - cy) * newScale - (movement.before.y - cy) * oldScale
-        const delta = panDelta(displayYaw.current, dx, dy, 1)
-        pan(delta.dx, delta.dz)
+        // Preserve the ground point under the midpoint through pan, zoom and
+        // twist. Each screen offset uses its own camera scale and orientation.
+        const before = panDelta(oldYaw, movement.before.x - cx, movement.before.y - cy, oldScale)
+        const after = panDelta(displayYaw.current, movement.after.x - cx, movement.after.y - cy, newScale)
+        pan(after.dx - before.dx, after.dz - before.dz)
         event.stopPropagation()
         setHovered(null)
       } else updateHover(event)

--- a/lib/game/camera-gesture.test.ts
+++ b/lib/game/camera-gesture.test.ts
@@ -19,9 +19,10 @@ describe("camera touch gestures", () => {
       gesture.start(1, { x: 100, y: 100 })
       gesture.start(2, { x: 200, y: 100 })
       expect(gesture.move(2, { x: 300, y: 100 })).toEqual({
-        before: { x: 150, y: 100, distance: 100 },
-        after: { x: 200, y: 100, distance: 200 },
+        before: { x: 150, y: 100, distance: 100, angle: 0 },
+        after: { x: 200, y: 100, distance: 200, angle: 0 },
         zoom: 0.5,
+        rotation: 0,
       })
       expect(gesture.end(lifted, { x: lifted === 1 ? 100 : 300, y: 100 })).toBe(false)
       const remaining = lifted === 1 ? 2 : 1
@@ -29,6 +30,7 @@ describe("camera touch gestures", () => {
       const movement = gesture.move(remaining, { x: x + 10, y: 110 })!
       expect(movement.after.x - movement.before.x).toBe(10)
       expect(movement.zoom).toBe(1)
+      expect(movement.rotation).toBe(0)
       expect(gesture.end(remaining, { x: x + 10, y: 110 })).toBe(false)
       expect(gesture.active).toBe(false)
       gesture.start(3, { x: 100, y: 100 })
@@ -40,7 +42,7 @@ describe("camera touch gestures", () => {
     const gesture = new CameraGesture()
     gesture.start(1, { x: 100, y: 100 })
     gesture.start(2, { x: 100, y: 100 })
-    expect(gesture.move(2, { x: 101, y: 100 })?.zoom).toBe(1)
+    expect(gesture.move(2, { x: 101, y: 100 })).toMatchObject({ zoom: 1, rotation: 0 })
     expect(gesture.end(2, { x: 101, y: 100 })).toBe(false)
     expect(gesture.end(1, { x: 100, y: 100 })).toBe(false)
     gesture.start(3, { x: 100, y: 100 })
@@ -49,5 +51,46 @@ describe("camera touch gestures", () => {
     gesture.clear()
     expect(gesture.move(4, { x: 150, y: 100 })).toBeNull()
     expect(gesture.end(4, { x: 100, y: 100 })).toBe(false)
+  })
+
+  it("tracks clockwise and counterclockwise twists while zooming and moving the midpoint", () => {
+    for (const direction of [-1, 1]) {
+      const gesture = new CameraGesture()
+      gesture.start(1, { x: 100, y: 100 })
+      gesture.start(2, { x: 200, y: 100 })
+      const movement = gesture.move(2, { x: 100, y: 100 + direction * 200 })!
+      expect(movement.rotation).toBeCloseTo(direction * Math.PI / 2)
+      expect(movement.zoom).toBe(0.5)
+      expect(movement.after).toMatchObject({ x: 100, y: 100 + direction * 100 })
+      expect(gesture.end(2, { x: 100, y: 100 + direction * 200 })).toBe(false)
+      expect(gesture.end(1, { x: 100, y: 100 })).toBe(false)
+    }
+  })
+
+  it("takes the short arc when twisting across the angle boundary in either direction", () => {
+    for (const direction of [-1, 1]) {
+      const gesture = new CameraGesture()
+      gesture.start(1, { x: 200, y: 200 })
+      gesture.start(2, { x: 100, y: 200 + direction })
+      const movement = gesture.move(2, { x: 100, y: 200 - direction })!
+      expect(movement.rotation).toBeCloseTo(direction * 2 * Math.atan(0.01))
+      expect(movement.zoom).toBe(1)
+    }
+  })
+
+  it("starts a fresh angle baseline when replacing either finger", () => {
+    for (const lifted of [1, 2]) {
+      const gesture = new CameraGesture()
+      gesture.start(1, { x: 100, y: 100 })
+      gesture.start(2, { x: 200, y: 100 })
+      gesture.move(2, { x: 100, y: 200 })
+      gesture.end(lifted, { x: 100, y: lifted === 1 ? 100 : 200 })
+      const remaining = lifted === 1 ? 2 : 1
+      const y = remaining === 1 ? 100 : 200
+      expect(gesture.move(remaining, { x: 110, y })?.rotation).toBe(0)
+      gesture.start(3, { x: 210, y })
+      expect(gesture.move(3, { x: 210, y })?.rotation).toBe(0)
+      expect(gesture.move(3, { x: 110, y: y + 100 })?.rotation).toBeCloseTo(Math.PI / 2)
+    }
   })
 })

--- a/lib/game/camera-gesture.ts
+++ b/lib/game/camera-gesture.ts
@@ -3,11 +3,15 @@ export interface GesturePoint { x: number; y: number }
 function frame(points: Map<number, GesturePoint>) {
   const [a, b] = points.values()
   return b
-    ? { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2, distance: Math.hypot(b.x - a.x, b.y - a.y) }
-    : { ...a, distance: 0 }
+    ? {
+      x: (a.x + b.x) / 2, y: (a.y + b.y) / 2,
+      distance: Math.hypot(b.x - a.x, b.y - a.y),
+      angle: Math.atan2(b.y - a.y, b.x - a.x),
+    }
+    : { ...a, distance: 0, angle: 0 }
 }
 
-/** A gesture stays camera-only after a drag or pinch, until every finger lifts. */
+/** A gesture stays camera-only after a drag, pinch or twist, until every finger lifts. */
 export class CameraGesture {
   private points = new Map<number, GesturePoint>()
   private origin: GesturePoint = { x: 0, y: 0 }
@@ -32,9 +36,13 @@ export class CameraGesture {
     this.points.set(id, point)
     if (Math.hypot(point.x - this.origin.x, point.y - this.origin.y) > 6) this.dragged = true
     const after = frame(this.points)
+    const angle = after.angle - before.angle
     return {
       before, after,
       zoom: before.distance > 0 && after.distance > 0 ? before.distance / after.distance : 1,
+      // Take the short arc across ±π; coincident fingers have no direction.
+      rotation: before.distance > 0 && after.distance > 0
+        ? Math.atan2(Math.sin(angle), Math.cos(angle)) : 0,
     }
   }
 

--- a/lib/game/camera-store.ts
+++ b/lib/game/camera-store.ts
@@ -33,7 +33,7 @@ interface CameraState {
   /** Camera focus point on the ground plane. */
   targetX: number
   targetZ: number
-  /** Unbounded integer so rotation tweens can wrap without spinning backwards. */
+  /** Unbounded quarter turns; fractional after a touch twist, so yaw stays continuous. */
   viewIndex: number
   /** Orthographic frustum height in world units. */
   viewSize: number

--- a/lib/game/render/iso.ts
+++ b/lib/game/render/iso.ts
@@ -2,10 +2,9 @@
  * Isometric camera math. Pure functions — no three.js, no React — so the
  * projection and panning behaviour can be unit-tested headlessly.
  *
- * The camera is orthographic with a fixed pitch and one of four fixed yaws,
- * RCT2-style. It orbits a `target` point on the ground plane (y = 0); panning
- * moves that target, rotation snaps between the four views, zoom changes the
- * orthographic frustum height.
+ * The camera is orthographic with a fixed pitch. It orbits a `target` point on
+ * the ground plane (y = 0); panning moves that target, keyboard rotation steps
+ * by quarter turns, touch twists rotate freely, and zoom changes the frustum height.
  */
 
 /** True isometric: atan(1/√2) ≈ 35.264°, so a cube's top face is a regular rhombus. */


### PR DESCRIPTION
Mobile players can now rotate the camera smoothly with a two-finger twist while panning or pinching to zoom, keeping the ground point beneath the gesture midpoint fixed and retaining the angle after release.
The gesture handles angle wraparound and finger replacement, suppresses accidental taps, and respects the opening reveal's input lock; camera comments now describe continuous touch rotation.
Validation: 58 targeted tests and TypeScript checks passed, plus a Playwright mobile touch check covering both rotation directions, combined zoom, midpoint preservation, selection, and release behavior.
