### PR TITLE
Add refresh button to randomize world seed

### DIFF
--- a/components/game/game-hud.tsx
+++ b/components/game/game-hud.tsx
@@ -9,7 +9,7 @@ import { ELEVATION_CONTROLS, type ElevationSettings } from "@/lib/game/map/eleva
 
 import Link from "next/link"
 import * as Tooltip from "@radix-ui/react-tooltip"
-import { Menu, Settings, X } from "lucide-react"
+import { Menu, RefreshCw, Settings, X } from "lucide-react"
 import "./game-hud.css"
 import { useEffect, useMemo, useState } from "react"
 import { useBuildStore } from "@/lib/game/build-store"
@@ -24,7 +24,7 @@ import { clampRoadTier, ROAD_TIERS } from "@/lib/game/map/road"
 import { TERRAIN } from "@/lib/game/map/terrain"
 import { tileAt, type BuildingDef, type GameMap } from "@/lib/game/map/types"
 import { nerve } from "@/lib/game/route-choice"
-import { parseSeed } from "@/lib/game/rng"
+import { parseSeed, randomSeed } from "@/lib/game/rng"
 import { CHANGELOG, CURRENT_VERSION } from "@/lib/changelog"
 import { SITE_MENU } from "@/lib/site-menu"
 import { ACTIVITY_LABELS, BEGGAR_RECOVERY_GOLD, simRegistry, type SimTraveler } from "@/lib/game/sim"
@@ -210,8 +210,8 @@ function MenuPanel({ onClose, playing }: { onClose: () => void; playing: boolean
 }
 
 /**
- * The seed as an editable field: paste a value and apply it, or save it as the
- * default for future sessions. The shell owns the seed; this only reports.
+ * The seed as an editable field: paste a value or refresh for a random world.
+ * The shell owns the seed; this only reports.
  */
 function SeedField({
   seed,
@@ -238,6 +238,15 @@ function SeedField({
     }
     setInvalid(false)
     onSeedChange(parsed)
+  }
+
+  const refresh = () => {
+    const rolled = randomSeed()
+    const next = rolled === seed ? (rolled + 1) % 2 ** 31 : rolled
+    setInput(String(next))
+    setInvalid(false)
+    onValidityChange?.(true)
+    onSeedChange(next)
   }
 
   return (
@@ -267,6 +276,9 @@ function SeedField({
           invalid ? "border-red" : "border-rule focus:border-gold"
         }`}
         />
+        <HudButton onClick={refresh} aria-label="Randomize world seed" title="Randomize world seed">
+          <RefreshCw size={14} aria-hidden="true" />
+        </HudButton>
         {!onValidityChange && <HudButton onClick={apply}>Apply</HudButton>}
       </div>
       {invalid && <div className="text-[11px] italic text-red">Digits only</div>}

--- a/components/game/game-shell.tsx
+++ b/components/game/game-shell.tsx
@@ -19,6 +19,7 @@ import type { CharacterModel } from "@/lib/game/character-assets"
 import { DEFAULT_TREE_MODEL, type TreeModel } from "@/lib/game/trees/render-model"
 import { DEFAULT_ROAD_LOOK, DEFAULT_ROAD_TIER, ROAD_TIERS } from "@/lib/game/map/road"
 import { loadSavedSeed } from "@/lib/game/seed-storage"
+import { randomSeed } from "@/lib/game/rng"
 import { loadDefaultMapSize, saveDefaultMapSize } from "@/lib/game/map-size-storage"
 import { generateMonks } from "@/lib/game/monks"
 import { tileToWorldX, tileToWorldZ } from "@/lib/game/map/types"
@@ -143,14 +144,6 @@ export const DEFAULT_SETTINGS: MapSettings = {
   rivers: WATER_COUNT_AUTO,
   lakes: WATER_COUNT_AUTO,
   ponds: WATER_COUNT_AUTO,
-}
-
-/**
- * Picking a seed is the one legitimate use of Math.random(): it happens outside
- * the simulation, and everything downstream is deterministic in the result.
- */
-function randomSeed(): number {
-  return Math.floor(Math.random() * 2 ** 31)
 }
 
 export function GameShell({

--- a/lib/game/rng.ts
+++ b/lib/game/rng.ts
@@ -17,6 +17,11 @@ export function makeRng(seed: number): () => number {
 /** The world seed everything defaults to before the player supplies one. */
 export const DEFAULT_WORLD_SEED = 20250805
 
+/** Pick a new world seed outside the deterministic simulation. */
+export function randomSeed(): number {
+  return Math.floor(Math.random() * 2 ** 31)
+}
+
 /**
  * Split one world seed into independent streams (tile jitter, trees, …) so
  * consumers never share RNG state yet all reproduce from the single seed.


### PR DESCRIPTION
Adds a refresh button beside the shared world seed input on the landing screen and in World tuning, immediately applying a different random seed and clearing validation errors without submitting the setup form.
Reuses the existing HUD button styling and shares the seed generator with the game shell.

Validation: TypeScript typecheck and all 135 targeted game/map tests passed; browser checks confirmed repeated randomization, invalid-input recovery, and mobile layout.
