### PR TITLE
Fix cart detours around buildings and increase roadside town setbacks

### DIFF
--- a/lib/game/map/crossroads.test.ts
+++ b/lib/game/map/crossroads.test.ts
@@ -94,8 +94,8 @@ describe("crossroads network", () => {
     expect(map.tiles).toEqual(before)
   })
   it("leaves tavern approach junctions unmarked and their paths unchanged", () => {
-    const map: GameMap = { width: 400, depth: 30, tiles: Array(12000).fill("grass"), buildings: [],
-      road: Array.from({ length: 400 }, (_, x) => ({ x, z: 15 })) }
+    const map: GameMap = { width: 400, depth: 34, tiles: Array(13600).fill("grass"), buildings: [],
+      road: Array.from({ length: 400 }, (_, x) => ({ x, z: 17 })) }
     for (const p of map.road!) map.tiles[p.z * map.width + p.x] = "path"
     addRoadsideTowns(map)
     expect(map.towns!.length).toBeGreaterThan(0)

--- a/lib/game/map/roadside-towns.test.ts
+++ b/lib/game/map/roadside-towns.test.ts
@@ -2,7 +2,7 @@ import { ROUTE_EDGE_INSET } from "./route-bounds"
 import { tavernWalkingRoute } from "../tavern-navigation"
 import { tileToWorldX, tileToWorldZ } from "./types"
 import { describe, expect, it } from "vitest"
-import { addRoadsideTowns, TOWN_SPACING, TOWN_CHAPEL_CLEARANCE, TOWN_APPROACH_CLEARANCE } from "./roadside-towns"
+import { addRoadsideTowns, TOWN_SPACING, TOWN_CHAPEL_CLEARANCE, TOWN_APPROACH_CLEARANCE, TOWN_ROAD_SETBACK } from "./roadside-towns"
 import { generateMap } from "./generate-map"
 import { type GameMap, tileAt } from "./types"
 import { tavernVisitPlan, servingHouses } from "../tavern"
@@ -13,9 +13,9 @@ import { enclaveHousing } from "../housing"
 import { buildInfluence } from "../build-influence"
 
 function roadMap(): GameMap {
-  const width = 400, depth = 30
+  const width = 400, depth = 34
   const map: GameMap = { width, depth, tiles: Array(width * depth).fill("grass"), buildings: [],
-    road: Array.from({ length: width }, (_, x) => ({ x, z: 15 })) }
+    road: Array.from({ length: width }, (_, x) => ({ x, z: 17 })) }
   for (const p of map.road!) map.tiles[p.z * width + p.x] = "path"
   return map
 }
@@ -29,6 +29,8 @@ describe("independent roadside towns", () => {
       const buildings = map.buildings.filter(b => b.townId === town.id)
       expect(buildings.map(b => b.buildType)).toEqual(["tavern", "house", "well"])
       expect(buildings.every(b => b.owner === "independent" && !b.construction)).toBe(true)
+      const entry = buildingEntry(buildings[0]), junction = map.road![town.junction]
+      expect(Math.hypot(entry.x - junction.x, entry.z - junction.z)).toBe(TOWN_ROAD_SETBACK)
       if (i) {
         expect(town.junction - map.towns![i - 1].junction).toBe(TOWN_SPACING)
         expect(TOWN_SPACING).toBe(192)
@@ -68,7 +70,7 @@ describe("independent roadside towns", () => {
     // The nominal second site at x=288 is flooded; the next dry town must
     // remain outside the first tavern's circle while finding accessible land.
     for (let z = 0; z < map.depth; z++) for (let x = 280; x < 310; x++) {
-      if (z !== 15) map.tiles[z * map.width + x] = "water"
+      if (z !== 17) map.tiles[z * map.width + x] = "water"
     }
     addRoadsideTowns(map)
     expect(map.towns).toHaveLength(2)
@@ -79,7 +81,7 @@ describe("independent roadside towns", () => {
 
   it("contributes no jobs, housing, renown or building influence", () => {
     const map = roadMap()
-    map.site = { junction: 200, branch: [{ x: 200, z: 15 }], door: { x: 200, z: 15 }, hovelId: "absent" }
+    map.site = { junction: 200, branch: [{ x: 200, z: 17 }], door: { x: 200, z: 17 }, hovelId: "absent" }
     const influence = buildInfluence(map)
     addRoadsideTowns(map)
     expect(jobBuildings(map)).toEqual([])
@@ -103,6 +105,13 @@ describe("independent roadside towns", () => {
       expect(tavernWalkingRoute(map, visit!.seat!.point, { x: tileToWorldX(map, road.x), z: tileToWorldZ(map, road.z), y: .2 })).toBeTruthy()
       for (const id of town.buildingIds) {
         const building = map.buildings.find(b => b.id === id)!
+        if (building.buildType === "tavern" || building.buildType === "house") {
+          for (const p of map.road!) {
+            const dx = Math.max(building.x - p.x, p.x - (building.x + building.w - 1), 0)
+            const dz = Math.max(building.z - p.z, p.z - (building.z + building.d - 1), 0)
+            expect(Math.max(dx, dz), "road bends also leave a clear verge").toBeGreaterThan(TOWN_ROAD_SETBACK)
+          }
+        }
         for (const entry of buildingApproaches(map, building)) {
           const pathMap = { ...map, tiles: map.tiles.map(t => t === "path" || t === "track" || t === "bridge" ? t : "forest" as const) }
           expect(settlementRoute(pathMap, pathMap.buildings, road, entry), "every entrance has a continuous path").not.toBeNull()

--- a/lib/game/map/roadside-towns.ts
+++ b/lib/game/map/roadside-towns.ts
@@ -10,13 +10,15 @@ import { tileAt, type BuildingDef, type GameMap, type RoadsideTown, type TilePos
 export const TOWN_SPACING = 192
 export const TOWN_CHAPEL_CLEARANCE = 48
 export const TOWN_APPROACH_CLEARANCE = 20
+/** Entrance distance from the main road; leave room for passing horse carts. */
+export const TOWN_ROAD_SETBACK = 3
 const NAMES = ["Alderford", "Hazelwick", "Birch End", "Willowbank", "Oakstead", "Ashbrook", "Elm Hollow", "Reedham"]
 
 /** The house sits beside the tavern, with parallel roof ridges and aligned fronts. */
 function townPlan(map: GameMap, junction: number, rotation: BuildingRotation, ordinal: number) {
   const road = map.road![junction]
   const outward = rotateBuildingPoint(0, -1, rotation)
-  const entry = { x: road.x + outward.x * 2, z: road.z + outward.z * 2 }
+  const entry = { x: road.x + outward.x * TOWN_ROAD_SETBACK, z: road.z + outward.z * TOWN_ROAD_SETBACK }
   // A winding road may pass close to an earlier town long after leaving it.
   // Check every existing tavern in map space, independent of travel duration.
   if (map.towns?.some(town => {
@@ -44,9 +46,13 @@ function townPlan(map: GameMap, junction: number, rotation: BuildingRotation, or
   const bottom = Math.max(...buildings.map(b => b.z + b.d)) + 1
   const patch: TilePos[] = []
   for (let tz = z; tz < bottom; tz++) for (let tx = x; tx < right; tx++) patch.push({ x: tx, z: tz })
-  patch.push(road, { x: road.x + outward.x, z: road.z + outward.z })
+  for (let step = 0; step < TOWN_ROAD_SETBACK; step++) {
+    patch.push({ x: road.x + outward.x * step, z: road.z + outward.z * step })
+  }
   const occupied = (p: TilePos, b: BuildingDef, margin = 0) => p.x >= b.x - margin && p.x < b.x + b.w + margin
     && p.z >= b.z - margin && p.z < b.z + b.d + margin
+  // Protect every nearby bend, not just the road tile facing the tavern door.
+  if (buildings.some(b => map.road!.some(p => occupied(p, b, TOWN_ROAD_SETBACK)))) return null
   const chapel = map.buildings.find(b => b.id === map.site?.hovelId)
   if (chapel && buildings.some(b => Math.hypot(
     Math.max(chapel.x - b.x - b.w, b.x - chapel.x - chapel.w, 0),

--- a/lib/game/sim.ts
+++ b/lib/game/sim.ts
@@ -14,8 +14,9 @@ import { buildingSpatialQuery } from "./building-spatial"
 import { settlementJob, jobSpeedScale } from "./jobs/design"
 import { seekSheep, stepShepherd, releaseSheep, type HerdingTask } from "./herding"
 import type { WildlifeWorld } from "./wildlife/simulation"
-import { cartPath, driveSegment, marketParking, type MarketParking } from "./transport/building-parking"
+import { cartPath, driveSegment, driveRouteSegment, marketParking, type MarketParking } from "./transport/building-parking"
 import { roadCartPose } from "./transport/bridge-guide"
+import { cartRoadDiversion } from "./transport/road-diversion"
 import { blockedRoad, findRoadDiversion, takeRoadShortcut, retireBypassedRoad, exploresRoadShortcut, type WalkingShortcut } from "./walking-shortcuts"
 import { createFootpaths, HEAVY_PATH_WEAR, recordWalkingPath, regrowFootpaths, type Footpaths } from "./footpaths"
 import { knightMounted, knightLoadout, knightTravelSpeed, knightWalkStride, type HorseRest } from "./knights"
@@ -591,9 +592,13 @@ function finishConvoyMove(s: SimTraveler, transportBefore: SimTraveler | null, m
   const previous = transportBefore.cartPose ?? roadCartPose(map, transportBefore.progress, s.direction, wheelbase, characterScale)
   const wrapped = Math.abs(s.progress - transportBefore.progress) > length / 2 && !s.track && !transportBefore.track
   const parking = s.marketParking ?? s.shrineParking
+  const cut = transportBefore.roadShortcut ?? s.roadShortcut
   let pose: CartPose | null
   if (wrapped) pose = roadCartPose(map, s.progress, s.direction, wheelbase, characterScale)
   else if (parking && !parking.walking) pose = parking.pose
+  else if (cut) pose = driveRouteSegment(previous, [cut.from, ...(cut.via ?? []), cut.to],
+    transportBefore.roadShortcut?.distance ?? 0, s.roadShortcut?.distance ?? cut.length, wheelbase,
+    (p, heading) => convoyBuildingsClear(map, p, puller, characterScale, heading))
   else {
     pose = driveSegment(previous, s, wheelbase, (p, heading) => convoyBuildingsClear(map, p, puller, characterScale, heading))
     if (pose && !parking && !s.track && !s.roadShortcut && !transportBefore.roadShortcut &&
@@ -2250,14 +2255,12 @@ export function stepSim(
           if (s.diversionCheck !== check || s.diversionBuildings !== map.buildings) {
             s.diversionCheck = check
             s.diversionBuildings = map.buildings
-            diversion = findRoadDiversion(map, blockedRoad(map), { x: s.x, z: s.z }, s.progress, direction,
-              p => s.convoy ? convoyPoint(map, p) : roadWorldPoint(map, p, s.lane))
-            if (diversion && s.convoy) {
+            if (s.convoy) {
               const puller = cartLoadout(s.id).puller
               const initial = s.cartPose ?? roadCartPose(map, s.progress, direction, -cartOffset(puller) * characterScale, characterScale)
-              const drive = cartPath(map, initial, diversion.to, puller, characterScale, parkingContext(sim, s, characterScale))
-              diversion = drive ? { ...diversion, via: drive.entry.slice(1, -1), length: routeLength(drive.entry) } : null
-            }
+              diversion = cartRoadDiversion(map, initial, s.progress, direction, puller, characterScale, () => parkingContext(sim, s, characterScale))
+            } else diversion = findRoadDiversion(map, blockedRoad(map), { x: s.x, z: s.z }, s.progress, direction,
+              p => roadWorldPoint(map, p, s.lane))
           }
         }
         const site = map.site

--- a/lib/game/transport/building-parking.test.ts
+++ b/lib/game/transport/building-parking.test.ts
@@ -62,6 +62,29 @@ describe("market cart yard", () => {
 })
 
 describe("cart building collisions", () => {
+  it.each([[1, .1, 8], [-1, .1, 26], [1, 1.25, 8], [-1, 1.25, 26], [1, .1, 16.2], [-1, .1, 15.8]] as const)(
+    "passes a tavern on the inside of a road bend in direction %s with dt %s from %s", (direction, dt, start) => {
+    const { map } = fixture()
+    map.road = [
+      ...Array.from({ length: 17 }, (_, x) => ({ x, z: 11 })),
+      ...Array.from({ length: 18 }, (_, z) => ({ x: 16, z: z + 12 })),
+    ]
+    for (const p of map.road) map.tiles[p.z * map.width + p.x] = "path"
+    map.buildings[0] = { ...map.buildings[0], buildType: "tavern", x: 13, z: 12, w: 3, d: 3 }
+    const traveler = generateTravelers(1, 1)[0]
+    Object.assign(traveler, { id: 8, type: TRAVELER_TYPES.vendor, direction, offset: start / 34, pace: 1 })
+    Object.assign(traveler.attributes, { piety: 0, hunger: 100, thirst: 100, stamina: 100 })
+    const sim = createSim([traveler], map), s = sim.travelers.get(8)!
+    s.timer = 10000
+    for (let i = 0; i < Math.ceil(35 / dt); i++) {
+      stepSim(sim, [traveler], map, 1, dt)
+      expect(convoyBuildingsClear(map, s.cartPose!, "horse", 1.5)).toBe(true)
+      if (direction * (s.progress - 16) > 8) break
+    }
+    expect(direction * (s.progress - 16)).toBeGreaterThan(8)
+    expect(s.roadShortcut).toBeUndefined()
+  })
+
   it("finds buildings beside a long convoy's axle and observes in-place footprint moves", () => {
     const { map } = fixture()
     map.buildings[0] = { ...map.buildings[0], buildType: "tavern", x: 13, z: 12, w: 2, d: 3 }

--- a/lib/game/transport/building-parking.ts
+++ b/lib/game/transport/building-parking.ts
@@ -5,7 +5,7 @@ import { tileToWorldX, tileToWorldZ, type BuildingDef, type GameMap } from "../m
 import { cartOffset, type Puller } from "./assets"
 import { alignCart, followCart, type CartPose } from "./follow"
 import { parkingClear, type ParkingContext, type ShrineParking } from "./navigation"
-import type { Point } from "./roadside"
+import { routePoint, type Point } from "./roadside"
 
 export interface MarketParking extends ShrineParking { buildingId: string }
 
@@ -20,6 +20,22 @@ export function driveSegment(pose: CartPose, to: Point, wheelbase: number, clear
     if (!clear(pose, heading)) return null
   }
   return pose
+}
+
+/** Preserve every planned bend when one simulation tick crosses several
+ * waypoints; a chord between tick endpoints can drag the axle into a wall. */
+export function driveRouteSegment(pose: CartPose, route: readonly Point[], start: number, end: number,
+  wheelbase: number, clear: (pose: CartPose, heading: number) => boolean): CartPose | null {
+  let distance = 0
+  for (let i = 1; i < route.length; i++) {
+    distance += Math.hypot(route[i].x - route[i - 1].x, route[i].z - route[i - 1].z)
+    if (distance >= end) break
+    if (distance <= start) continue
+    const next = driveSegment(pose, route[i], wheelbase, clear)
+    if (!next) return null
+    pose = next
+  }
+  return driveSegment(pose, routePoint(route, end), wheelbase, clear)
 }
 
 /** Bounded forward-only search. Heading is part of the state: a pedestrian

--- a/lib/game/transport/road-diversion.ts
+++ b/lib/game/transport/road-diversion.ts
@@ -1,0 +1,48 @@
+import { mapBuildingQuery } from "../building-spatial"
+import type { GameMap } from "../map/types"
+import type { WalkingShortcut } from "../walking-shortcuts"
+import { cartOffset, type Puller } from "./assets"
+import { cartPath } from "./building-parking"
+import { roadCartPose } from "./bridge-guide"
+import type { CartPose } from "./follow"
+import { convoyBuildingsClear, convoyPoint, type ParkingContext } from "./navigation"
+import { advanceCartProgress } from "./route"
+import { routeLength } from "./roadside"
+
+/** Notice walls with the whole moving convoy, including the axle cutting the
+ * inside of a bend whose road tiles are all open to pedestrians. */
+export function cartRoadDiversion(map: GameMap, initial: CartPose, progress: number, direction: 1 | -1,
+  puller: Puller, scale: number, getContext: () => ParkingContext): WalkingShortcut | null {
+  const wheelbase = -cartOffset(puller) * scale, lookahead = wheelbase + 4
+  const nearby = mapBuildingQuery(map, Math.ceil(lookahead + wheelbase + 2))
+  if (!nearby({ x: initial.hitch.x + (map.width - 1) / 2, z: initial.hitch.z + (map.depth - 1) / 2 }).length) return null
+  const last = (map.road?.length ?? 1) - 1
+  let pose = initial, at = progress, blocked: number | undefined
+  for (let distance = .1; distance <= lookahead; distance += .1) {
+    const next = advanceCartProgress(map, at, direction * .1)
+    if (next < 0 || next > last) break
+    const hitch = convoyPoint(map, next)
+    const heading = Math.atan2(hitch.x - pose.hitch.x, hitch.z - pose.hitch.z)
+    pose = roadCartPose(map, next, direction, wheelbase, scale, pose)
+    if (!convoyBuildingsClear(map, pose, puller, scale, heading) || !convoyBuildingsClear(map, pose, puller, scale)) {
+      blocked = next
+      break
+    }
+    at = next
+  }
+  if (blocked === undefined) return null
+  const context = getContext()
+  // Rejoin beyond the obstruction with the axle already facing down the road.
+  // A pedestrian's nearest free tile can leave the cart scraping the same wall.
+  for (let beyond = wheelbase + 2; beyond <= wheelbase + 12; beyond += 2) {
+    const end = advanceCartProgress(map, blocked, direction * beyond)
+    if (end < 0 || end > last) break
+    const to = convoyPoint(map, end), ahead = convoyPoint(map, advanceCartProgress(map, end, direction * .1))
+    const heading = Math.atan2(ahead.x - to.x, ahead.z - to.z)
+    const drive = cartPath(map, initial, to, puller, scale, context, heading)
+    if (!drive) continue
+    return { from: initial.hitch, to, start: progress, end,
+      via: drive.entry.slice(1, -1), length: routeLength(drive.entry), distance: 0 }
+  }
+  return null
+}


### PR DESCRIPTION
Prevent horse carts from getting stuck at building corners by checking the full convoy ahead, planning wider detours, and following every waypoint during larger simulation steps.
Move generated taverns and houses one tile farther from the main path, preserve entrance connections, and enforce clearance from nearby road bends.

Validation: all 63 focused cart, roadside-town, and crossroads tests pass, along with `npm run typecheck`.
The full suite also encountered three confirmed pre-existing bridge failures and 12 timeouts.
