### PR TITLE
Add map panning at screen edges

### DIFF
--- a/components/game/camera-rig.tsx
+++ b/components/game/camera-rig.tsx
@@ -7,6 +7,7 @@ import * as THREE from "three"
 import { groundHeight } from "@/lib/game/map/elevation"
 import { surfaceHeight, ropeHeightAt } from "@/lib/game/map/bridges"
 import { CameraGesture } from "@/lib/game/camera-gesture"
+import { cameraEdgePan } from "@/lib/game/camera-edge-pan"
 import { useBuildStore } from "@/lib/game/build-store"
 import { useCameraStore } from "@/lib/game/camera-store"
 import { worldToTileX, worldToTileZ, type GameMap, type TilePos } from "@/lib/game/map/types"
@@ -23,7 +24,7 @@ import {
 /** How fast the yaw and zoom tweens converge. Higher = snappier. */
 const TWEEN_LAMBDA = 9
 
-/** Keyboard pan speed, in world units per second at the default zoom. */
+/** Keyboard and edge pan speed, in world units per second at the default zoom. */
 const KEY_PAN_SPEED = 18
 
 export function CameraRig({ map, onPlace }: { map: GameMap; onPlace?: (at: TilePos) => void }) {
@@ -34,6 +35,8 @@ export function CameraRig({ map, onPlace }: { map: GameMap; onPlace?: (at: TileP
   const displayYaw = useRef(yawForView(useCameraStore.getState().viewIndex))
   const displayViewSize = useRef(useCameraStore.getState().viewSize)
   const heldKeys = useRef(new Set<string>())
+  const edgePointer = useRef<PointerEvent | null>(null)
+  const refreshHover = useRef<((event: PointerEvent) => void) | null>(null)
 
   const minPickY = useMemo(() => (map.water?.surface?.reduce((a, b) => Math.min(a, b), 0) ?? 0) - 0.5, [map.water])
   const pickPlane = useRef(new THREE.Plane(new THREE.Vector3(0, 1, 0), -4.3))
@@ -86,14 +89,22 @@ export function CameraRig({ map, onPlace }: { map: GameMap; onPlace?: (at: TileP
       }
       setHovered(null)
     }
+    refreshHover.current = updateHover
+
+    const trackEdgePointer = (event: PointerEvent) => {
+      edgePointer.current = event.pointerType === "mouse" && event.buttons === 0 && !gesture.active
+        ? event : null
+    }
 
     const onPointerDown = (event: PointerEvent) => {
+      edgePointer.current = null
       gesture.start(event.pointerId, point(event))
       canvas.setPointerCapture(event.pointerId)
       if (gesture.pinching) setHovered(null)
     }
 
     const onPointerMove = (event: PointerEvent) => {
+      trackEdgePointer(event)
       const movement = gesture.move(event.pointerId, point(event))
       if (!movement) {
         if (event.pointerType !== "touch") updateHover(event)
@@ -125,6 +136,8 @@ export function CameraRig({ map, onPlace }: { map: GameMap; onPlace?: (at: TileP
     const endDrag = (event: PointerEvent) => {
       if (!gesture.has(event.pointerId)) return
       const tap = gesture.end(event.pointerId, point(event), event.type !== "pointerup")
+      if (event.type === "pointerup") trackEdgePointer(event)
+      else edgePointer.current = null
       if (canvas.hasPointerCapture(event.pointerId)) canvas.releasePointerCapture(event.pointerId)
       canvas.style.cursor = gesture.active ? "grabbing" : "grab"
       if (tap && event.button === 0) {
@@ -144,13 +157,16 @@ export function CameraRig({ map, onPlace }: { map: GameMap; onPlace?: (at: TileP
       }
     }
     const onBlur = () => {
+      edgePointer.current = null
       gesture.clear()
       setHovered(null)
       canvas.style.cursor = "grab"
     }
     const onPointerLeave = () => {
+      edgePointer.current = null
       if (!gesture.active) setHovered(null)
     }
+    const onVisibilityChange = () => { if (document.hidden) onBlur() }
 
     // Suppress the context menu so right-drag panning stays available later.
     const onContextMenu = (event: Event) => event.preventDefault()
@@ -160,6 +176,8 @@ export function CameraRig({ map, onPlace }: { map: GameMap; onPlace?: (at: TileP
     canvas.addEventListener("click", onClick, true)
     canvas.addEventListener("lostpointercapture", endDrag)
     window.addEventListener("blur", onBlur)
+    document.addEventListener("visibilitychange", onVisibilityChange)
+    canvas.addEventListener("pointerenter", trackEdgePointer)
     canvas.addEventListener("pointermove", onPointerMove, true)
     canvas.addEventListener("pointerup", endDrag)
     canvas.addEventListener("pointercancel", endDrag)
@@ -167,11 +185,15 @@ export function CameraRig({ map, onPlace }: { map: GameMap; onPlace?: (at: TileP
     canvas.addEventListener("contextmenu", onContextMenu)
 
     return () => {
+      edgePointer.current = null
+      refreshHover.current = null
       canvas.style.touchAction = previousTouchAction
       canvas.removeEventListener("pointerdown", onPointerDown, true)
       canvas.removeEventListener("click", onClick, true)
       canvas.removeEventListener("lostpointercapture", endDrag)
       window.removeEventListener("blur", onBlur)
+      document.removeEventListener("visibilitychange", onVisibilityChange)
+      canvas.removeEventListener("pointerenter", trackEdgePointer)
       canvas.removeEventListener("pointermove", onPointerMove, true)
       canvas.removeEventListener("pointerup", endDrag)
       canvas.removeEventListener("pointercancel", endDrag)
@@ -271,6 +293,7 @@ export function CameraRig({ map, onPlace }: { map: GameMap; onPlace?: (at: TileP
     const { viewIndex, viewSize, pan, inputLocked } = useCameraStore.getState()
     if (inputLocked) {
       heldKeys.current.clear()
+      edgePointer.current = null
       displayYaw.current = yawForView(viewIndex)
       displayViewSize.current = viewSize
     }
@@ -290,18 +313,31 @@ export function CameraRig({ map, onPlace }: { map: GameMap; onPlace?: (at: TileP
       dt,
     )
 
-    // Keyboard panning is screen-relative, so it follows the current rotation.
+    // Edge and keyboard panning follow the current camera rotation.
+    let edge = { strafe: 0, forward: 0 }
+    const pointer = edgePointer.current
+    if (pointer && !document.hidden) {
+      const canvas = gl.domElement
+      edge = cameraEdgePan(pointer.clientX, pointer.clientY, canvas.getBoundingClientRect())
+      // Hit-test each frame: a panel can open under a stationary cursor.
+      if ((edge.strafe || edge.forward) && document.elementFromPoint(pointer.clientX, pointer.clientY) !== canvas) {
+        edge = { strafe: 0, forward: 0 }
+        edgePointer.current = null
+      }
+    }
     const keys = heldKeys.current
     const up = keys.has("w") || keys.has("arrowup")
     const down = keys.has("s") || keys.has("arrowdown")
     const left = keys.has("a") || keys.has("arrowleft")
     const right = keys.has("d") || keys.has("arrowright")
-    if (up || down || left || right) {
+    const keyboardPan = up || down || left || right
+    const edgePanning = !keyboardPan && (edge.forward !== 0 || edge.strafe !== 0)
+    if (keyboardPan || edgePanning) {
       const basis = screenBasis(displayYaw.current)
       // Scale with zoom so panning feels the same at every zoom level.
       const speed = KEY_PAN_SPEED * (displayViewSize.current / 26) * dt
-      const forward = (up ? 1 : 0) - (down ? 1 : 0)
-      const strafe = (right ? 1 : 0) - (left ? 1 : 0)
+      const forward = keyboardPan ? (up ? 1 : 0) - (down ? 1 : 0) : edge.forward
+      const strafe = keyboardPan ? (right ? 1 : 0) - (left ? 1 : 0) : edge.strafe
       pan(
         basis.fwdX * forward * speed + basis.rightX * strafe * speed,
         basis.fwdZ * forward * speed + basis.rightZ * strafe * speed,
@@ -326,6 +362,8 @@ export function CameraRig({ map, onPlace }: { map: GameMap; onPlace?: (at: TileP
     // Culling, sprite poses, and their batch view anchors must all observe the
     // same transform that the final world and character passes will render.
     cam.updateMatrixWorld()
+    // Building previews must follow the tile moving under a stationary cursor.
+    if (edgePanning && pointer) refreshHover.current?.(pointer)
   }, -4)
 
   return null

--- a/lib/game/camera-edge-pan.test.ts
+++ b/lib/game/camera-edge-pan.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest"
+import { cameraEdgePan } from "./camera-edge-pan"
+
+const bounds = { left: 100, top: 50, right: 900, bottom: 650 }
+
+describe("camera edge panning", () => {
+  it("pans toward each edge of an offset viewport", () => {
+    expect(cameraEdgePan(100, 350, bounds)).toEqual({ strafe: -1, forward: 0 })
+    expect(cameraEdgePan(900, 350, bounds)).toEqual({ strafe: 1, forward: 0 })
+    expect(cameraEdgePan(500, 50, bounds)).toEqual({ strafe: 0, forward: 1 })
+    expect(cameraEdgePan(500, 650, bounds)).toEqual({ strafe: 0, forward: -1 })
+  })
+
+  it("ramps up within the edge band and stays still in the interior", () => {
+    expect(cameraEdgePan(112, 350, bounds)).toEqual({ strafe: -0.5, forward: 0 })
+    expect(cameraEdgePan(124, 350, bounds)).toEqual({ strafe: 0, forward: 0 })
+    expect(cameraEdgePan(500, 350, bounds)).toEqual({ strafe: 0, forward: 0 })
+  })
+
+  it("caps diagonal speed at every corner", () => {
+    for (const x of [bounds.left, bounds.right]) for (const y of [bounds.top, bounds.bottom]) {
+      const { strafe, forward } = cameraEdgePan(x, y, bounds)
+      expect(Math.hypot(strafe, forward)).toBeCloseTo(1)
+      expect(Math.sign(strafe)).toBe(x === bounds.left ? -1 : 1)
+      expect(Math.sign(forward)).toBe(y === bounds.top ? 1 : -1)
+    }
+  })
+
+  it("does not pan outside the canvas or in an empty viewport", () => {
+    for (const [x, y] of [[99, 350], [901, 350], [500, 49], [500, 651]]) {
+      expect(cameraEdgePan(x, y, bounds)).toEqual({ strafe: 0, forward: 0 })
+    }
+    expect(cameraEdgePan(0, 0, { left: 0, top: 0, right: 0, bottom: 0 })).toEqual({ strafe: 0, forward: 0 })
+  })
+
+  it("keeps the center of a small canvas neutral", () => {
+    expect(cameraEdgePan(10, 10, { left: 0, top: 0, right: 20, bottom: 20 })).toEqual({ strafe: 0, forward: 0 })
+  })
+})

--- a/lib/game/camera-edge-pan.ts
+++ b/lib/game/camera-edge-pan.ts
@@ -1,0 +1,21 @@
+/** A narrow band in CSS pixels, independent of render resolution and zoom. */
+const EDGE_PAN_BAND = 24
+
+/** Screen-relative input: right is positive X, up is positive Y. */
+export function cameraEdgePan(
+  x: number,
+  y: number,
+  bounds: { left: number; top: number; right: number; bottom: number },
+): { strafe: number; forward: number } {
+  const width = bounds.right - bounds.left, height = bounds.bottom - bounds.top
+  if (width <= 0 || height <= 0 || x < bounds.left || x > bounds.right || y < bounds.top || y > bounds.bottom) {
+    return { strafe: 0, forward: 0 }
+  }
+  const bandX = Math.min(EDGE_PAN_BAND, width / 2), bandY = Math.min(EDGE_PAN_BAND, height / 2)
+  const strength = (distance: number, band: number) => Math.max(0, 1 - distance / band)
+  const strafe = strength(bounds.right - x, bandX) - strength(x - bounds.left, bandX)
+  const forward = strength(y - bounds.top, bandY) - strength(bounds.bottom - y, bandY)
+  // Corners move diagonally without exceeding the maximum pan speed.
+  const length = Math.max(1, Math.hypot(strafe, forward))
+  return { strafe: strafe / length, forward: forward / length }
+}


### PR DESCRIPTION
Moving the mouse within 24 pixels of the map viewport edge now pans toward that edge, with gradual speed, diagonal movement, and camera rotation and zoom respected.
Scrolling pauses during dragging, over UI controls, when input is locked, and when the window loses focus; hovered tiles refresh during scrolling to keep building previews aligned.
Added unit coverage for edge directions, speed ramping, corners, and viewport bounds.
Validation: all 9 camera tests and TypeScript checks passed, and Playwright verified every edge at all four rotations plus stopping behavior without page errors.
