### PR TITLE
Keep dark path textures inside forest boundaries

### DIFF
--- a/components/game/terrain-tiles.tsx
+++ b/components/game/terrain-tiles.tsx
@@ -701,7 +701,7 @@ export function TerrainTiles(props: TerrainProps) {
     texture.minFilter = texture.magFilter = THREE.NearestFilter
     texture.needsUpdate = true
     return { texture, atlas: shadowAtlas, floor: forestFloor, grain: edgeGrain, size: new THREE.Vector2(map.width, map.depth) }
-  }, [map.tiles, map.width, map.depth, map.shortcuts, map.darkForests, trees, felledTrees, shadowAtlas, forestFloor, edgeGrain])
+  }, [map.tiles, map.width, map.depth, map.shortcuts, map.darkForests, map.darkForestFloor, trees, felledTrees, shadowAtlas, forestFloor, edgeGrain])
   useEffect(() => () => treeGround.texture.dispose(), [treeGround])
 
   const tier = ROAD_TIERS[clampRoadTier(props.roadTier ?? DEFAULT_ROAD_TIER)]

--- a/lib/game/map/generate-map.ts
+++ b/lib/game/map/generate-map.ts
@@ -620,6 +620,7 @@ export function generateMap(options: GenerateMapOptions): GameMap {
   // dark-shade field so it also covers the clearings and trails threading the
   // old growth: without that, the road would happily ride a one-tile game
   // trail straight through the middle.
+  const darkForestFloor = tiles.flatMap((terrain, i) => terrain === "darkwood" ? [i] : [])
   const darkShade = computeDarkShade({ width, depth, tiles, buildings: [] })
   const darkPenalty = (i: number) =>
     tiles[i] === "darkwood" ? DARK_ROAD_COST : DARK_ROAD_COST * darkShade[i]
@@ -864,6 +865,7 @@ export function generateMap(options: GenerateMapOptions): GameMap {
     road,
     shortcuts,
     darkForests,
+    darkForestFloor,
     site,
     water: waterInfo,
   }

--- a/lib/game/map/types.ts
+++ b/lib/game/map/types.ts
@@ -110,6 +110,8 @@ export interface GameMap {
   shortcuts?: Shortcut[]
   /** Ancient groves, including those away from the main road. */
   darkForests?: DarkForest[]
+  /** Original old-growth tile indices, before roads and their shoulders clear trees. */
+  darkForestFloor?: number[]
   /** Present on generated maps: the relic's hovel and the branch that reaches it. */
   site?: FoundingSite
 }

--- a/lib/game/trees/ground.test.ts
+++ b/lib/game/trees/ground.test.ts
@@ -43,6 +43,31 @@ describe("forest depth shadow tiles", () => {
     expect(Array.from(shadows.slice(4 * 9, 5 * 9))).toEqual([1, 1, 2, 3, 3, 3, 2, 1, 1])
   })
 
+  it.each(["approach", "shortcut"] as const)("keeps a %s and its shoulders standard until entering the forest", routeKind => {
+    const map = parseAsciiMap([
+      "..........",
+      ".....DDD..",
+      ".--------.",
+      ".....DDD..",
+      "..........",
+    ])
+    const route = Array.from({ length: 8 }, (_, i) => ({ x: i + 1, z: 2 }))
+    // Record the old-growth footprint before carving the track and verges.
+    map.darkForestFloor = []
+    for (let z = 1; z <= 3; z++) for (let x = 5; x <= 7; x++) {
+      map.darkForestFloor.push(z * map.width + x)
+      map.tiles[z * map.width + x] = z === 2 ? "track" : "clearing"
+    }
+    map.tiles[map.width + 4] = "clearing"
+    if (routeKind === "approach") map.darkForests = [{ center: route[6], clearing: [], approach: route }]
+    else map.shortcuts = [{ entry: 0, exit: 7, tiles: route }]
+    const field = treeGroundField(map, [])
+    const dark = (x: number, z: number) => field.data[(z * map.width + x) * 4 + 1]
+    for (const x of [1, 2, 3, 4, 8]) expect(dark(x, 2)).toBe(0)
+    expect(dark(4, 1)).toBe(0)
+    for (const x of [5, 6, 7]) for (const z of [1, 2, 3]) expect(dark(x, z)).toBe(255)
+  })
+
   it("keeps isolated trees dim regardless of the number of trunks on that tile", () => {
     const map = woods(9), single = [tree(map, 4, 4)]
     expect(treeCanopyDepth(map, single)[4 * 9 + 4]).toBe(1)

--- a/lib/game/trees/ground.ts
+++ b/lib/game/trees/ground.ts
@@ -81,12 +81,15 @@ export function treeGroundField(map: GameMap, trees: readonly TreePlacement[], f
   // and the shoulders of forest tracks retain the same dark litter artwork.
   const dark = new Set(map.tiles.flatMap((t, i) => t === "darkwood" ? [i] : []))
   for (const forest of map.darkForests ?? []) for (const p of forest.clearing) dark.add(p.z * map.width + p.x)
+  // Preserve the forest edge even where cutting a track removed its trees.
+  // An authored route may cross open meadow long before reaching old growth.
+  const forestFloor = new Set(map.darkForestFloor ?? dark)
   for (const i of forestTrackTiles(map)) {
-    dark.add(i)
+    if (forestFloor.has(i)) dark.add(i)
     const x = i % map.width, z = Math.floor(i / map.width)
     for (const [dx, dz] of [[1, 0], [-1, 0], [0, 1], [0, -1]]) {
       const nx = x + dx, nz = z + dz, n = nz * map.width + nx
-      if (nx >= 0 && nz >= 0 && nx < map.width && nz < map.depth && map.tiles[n] === "clearing") dark.add(n)
+      if (nx >= 0 && nz >= 0 && nx < map.width && nz < map.depth && map.tiles[n] === "clearing" && forestFloor.has(n)) dark.add(n)
     }
   }
   const corners = depthBandCorners(map, Array.from(depths), true)


### PR DESCRIPTION
Forest approaches and shortcuts previously carried dark forest-floor artwork across open meadow; they now retain standard ground textures until entering the forest, while grove clearings stay dark.
Map generation preserves the original old-growth footprint before cutting paths and shoulders, and the renderer uses it to select dark floor tiles.

Validation: all 100 tests in the ground, forest-entrance, and map-generation suites passed, including regression coverage for approach and shortcut boundaries; `npm run typecheck` and `git diff --check` also passed.
