### PR TITLE
Reserve tree thinning for sustained FPS drops

### DIFF
--- a/components/game/foliage-field.tsx
+++ b/components/game/foliage-field.tsx
@@ -15,7 +15,7 @@ import { encodeObjectId, OUTLINE_ID_LAYER_MASK, treeObjectId } from "@/lib/game/
 import { makeRng } from "@/lib/game/rng"
 import { useBuildStore } from "@/lib/game/build-store"
 import { isWorldVisible } from "@/lib/game/render/visibility"
-import { sceneryDetail } from "@/lib/game/render/scenery-detail"
+import { frameQuality } from "@/lib/game/render/frame-quality"
 import { useCameraStore } from "@/lib/game/camera-store"
 
 export interface FoliagePlacement extends TreePlacement { foliageVariant?: number }
@@ -85,7 +85,9 @@ export function FoliageField({ atlas, placements, seed = 1, idBase = 0, hidden, 
     const mesh = body.current, ids = idMesh.current
     if (mesh && ids) {
       mesh.updateWorldMatrix(true, false)
-      const thin = sceneryDetail(scene) === 2, selection = useCameraStore.getState().selection
+      // Halving the forest is a last resort for sustained FPS pressure; zoom
+      // detail alone must preserve every tree.
+      const thin = frameQuality(scene) === 2, selection = useCameraStore.getState().selection
       data.instances.update(mesh, currentCamera, thin, selection?.kind === "tree" ? selection.id : -1)
       ids.count = mesh.count
       mesh.userData.totalTrees = entries.length


### PR DESCRIPTION
Zooming out previously halved the rendered tree sprites even when performance was healthy.
Tree thinning now activates only at the highest sustained FPS-pressure level, preserving full tree density during normal zoom and restoring it through the existing recovery logic.
Validation: typecheck and all 12 relevant frame-quality, scenery-detail, and foliage-instance tests passed; the foliage test required a longer timeout.
