### PR TITLE
Halve the traveler thirst rate

### DIFF
--- a/lib/game/balance.test.ts
+++ b/lib/game/balance.test.ts
@@ -111,6 +111,17 @@ describe("balance presets", () => {
     Object.assign(current.rules, { hungerDecay: 3, staminaDecay: 2.1 })
     expect(importBalance(exportBalance(current)).balance).toEqual(current)
   })
+  it("halves the previous default thirst rate in version 5 presets", () => {
+    const old = JSON.parse(exportBalance(DEFAULT_BALANCE))
+    old.version = 5
+    old.balance.rules.thirstDecay = 6
+    expect(importBalance(JSON.stringify(old)).balance?.rules.thirstDecay).toBe(3)
+    old.balance.rules.thirstDecay = 9
+    expect(importBalance(JSON.stringify(old)).balance?.rules.thirstDecay).toBe(9)
+    const current = fresh()
+    current.rules.thirstDecay = 6
+    expect(importBalance(exportBalance(current)).balance).toEqual(current)
+  })
   it.each([NaN, Infinity, -1, 1.5, 100001, "200", null])(
     "rejects invalid starting supplies: %s",
     (value) => {

--- a/lib/game/balance.ts
+++ b/lib/game/balance.ts
@@ -462,8 +462,8 @@ export const RULE_FIELDS = [
   },
   {
     key: "thirstDecay", group: "Traveler needs", label: "Thirst drain per game hour",
-    description: "Hydration lost per game hour. Default: 144 points per day, with a full bar lasting about 17 hours. Camping halves this rate; shrine hospitality restores it.",
-    default: 6, min: 0, max: 50, step: 0.1,
+    description: "Hydration lost per game hour. Default: 72 points per day, with a full bar lasting about 33 hours. Camping halves this rate; shrine hospitality restores it.",
+    default: 3, min: 0, max: 50, step: 0.1,
   },
   {
     key: "staminaDecay", group: "Traveler needs", label: "Stamina drain per game hour",
@@ -629,7 +629,7 @@ export function validateBalance(
   }
   return { balance: clean, error: null }
 }
-export const BALANCE_VERSION = 5
+export const BALANCE_VERSION = 6
 export function exportBalance(balance: GameBalance): string {
   return JSON.stringify({ version: BALANCE_VERSION, balance }, null, 2)
 }
@@ -637,8 +637,8 @@ export function importBalance(json: string): ReturnType<typeof validateBalance> 
   try {
     const preset = record(JSON.parse(json))
     const version = preset?.version
-    if (version !== 1 && version !== 2 && version !== 3 && version !== 4 && version !== BALANCE_VERSION)
-      return { balance: null, error: "Unsupported preset version. Expected version 1, 2, 3, 4 or 5." }
+    if (version !== 1 && version !== 2 && version !== 3 && version !== 4 && version !== 5 && version !== BALANCE_VERSION)
+      return { balance: null, error: "Unsupported preset version. Expected version 1, 2, 3, 4, 5 or 6." }
     // Add defaults for new structures while retaining all authored settings.
     const saved = record(preset?.balance)
     const rules = record(saved?.rules)
@@ -657,7 +657,7 @@ export function importBalance(json: string): ReturnType<typeof validateBalance> 
         ...rules,
         // Adopt slower defaults in old saves without overwriting custom rates.
         ...((version < 4 && rules.hungerDecay === 12.5 || version < 5 && rules.hungerDecay === 3) ? { hungerDecay: DEFAULT_BALANCE.rules.hungerDecay } : {}),
-        ...(version < 4 && rules.thirstDecay === 25 ? { thirstDecay: DEFAULT_BALANCE.rules.thirstDecay } : {}),
+        ...((version < 4 && rules.thirstDecay === 25 || version < 6 && rules.thirstDecay === 6) ? { thirstDecay: DEFAULT_BALANCE.rules.thirstDecay } : {}),
         ...(version < 5 && rules.staminaDecay === 2.1 ? { staminaDecay: DEFAULT_BALANCE.rules.staminaDecay } : {}),
       },
       buildings: {

--- a/lib/game/sim.test.ts
+++ b/lib/game/sim.test.ts
@@ -219,16 +219,16 @@ describe("stepSim", () => {
     const s = sim.travelers.get(0)!
     const hour = GAME_DAY_SECONDS / 24
     stepSim(sim, travelers, map, 1, hour)
-    expect([s.hunger, s.thirst, s.stamina]).toEqual([78.5, 74, 78.95])
+    expect([s.hunger, s.thirst, s.stamina]).toEqual([78.5, 77, 78.95])
 
     Object.assign(sim.balance.rules, { hungerDecay: 2, thirstDecay: 6, staminaDecay: 0 })
     stepSim(sim, travelers, map, 1, hour)
-    expect([s.hunger, s.thirst, s.stamina]).toEqual([76.5, 68, 78.95])
+    expect([s.hunger, s.thirst, s.stamina]).toEqual([76.5, 71, 78.95])
 
     s.activity = "camping"
     s.stamina = 0
     stepSim(sim, travelers, map, 1, hour)
-    expect([s.hunger, s.thirst, s.stamina]).toEqual([75.5, 65, 60])
+    expect([s.hunger, s.thirst, s.stamina]).toEqual([75.5, 68, 60])
   })
 
   it("keeps food and water supplied longer over an active day", () => {
@@ -246,8 +246,9 @@ describe("stepSim", () => {
         s.activity = "walking"
       }
     }
-    // Legs never bottom out: walkers pitch camp once stamina falls below 20.
-    expect(depleted).toEqual({ hunger: 0, thirst: 1, stamina: 0 })
+    // Nothing bottoms out in a day: a full cup lasts about 33 hours, and walkers
+    // pitch camp once stamina falls below 20.
+    expect(depleted).toEqual({ hunger: 0, thirst: 0, stamina: 0 })
     expect(sim.time).toBeCloseTo(1)
   })
 
@@ -372,7 +373,7 @@ describe("stepSim", () => {
     expect(buyer.hunger).toBeLessThan(50)
   })
 
-  it("needs only one drink in the first day when starting fully supplied", () => {
+  it("needs only one drink in the first two days when starting fully supplied", () => {
     const map = makeMap()
     const travelers = [
       makeTraveler(0, "pilgrim", { hunger: 100, thirst: 100, gold: 100 }),
@@ -384,7 +385,7 @@ describe("stepSim", () => {
     const buyer = sim.travelers.get(0)!, vendor = sim.travelers.get(1)!
     vendor.timer = GAME_DAY_SECONDS + 1
     let meals = 0, drinks = 0
-    for (let elapsed = 0; elapsed < GAME_DAY_SECONDS; elapsed += 0.25) {
+    for (let elapsed = 0; elapsed < 2 * GAME_DAY_SECONDS; elapsed += 0.25) {
       const { hunger, thirst } = buyer
       stepSim(sim, travelers, map, 0, 0.25)
       if (buyer.hunger > hunger) meals++
@@ -1014,8 +1015,8 @@ describe("beggar progression", () => {
     stepSim(sim, travelers, map, 0, 0.25)
     expect(person.beggar).toBe(true)
     expect(person.activity).toBe("toBegging")
-    // Thirst has run out during the day; that must not prevent asking for help.
-    expect(person.thirst).toBe(0)
+    // An empty cup must not prevent asking for help.
+    person.thirst = 0
     expect(runUntil(sim, travelers, map, () => person.activity === "begging", 30)).toBe(true)
     stepSim(sim, travelers, map, 1, 1)
     expect(person.activity).toBe("begging")


### PR DESCRIPTION
Travelers were getting thirsty far too quickly — a full hydration bar lasted only about 17 game hours. This drops the `thirstDecay` default from 6 to 3 points per game hour, so a full bar now lasts about 33 hours; the World tuning slider, HUD and `/docs/game-specs` all read that value, so they follow automatically.

The balance preset version is bumped to 6, adopting the new default for saved presets still on the old 6 while leaving custom thirst tuning alone, matching how the earlier hunger and stamina halvings migrated. Three sim tests that encoded the old rate are rebased — including the beggar test, which now empties the cup itself since a day's walking no longer does — and a migration test covers v5 presets.

Verified with the `lib/game` needs, water, transport, sim and balance suites (all passing) plus a clean `tsc --noEmit`; the one failure in `lib/game/jobs/preview.test.ts` is pre-existing on `main` and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)