### PR TITLE
Prioritize building selection over obscured NPCs

### DIFF
--- a/components/game/character-selection.tsx
+++ b/components/game/character-selection.tsx
@@ -9,7 +9,7 @@ import type { FigureClickHandler } from "./traveler-figure"
 
 /**
  * Clicks pick the person under the pointer before the scenery in front of them,
- * so a walker stays reachable through the crowns and walls that hide them.
+ * so a walker stays reachable through trees while buildings block their occupants.
  * Mounted once per scene; every monk and traveler group marks itself with
  * `markPerson`.
  */

--- a/components/game/game-canvas.tsx
+++ b/components/game/game-canvas.tsx
@@ -15,6 +15,7 @@ import { usePersonDesignStore } from "@/lib/game/base-person/design-store"
 import { PixelCanvas, PixelCharacters, PixelWorld, type PixelationProps } from "@/components/pixel-canvas"
 
 import { useCameraStore } from "@/lib/game/camera-store"
+import { markSelectionScenery } from "@/lib/game/selection"
 import type { Resources } from "@/lib/game/settlement"
 import type { TilePos } from "@/lib/game/map/types"
 import { deriveSeed, SEED_STREAM } from "@/lib/game/rng"
@@ -204,7 +205,7 @@ export function GameCanvas({
           <group name="visibility-trees" visible={visibility.showTrees}>
             <Trees map={map} placements={trees} ents={lastMarch} characterScale={characterScale} model={treeModel} />
           </group>
-          <group name="visibility-scenery" visible={visibility.showScenery}>
+          <group name="visibility-scenery" ref={markSelectionScenery} visible={visibility.showScenery}>
             <Environment map={terrainMap} />
             <Signpost map={terrainMap} />
             <ForestWarnings map={terrainMap} />

--- a/components/game/trees.tsx
+++ b/components/game/trees.tsx
@@ -5,7 +5,7 @@ import { SceneAssetBoundary } from "./scene-assets"
 import { lazy, useCallback, useEffect, useMemo } from "react"
 import { BASE_CHARACTER_SCALE } from "@/lib/game/base-person/gait"
 import { useCameraStore } from "@/lib/game/camera-store"
-import { selectElement } from "@/lib/game/selection"
+import { markSelectionScenery, selectElement } from "@/lib/game/selection"
 import { useBuildStore } from "@/lib/game/build-store"
 import { deriveSeed, SEED_STREAM } from "@/lib/game/rng"
 import type { GameMap } from "@/lib/game/map/types"
@@ -52,7 +52,7 @@ export function Trees({ map, placements: supplied, ents = false, characterScale 
   const selectTree = useCallback((id: number, event: { delta: number; stopPropagation: () => void }) => selectElement({ kind: "tree", id }, event), [])
   const seed = deriveSeed(map.seed ?? 0, SEED_STREAM.treeShapes)
   return (
-    <group>
+    <group ref={markSelectionScenery}>
       {model === "sprites"
         ? <SceneAssetBoundary>
             <FoliageField atlas={DEFAULT_FOLIAGE_ATLAS} placements={placements} hidden={felled} onSelect={selectTree} seed={seed} idBase={map.buildings.length} />

--- a/lib/game/selection.test.ts
+++ b/lib/game/selection.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { useBuildStore } from "./build-store"
 import { useCameraStore, type Selection } from "./camera-store"
-import { markPerson, prioritizePeople, selectElement, selectionObjectId } from "./selection"
+import { markPerson, markSelectionScenery, prioritizePeople, selectElement, selectionObjectId } from "./selection"
 import { buildingObjectId, pileObjectId, RELIC_OBJECT_ID, residentObjectId, travelerObjectId, treeObjectId, wildlifeObjectId } from "./render/outline"
 
 const objects = {
@@ -58,20 +58,53 @@ describe("shared selection", () => {
     markPerson(person)
     const walker = { object: { userData: {}, parent: person }, distance: 9 }
     const hat = { object: { userData: {}, parent: person }, distance: 10 }
-    const crown = { object: { userData: {}, parent: null }, distance: 4 }
-    const trunk = { object: { userData: {}, parent: null }, distance: 6 }
+    const tree = { userData: {} as Record<string, unknown>, parent: null }
+    markSelectionScenery(tree)
+    const crown = { object: { userData: {}, parent: tree }, distance: 4 }
+    const trunk = { object: { userData: {}, parent: tree }, distance: 6 }
     expect(prioritizePeople([crown, walker, trunk, hat])).toEqual([walker, hat, crown, trunk])
   })
 
   it("leaves hits alone when people are not involved", () => {
     const crown = { object: { userData: {}, parent: null }, distance: 4 }
     const trunk = { object: { userData: {}, parent: null }, distance: 6 }
+    markSelectionScenery(crown.object)
+    markSelectionScenery(trunk.object)
     const hits = [crown, trunk]
     expect(prioritizePeople(hits)).toBe(hits)
     const person = { userData: {} as Record<string, unknown>, parent: null }
     markPerson(person)
     const people = [{ object: { userData: {}, parent: person }, distance: 1 }]
     expect(prioritizePeople(people)).toBe(people)
+  })
+
+  it.each([false, true])("picks a building before its occupants (batched: %s)", (batched) => {
+    const person = { userData: {} }
+    markPerson(person)
+    const occupant = { object: { parent: person }, distance: 9 }
+    const building = { object: { visible: !batched, userData: { batchedPickTarget: batched } }, distance: 6 }
+    const tree = { object: { userData: {} }, distance: 3 }
+    markSelectionScenery(tree.object)
+    expect(prioritizePeople([tree, building, occupant])).toEqual([building, occupant, tree])
+  })
+
+  it("keeps exposed people selectable in front of buildings and through scenery", () => {
+    const person = { userData: {} }
+    markPerson(person)
+    const walker = { object: { parent: person }, distance: 5 }
+    const building = { object: {}, distance: 9 }
+    const environment = { object: { userData: {} }, distance: 2 }
+    markSelectionScenery(environment.object)
+    expect(prioritizePeople([environment, walker, building])).toEqual([walker, building, environment])
+  })
+
+  it("does not pass clicks through other unmarked objects to people", () => {
+    const person = { userData: {} }
+    markPerson(person)
+    const walker = { object: { parent: person }, distance: 5 }
+    const prop = { object: {}, distance: 2 }
+    const hits = [prop, walker]
+    expect(prioritizePeople(hits)).toBe(hits)
   })
 
   it("ignores hidden scenery and characters, including visible children of hidden layers", () => {
@@ -84,7 +117,7 @@ describe("shared selection", () => {
     const ground = { object: { visible: true, parent: null } }
     expect(prioritizePeople([walker, roof, tree, ground])).toEqual([ground])
     hiddenLayer.visible = true
-    expect(prioritizePeople([ground, tree, walker])).toEqual([walker, ground, tree])
+    expect(prioritizePeople([ground, tree, walker])).toEqual([ground, tree, walker])
   })
 
   it("clears the effect when a selected identity is gone", () => {

--- a/lib/game/selection.ts
+++ b/lib/game/selection.ts
@@ -44,6 +44,7 @@ export function selectionObjectId(selection: Selection | null, objects: {
 
 /** Marks a rendered subtree as a person, for `prioritizePeople`. */
 const PERSON_PICK = "person"
+const SCENERY_PICK = "selectionScenery"
 
 interface PickObject {
   visible?: boolean
@@ -56,22 +57,23 @@ export function markPerson(object: { userData: Record<string, unknown> } | null 
   if (object) object.userData[PERSON_PICK] = true
 }
 
-/** True when the object, or anything it hangs from, stands for a person. */
-function isPersonPick(object: PickObject | null | undefined): boolean {
+/** Only trees and environment scenery yield their clicks to people behind them. */
+export function markSelectionScenery(object: { userData: Record<string, unknown> } | null | undefined) {
+  if (object) object.userData[SCENERY_PICK] = true
+}
+
+function hasPickTag(object: PickObject | null | undefined, tag: string): boolean {
   for (let node = object ?? null; node; node = node.parent ?? null) {
-    if (node.userData?.[PERSON_PICK] === true) return true
+    if (node.userData?.[tag] === true) return true
   }
   return false
 }
 
 /**
- * Re-order raycast hits so people come first. A walker is small next to the
- * trees and buildings around them, so the nearest hit under the pointer is
- * usually the scenery standing in front — clicking a pilgrim on a forest path
- * would pick the crown that hides them. Distance order is kept within each
- * group, so the nearest person still wins, and scenery is only demoted, never
- * dropped: with no tool active the person's handler stops the event, and in
- * build mode nothing stops it and the ground still takes the click.
+ * Let people be picked through trees and environment scenery. Other surfaces
+ * keep their distance order with people, so roofs and walls block occupants
+ * while an exposed person in front of a building remains selectable. Scenery
+ * is demoted only when a person is hit, and retained for build-tool events.
  */
 export function prioritizePeople<T extends { object: PickObject }>(hits: readonly T[]): T[] {
   // Batched buildings keep their original surface as the exact picking mesh.
@@ -79,7 +81,11 @@ export function prioritizePeople<T extends { object: PickObject }>(hits: readonl
   const visibleHits = hits.filter(hit => hit.object.userData?.batchedPickTarget === true
     ? isObjectVisible(hit.object.parent ?? {}) : isObjectVisible(hit.object))
   if (visibleHits.length !== hits.length) hits = visibleHits
-  const people = hits.filter((hit) => isPersonPick(hit.object))
-  if (people.length === 0 || people.length === hits.length) return hits as T[]
-  return [...people, ...hits.filter((hit) => !isPersonPick(hit.object))]
+  if (!hits.some(hit => hasPickTag(hit.object, PERSON_PICK))) return hits as T[]
+  const solid: T[] = [], scenery: T[] = []
+  for (const hit of hits) {
+    const passThrough = hasPickTag(hit.object, SCENERY_PICK) && !hasPickTag(hit.object, PERSON_PICK)
+    ;(passThrough ? scenery : solid).push(hit)
+  }
+  return scenery.length ? [...solid, ...scenery] : hits as T[]
 }


### PR DESCRIPTION
Buildings now take selection priority over NPCs behind their roofs and walls, while exposed NPCs remain selectable. Only trees and environment scenery yield clicks to NPCs, preserving visibility filtering and build-tool behavior. Regression tests cover ordinary and batched buildings, scenery pass-through, and other objects retaining selection priority.

Validation: all 24 selection tests passed (`npm test -- lib/game/selection.test.ts`), and `npm run typecheck` passed.
