### PR TITLE
Place signposts opposite T-junctions and clear of taverns

### DIFF
--- a/components/game/signpost.tsx
+++ b/components/game/signpost.tsx
@@ -11,7 +11,7 @@ import { signpostPlacements } from "@/lib/game/map/signpost"
 import type { GameMap } from "@/lib/game/map/types"
 import { encodeObjectId, SIGNPOST_OBJECT_ID } from "@/lib/game/render/outline"
 
-/** Central waymarkers use the shared pixelated scenery renderer and directional timber boards. */
+/** Waymarkers use the shared pixelated scenery renderer and directional timber boards. */
 export function Signpost({ map }: { map: GameMap }) {
   const posts = useMemo(() => signpostPlacements(map).map((post, index) => ({
     ...post,

--- a/lib/game/map/crossroads.test.ts
+++ b/lib/game/map/crossroads.test.ts
@@ -3,11 +3,14 @@ import { forestTrackTiles } from "./forest-entrances"
 import { createFootpaths, foundingRoadTraffic, foundingRoadStrength } from "../footpaths"
 import { describe, expect, it } from "vitest"
 import { createCrossroads, crossroadIslandAt } from "./crossroads"
-import { type GameMap, type TilePos, tileToWorldX, tileToWorldZ } from "./types"
+import { type GameMap, type TilePos, tileAt, tileToWorldX, tileToWorldZ } from "./types"
 import { settlementRoute } from "../settlement-route"
 import { shortcutCost } from "../walking-shortcuts"
 import { cartRoute } from "../transport/route"
 import { crossroadSignpostParts } from "../building-art/structure"
+import { addRoadsideTowns } from "./roadside-towns"
+import { tJunctionVerge } from "./signpost"
+import { elevationStep } from "./elevation"
 
 function fixture(): GameMap {
   const road = Array.from({ length: 15 }, (_, x) => ({ x, z: 7 }))
@@ -25,6 +28,55 @@ function continuous(route: TilePos[]) {
 }
 
 describe("crossroads network", () => {
+  it.each([[1, 0], [-1, 0], [0, 1], [0, -1]])("puts a T marker on the missing (%i, %i) arm without changing paths", (dx, dz) => {
+    const map = fixture()
+    map.site = undefined; map.darkForests = []; map.road = []
+    map.tiles.fill("grass")
+    for (const [x, z] of [[1, 0], [-1, 0], [0, 1], [0, -1]]) {
+      if (x === dx && z === dz) continue
+      for (let i = 0; i <= 5; i++) map.tiles[(7 + z * i) * map.width + 7 + x * i] = "path"
+    }
+    const before = [...map.tiles]
+    createCrossroads(map)
+    const center = { x: 7 + dx, z: 7 + dz }
+    expect(map.crossroads).toHaveLength(1)
+    expect(map.crossroads![0].center).toEqual(center)
+    expect(map.crossroads![0].arms).toHaveLength(3)
+    expect(crossroadIslandAt(map, 7, 7)).toBe(false)
+    for (let i = 0; i < before.length; i++) {
+      expect(map.tiles[i]).toBe(i === center.z * map.width + center.x ? "clearing" : before[i])
+    }
+  })
+  it("keeps T-junction road and shrine routes unchanged", () => {
+    const map = fixture()
+    for (const p of map.darkForests![0].approach.slice(1)) map.tiles[p.z * map.width + p.x] = "grass"
+    map.darkForests = []
+    const before = JSON.stringify({ road: map.road, site: map.site })
+    createCrossroads(map)
+    expect(map.crossroads![0].center).toEqual({ x: 7, z: 6 })
+    expect(JSON.stringify({ road: map.road, site: map.site })).toBe(before)
+  })
+  it.each(["water", "darkwood"] as const)("omits a T marker when the opposite verge is %s", terrain => {
+    const map = fixture()
+    for (const p of map.darkForests![0].approach.slice(1)) map.tiles[p.z * map.width + p.x] = "grass"
+    map.darkForests = []
+    map.tiles[6 * map.width + 7] = terrain
+    const before = [...map.tiles]
+    createCrossroads(map)
+    expect(map.crossroads).toEqual([])
+    expect(map.tiles).toEqual(before)
+  })
+  it("leaves tavern approach junctions unmarked and their paths unchanged", () => {
+    const map: GameMap = { width: 400, depth: 30, tiles: Array(12000).fill("grass"), buildings: [],
+      road: Array.from({ length: 400 }, (_, x) => ({ x, z: 15 })) }
+    for (const p of map.road!) map.tiles[p.z * map.width + p.x] = "path"
+    addRoadsideTowns(map)
+    expect(map.towns!.length).toBeGreaterThan(0)
+    const before = JSON.stringify({ tiles: map.tiles, road: map.road, towns: map.towns })
+    createCrossroads(map)
+    expect(map.crossroads).toEqual([])
+    expect(JSON.stringify({ tiles: map.tiles, road: map.road, towns: map.towns })).toBe(before)
+  })
   it("shares one marked island between the church, continuing road and dark forest", () => {
     const map = fixture(); createCrossroads(map)
     expect(map.crossroads).toHaveLength(1)
@@ -70,7 +122,7 @@ describe("crossroads network", () => {
     expect(map.crossroads).toHaveLength(1); expect(map.tiles[6 * 15 + 6]).toBe("water")
     expect(map.crossroads![0].center).not.toEqual({ x: 7, z: 7 })
   })
-  it("marks boundary forks using an island on the inward side", () => {
+  it("omits boundary T markers when the opposite verge is outside the map", () => {
     const map = fixture()
     map.tiles.fill("grass")
     map.road = Array.from({ length: 15 }, (_, x) => ({ x, z: 0 }))
@@ -81,21 +133,21 @@ describe("crossroads network", () => {
     for (const p of map.site!.branch) map.tiles[p.z * 15 + p.x] = "track"
     for (const p of map.road) map.tiles[p.z * 15 + p.x] = "path"
     createCrossroads(map)
-    expect(map.crossroads).toHaveLength(1)
-    expect(map.crossroads![0].center).toEqual({ x: 7, z: 1 })
+    expect(map.crossroads).toHaveLength(0)
     expect(map.site!.branch[0]).toEqual(map.road[map.site!.junction])
     continuous(map.road); continuous(map.site!.branch)
     for (const p of [...map.road, ...map.site!.branch]) expect(crossroadIslandAt(map, p.x, p.z)).toBe(false)
   })
-  it("recognizes a bridge as a road arm and fits the island beside its landing", () => {
+  it("recognizes a bridge as a T arm and places the post across from the incoming path", () => {
     const map = fixture()
     map.tiles[7 * 15 + 6] = "bridge"
-    for (let x = 4; x < 11; x++) map.tiles[6 * 15 + x] = "water"
+    for (const p of map.darkForests![0].approach.slice(1)) map.tiles[p.z * map.width + p.x] = "grass"
     map.darkForests = []
     createCrossroads(map)
     expect(map.crossroads).toHaveLength(1)
     expect(map.crossroads![0].arms.filter(a => a.mark === "road")).toHaveLength(2)
     expect(map.tiles[7 * 15 + 6]).toBe("bridge")
+    expect(map.crossroads![0].center).toEqual({ x: 7, z: 6 })
     expect(map.site!.branch[0]).toEqual(map.road![map.site!.junction])
     continuous(map.road!); continuous(map.site!.branch)
   })
@@ -131,11 +183,18 @@ describe("generated crossroads", () => {
     }
   })
   it.each([128, 192, 256].flatMap(size => [0, 2, 3, 4, 5, 20260908].map(seed => ({ size, seed }))))(
-    "marks the shrine junction on a fresh $size-tile world, seed $seed", ({ size, seed }) => {
+    "marks the shrine junction when its verge is usable on a $size-tile world, seed $seed", ({ size, seed }) => {
       const map = generateMap({ width: size, depth: size, seed })
       const fork = map.site!.branch[0]
       expect(map.road!.length).toBeGreaterThan(0)
-      expect(map.crossroads!.some(c => Math.hypot(c.center.x - fork.x, c.center.z - fork.z) <= 4)).toBe(true)
+      if (!map.crossroads!.some(c => Math.hypot(c.center.x - fork.x, c.center.z - fork.z) <= 4)) {
+        // A T beside water, the map edge or a cliff has no safe opposite verge.
+        const verge = tJunctionVerge(map, fork)
+        expect(verge).not.toBeNull()
+        const terrain = tileAt(map, verge!.x, verge!.z)
+        expect(!terrain || ["water", "bridge", "darkwood"].includes(terrain)
+          || !Number.isFinite(elevationStep(map.elevation, fork.z * size + fork.x, verge!.z * size + verge!.x))).toBe(true)
+      }
     }, 30000)
   it("retains lightly worn forest approaches outside the canopy without marking forests at the crossroads", () => {
     const map = fixture(); createCrossroads(map); map.footpaths = createFootpaths(map)

--- a/lib/game/map/crossroads.ts
+++ b/lib/game/map/crossroads.ts
@@ -1,4 +1,5 @@
 import { elevationStep } from "./elevation"
+import { buildingApproaches } from "../building-rotation"
 import { isRoadTerrain } from "./road"
 import { ROUTE_DIRS } from "./route"
 import { tileAt, type GameMap, type TilePos } from "./types"
@@ -13,7 +14,7 @@ const distance = (a: TilePos, b: TilePos) => Math.max(Math.abs(a.x - b.x), Math.
 const RING = [[0, -1], [1, -1], [1, 0], [1, 1], [0, 1], [-1, 1], [-1, 0], [-1, -1]] as const
 
 const islands = new WeakMap<Crossroad[], Set<number>>()
-/** Reserved ground: navigation, carts and construction all leave the post's island alone. */
+/** Reserved ground: navigation, carts and construction all leave the post alone. */
 export function crossroadIslandAt(map: GameMap, x: number, z: number): boolean {
   if (!map.crossroads?.length) return false
   let cells = islands.get(map.crossroads)
@@ -61,14 +62,20 @@ function around(route: TilePos[], center: TilePos, start?: TilePos, end?: TilePo
   return { route: result, indices }
 }
 
-/** Apply once after generation. A ring uses existing terrain rendering and real walking tiles. */
+/** Apply once after generation: roadside posts at Ts, walkable rings at four-way crossings. */
 export function createCrossroads(map: GameMap): void {
   if (map.crossroads) return
   const shrine = destinationDistances(map, map.site ? [map.site.door] : [])
   const candidates: Crossroad[] = []
+  // Door tracks are building approaches, not destinations needing a waymarker.
+  // Include the road across the frontage so a post cannot move opposite the tavern.
+  const tavernEntries = map.buildings.filter(b => b.buildType === "tavern")
+    .flatMap(b => buildingApproaches(map, b))
+  const nearTavern = (p: TilePos) => tavernEntries.some(entry => distance(entry, p) <= 3)
   for (let z = 0; z < map.depth; z++) for (let x = 0; x < map.width; x++) {
     if (!isRoadTerrain(tileAt(map, x, z))) continue
     const center = { x, z }, index = key(map, center)
+    if (nearTavern(center)) continue
     const directions = ROUTE_DIRS.filter(([dx, dz]) => {
       const next = tileAt(map, x + dx, z + dz)
       return isRoadTerrain(next) || next === "bridge"
@@ -90,10 +97,26 @@ export function createCrossroads(map: GameMap): void {
   for (const crossroad of candidates) {
     const junction = crossroad.center
     if (map.crossroads.some(c => distance(c.center, junction) <= 3)) continue
+    if (crossroad.arms.length === 3) {
+      // The missing arm is across the through road from the incoming path.
+      // Leave the junction and all route indices intact; never carve a ring at a T.
+      const [dx, dz] = ROUTE_DIRS.find(([x, z]) => !crossroad.arms.some(a => a.direction.x === x && a.direction.z === z))!
+      const center = { x: junction.x + dx, z: junction.z + dz }
+      const terrain = tileAt(map, center.x, center.z)
+      if (!terrain || isRoadTerrain(terrain) || ["water", "bridge", "darkwood"].includes(terrain)) continue
+      if (nearTavern(center) || map.crossroads.some(c => distance(c.center, center) <= 2)) continue
+      if (map.buildings.some(b => center.x >= b.x - 1 && center.x <= b.x + b.w && center.z >= b.z - 1 && center.z <= b.z + b.d)) continue
+      if (map.site && same(map.site.door, center)) continue
+      if (!Number.isFinite(elevationStep(map.elevation, key(map, junction), key(map, center)))) continue
+      map.tiles[key(map, center)] = "clearing"
+      map.crossroads.push({ ...crossroad, center, junction })
+      continue
+    }
     // A junction on an edge or beside an obstacle still needs a marker. Try
     // the adjoining ground. Narrow bridge landings can use the first dry
     // corner along an outgoing track, keeping the marker beside the fork.
     const fits = (center: TilePos) => {
+      if (nearTavern(center)) return false
       if (map.crossroads!.some(c => distance(c.center, center) <= 2)) return false
       if ((map.darkForests ?? []).some(grove => distance(grove.center, center) <= 2)) return false
       if (map.site && same(map.site.door, center)) return false

--- a/lib/game/map/signpost.test.ts
+++ b/lib/game/map/signpost.test.ts
@@ -7,15 +7,25 @@ import { tileAt, tileToWorldX, tileToWorldZ, type GameMap } from "./types"
 
 describe("crossroads waymarkers", () => {
   const maps = Array.from({ length: 4 }, (_, i) => generateMap({ width: MIN_MAP_SIZE, depth: MIN_MAP_SIZE, seed: i * 7919 + 1 }))
-  it("stands in the centre of a dry island encircled by paths", () => {
+  it("stands opposite T-junctions and on dry islands at four-way crossings", () => {
     for (const map of maps) {
       const posts = signpostPlacements(map)
       expect(posts.length).toBeGreaterThan(0)
       for (const post of posts) {
         expect(tileAt(map, post.tile.x, post.tile.z)).toBe("clearing")
         expect(post.x).toBe(tileToWorldX(map, post.tile.x)); expect(post.z).toBe(tileToWorldZ(map, post.tile.z))
-        for (let dz = -1; dz <= 1; dz++) for (let dx = -1; dx <= 1; dx++) {
-          if (dx || dz) expect(["path", "track"]).toContain(tileAt(map, post.tile.x + dx, post.tile.z + dz))
+        const crossroad = map.crossroads!.find(c => c.center === post.tile)!
+        if (post.arms.length === 3) {
+          const junction = crossroad.junction!
+          expect(post.tile).toEqual({
+            x: junction.x - post.arms.reduce((sum, arm) => sum + arm.direction.x, 0),
+            z: junction.z - post.arms.reduce((sum, arm) => sum + arm.direction.z, 0),
+          })
+          expect(["path", "track"]).toContain(tileAt(map, junction.x, junction.z))
+        } else {
+          for (let dz = -1; dz <= 1; dz++) for (let dx = -1; dx <= 1; dx++) {
+            if (dx || dz) expect(["path", "track"]).toContain(tileAt(map, post.tile.x + dx, post.tile.z + dz))
+          }
         }
         expect(post.arms.length).toBeGreaterThanOrEqual(3)
       }

--- a/lib/game/map/signpost.ts
+++ b/lib/game/map/signpost.ts
@@ -2,7 +2,7 @@ import { isRoadTerrain } from "./road"
 import type { CrossroadArm } from "./crossroads"
 import { tileAt, tileToWorldX, tileToWorldZ, type GameMap, type TilePos } from "./types"
 
-/** Keep crowns, rocks and ground plants clear of every marked island. */
+/** Keep crowns, rocks and ground plants clear of every post. */
 export const SIGNPOST_CLEARANCE = 0.85
 export interface SignpostPlacement {
   tile: TilePos
@@ -11,7 +11,7 @@ export interface SignpostPlacement {
   yaw: number
 }
 
-/** The post stands at the centre of the ground its paths circle. */
+/** Posts stand on the opposite verge at Ts and on central islands at crossroads. */
 export function signpostPlacements(map: GameMap): (Omit<SignpostPlacement, "yaw"> & { arms: CrossroadArm[] })[] {
   return (map.crossroads ?? []).map(({ center, arms }) => ({
     tile: center, x: tileToWorldX(map, center.x), z: tileToWorldZ(map, center.z), arms,

--- a/lib/game/map/types.ts
+++ b/lib/game/map/types.ts
@@ -78,7 +78,7 @@ export interface DarkForest {
 }
 
 export interface GameMap {
-  /** Marked islands where the generated roads and destination tracks meet. */
+  /** Reserved signpost sites where generated roads and destination tracks meet. */
   crossroads?: import("./crossroads").Crossroad[]
   /** Independent roadside communities, indexed by distance along the main road. */
   towns?: RoadsideTown[]


### PR DESCRIPTION
Place T-junction signposts on the verge opposite the incoming path without rerouting traffic, and retain central islands for four-way crossroads.
Exclude tavern approaches and omit T-junction posts where the opposite verge is blocked, with updated comments and regression coverage for orientations, route continuity, terrain constraints, and tree clearance.

Validation: 78 focused tests, TypeScript checking, and diff whitespace checks passed.
A broader test run was stopped after failures; the isolated bridge test reproduces an existing `foundSite` crash at `lib/game/map/generate-map.ts:989` with the original code as well.
