### PR TITLE
Move the "generating map" caption above the loading bar

### DIFF
--- a/components/game/loading-church.css
+++ b/components/game/loading-church.css
@@ -91,9 +91,10 @@
 }
 .loading-church-caption {
   position: absolute;
-  top: calc(50% + var(--church-caption-offset) + 12px);
+  /* Sits above the progress bar: the bar's own height plus a four-pixel gap. */
+  top: calc(50% - var(--church-roof-offset) - 10 * var(--loading-pixel));
   left: 50%;
-  transform: translateX(-50%);
+  transform: translate(-50%, -100%);
   color: #d4c297;
   font-family: var(--font-cinzel), serif;
   font-size: 11px;

--- a/components/game/loading-church.tsx
+++ b/components/game/loading-church.tsx
@@ -131,13 +131,13 @@ export function LoadingChurch({ showChurch, phase, overlayRef, idle = false, gen
       fetchPriority="high" loading="eager" decoding="sync" alt="" draggable={false}
       className="loading-church-image" style={{ width: `${8 * scale}dvh`, height: `${8 * scale}dvh` }} />}
     {generating && <>
+      <p className="loading-church-caption" role="status">generating map</p>
       <svg className="loading-church-progress" viewBox={`0 0 ${CONSTRUCTION_BAR_WIDTH} ${CONSTRUCTION_BAR_HEIGHT}`}
         role="progressbar" aria-label="Generating map" shapeRendering="crispEdges">
         <rect width={48} height={6} fill="#30210c" />
         <rect x={1} y={1} width={46} height={4} fill="#5b4d2f" />
         <rect className="loading-church-progress-fill" x={2} y={2} width={12} height={2} fill="#dab767" />
       </svg>
-      <p className="loading-church-caption" role="status">generating map</p>
     </>}
   </div>
 }


### PR DESCRIPTION
The "generating map" caption on the homescreen loading state now sits directly above the progress bar instead of below the church. It is anchored to the bar's top edge — the bar's own height plus a four-pixel gap, expressed in `--loading-pixel` so the gap scales with the rest of the loading art and stays on the character pixel grid. The paragraph also moved before the bar in the DOM so screen-reader order matches the visual order. Verified in the running app on seed 15839: caption bottom 256.3px, bar top 259.8px, both centred, bar still clear of the church roof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)