### PR TITLE
Keep building detail and interior access tied to zoom

### DIFF
--- a/components/building-lab/building-model.tsx
+++ b/components/building-lab/building-model.tsx
@@ -5,7 +5,7 @@ import * as THREE from "three"
 import { GRASS_TEXTURE_URL } from "@/lib/game/render/ground-surface"
 import { useFrame, type ThreeEvent } from "@react-three/fiber"
 import { buildingGeometryLevels, buildingPartDetail } from "@/lib/game/building-art/merged-geometry"
-import { sceneryDetail } from "@/lib/game/render/scenery-detail"
+import { buildingDetail } from "@/lib/game/render/scenery-detail"
 import { useBuildingBatches } from "@/components/game/building-batches"
 import { StaticBlock } from "@/components/game/static-block"
 import { buildingParts, type BuildingPart } from "@/lib/game/building-art/geometry"
@@ -85,7 +85,7 @@ function MergedParts({ parts, idColor, onClick, terrainFloors, surfaceMaterial, 
   }, [batches, batchable, levels, idColor])
   useEffect(() => () => { for (const geometry of new Set(levels)) geometry.dispose() }, [levels])
   useFrame(({ scene }) => {
-    const geometry = levels[sceneryDetail(scene)]
+    const geometry = levels[buildingDetail(scene)]
     if (body.current) body.current.geometry = geometry
     if (ids.current) ids.current.geometry = geometry
   })
@@ -122,7 +122,7 @@ export function StructureModel({ parts, idColor, ghostColor, ink = true, cutaway
   const scratch = useMemo(()=>({direction:new THREE.Vector3(),rotation:new THREE.Quaternion()}),[])
   useFrame(({camera, scene})=>{
     if (!cutaway || !root.current) return
-    const nextDistant = sceneryDetail(scene) > 0
+    const nextDistant = buildingDetail(scene) > 0
     if (distant !== nextDistant) setDistant(nextDistant)
     if (nextDistant) return
     root.current.getWorldQuaternion(scratch.rotation).invert()

--- a/components/game/building-batches.tsx
+++ b/components/game/building-batches.tsx
@@ -6,7 +6,7 @@ import * as THREE from "three"
 import { PixelWorld } from "@/components/pixel-canvas"
 import { buildingBatchCell, buildingSurfaceMaterial, mergedBuildingBlock, type BuildingBatchSource } from "@/lib/game/render/building-batch"
 import { OUTLINE_ID_LAYER_MASK } from "@/lib/game/render/outline"
-import { sceneryDetail } from "@/lib/game/render/scenery-detail"
+import { buildingDetail } from "@/lib/game/render/scenery-detail"
 
 const Context = createContext<{ material: THREE.MeshLambertMaterial; register: (source: BuildingBatchSource) => () => void } | null>(null)
 export const useBuildingBatches = () => useContext(Context)
@@ -56,7 +56,7 @@ export function BuildingBatches({ children }: { children: ReactNode }) {
       source.body.userData.batchedPickTarget = buildingBatchControl.enabled
     }
     root.current.visible = buildingBatchControl.enabled
-    const detail = sceneryDetail(scene)
+    const detail = buildingDetail(scene)
     shading.value = detail === 0 ? 1 : 0
     for (const cell of state.cells.values()) {
       cell.body.geometry = cell.geometry.body[detail]; cell.ids.geometry = cell.geometry.ids[detail]

--- a/components/game/close-scenery.tsx
+++ b/components/game/close-scenery.tsx
@@ -3,12 +3,12 @@
 import { useRef, type ReactNode } from "react"
 import { useFrame } from "@react-three/fiber"
 import type * as THREE from "three"
-import { sceneryDetail } from "@/lib/game/render/scenery-detail"
+import { buildingDetail } from "@/lib/game/render/scenery-detail"
 
 /** Interior inventory stays mounted, but neither draws nor catches clicks in
  * the overview. Exterior workshop stacks remain usable at every zoom. */
 export function CloseScenery({ children, enabled = true }: { children: ReactNode; enabled?: boolean }) {
   const root = useRef<THREE.Group>(null)
-  useFrame(({ scene }) => { if (root.current) root.current.visible = !enabled || sceneryDetail(scene) === 0 })
+  useFrame(({ scene }) => { if (root.current) root.current.visible = !enabled || buildingDetail(scene) === 0 })
   return <group ref={root} name="interior-inventory" raycast={() => root.current?.visible ? undefined : false}>{children}</group>
 }

--- a/components/game/shrine.tsx
+++ b/components/game/shrine.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { sceneryDetail } from "@/lib/game/render/scenery-detail"
+import { buildingDetail } from "@/lib/game/render/scenery-detail"
 import { useUnitInterior } from "./use-unit-interior"
 
 import { groundHeight } from "@/lib/game/map/elevation"
@@ -35,7 +35,7 @@ export function Shrine({ map, relic, showInteriors = false }: { map: GameMap; re
   const relicSelected = useCameraStore(s => isSelected(s.selection, { kind: "relic" }))
   const buildingSelected = useCameraStore(s => isSelected(s.selection, { kind: "building", id: map.site?.hovelId ?? "" }))
   useFrame(({ scene }) => {
-    const near = sceneryDetail(scene) === 0
+    const near = buildingDetail(scene) === 0
     if (lights.current) lights.current.visible = near
     const sim = simRegistry.current
     const available = !processionRegistry.current || !relicIsCarried(processionRegistry.current)

--- a/components/game/use-unit-interior.ts
+++ b/components/game/use-unit-interior.ts
@@ -2,7 +2,7 @@
 
 import { useRef, useState } from "react"
 import { useFrame } from "@react-three/fiber"
-import { sceneryDetail } from "@/lib/game/render/scenery-detail"
+import { buildingDetail } from "@/lib/game/render/scenery-detail"
 import { useCameraStore } from "@/lib/game/camera-store"
 import { unitInterior } from "@/lib/game/building-interior"
 import type { GameMap } from "@/lib/game/map/types"
@@ -17,7 +17,7 @@ export function useUnitInterior(map: GameMap) {
     const selection = useCameraStore.getState().selection
     const unit = selection?.kind === "traveler" ? simRegistry.current?.travelers.get(selection.id)
       : selection?.kind === "monk" ? monkPositionRegistry.current?.get(selection.id) : undefined
-    const next = sceneryDetail(scene) === 0 ? unitInterior(map, unit) : null
+    const next = buildingDetail(scene) === 0 ? unitInterior(map, unit) : null
     if (next !== previous.current) { previous.current = next; setInterior(next) }
   })
   return interior

--- a/lib/game/render/frame-quality.test.ts
+++ b/lib/game/render/frame-quality.test.ts
@@ -1,7 +1,7 @@
 import { expect, it } from "vitest"
 import { Scene, OrthographicCamera } from "three"
 import { FrameQualityController, frameQuality, frameQualityControl, updateFrameQuality } from "./frame-quality"
-import { updateSceneryDetail, sceneryDetailStatus } from "./scenery-detail"
+import { buildingDetail, updateSceneryDetail, sceneryDetailStatus } from "./scenery-detail"
 
 it("reduces sustained slow frames, holds in background tabs, and recovers slowly", () => {
   const control = new FrameQualityController()
@@ -43,6 +43,23 @@ it("allows FPS pressure to lower close-view scenery while preserving the zoom qu
   expect(updateSceneryDetail(scene, camera, 900, 0, 36)).toBe(0)
   expect(updateSceneryDetail(scene, camera, 900, .1, 36, "desktop", 2)).toBe(0)
   expect(updateSceneryDetail(scene, camera, 900, .3, 36, "desktop", 2)).toBe(2)
+  expect(buildingDetail(scene)).toBe(0)
   expect(sceneryDetailStatus(scene)).toMatchObject({ zooming: false, fade: 0 })
   expect(updateSceneryDetail(scene, camera, 900, 1, 36, "desktop", 0)).toBe(0)
+})
+
+it("keeps buildings and interior access at close detail through sustained low FPS and recovery", () => {
+  const scene = new Scene(), camera = new OrthographicCamera(-18, 18, 18, -18)
+  let time = 0
+  const frame = (delta: number) => {
+    time += delta
+    const quality = updateFrameQuality(scene, delta, false)
+    updateSceneryDetail(scene, camera, 900, time, 36, "desktop", quality)
+    expect(buildingDetail(scene)).toBe(0)
+  }
+  for (let i = 0; i < 75; i++) frame(1 / 25)
+  expect(frameQuality(scene)).toBe(2)
+  expect(sceneryDetailStatus(scene)).toMatchObject({ current: 2, building: 0 })
+  for (let i = 0; i < 660; i++) frame(1 / 60)
+  expect(frameQuality(scene)).toBe(0)
 })

--- a/lib/game/render/scenery-detail.test.ts
+++ b/lib/game/render/scenery-detail.test.ts
@@ -1,6 +1,6 @@
 import { expect, it } from "vitest"
 import * as THREE from "three"
-import { chooseSceneryDetail, updateSceneryDetail, sceneryDetailStatus, sceneryCloseOpacity, sceneryFadeProgress, scenerySourceVisible, treeEdgeOpacity } from "./scenery-detail"
+import { buildingDetail, chooseSceneryDetail, updateSceneryDetail, sceneryDetailStatus, sceneryCloseOpacity, sceneryFadeProgress, scenerySourceVisible, treeEdgeOpacity } from "./scenery-detail"
 import { indexFlatGeometry } from "./flat-geometry"
 import { StaticInstanceBatch } from "./static-instances"
 import { coarseCrown } from "../trees/coarse-crown"
@@ -28,6 +28,34 @@ it("drops detail 15 percent earlier on desktop and more aggressively on coarse-p
   expect(chooseSceneryDetail(14.5, 1, "mobile")).toBe(1)
   expect(chooseSceneryDetail(17.5, 2, "mobile")).toBe(2)
   expect(chooseSceneryDetail(30.5, 1, "mobile")).toBe(0)
+})
+
+it("keeps building zoom thresholds independent of FPS pressure, including on initial load", () => {
+  const scene = new THREE.Scene(), camera = new THREE.OrthographicCamera(-22.5, 22.5, 22.5, -22.5)
+  expect(buildingDetail(scene)).toBe(0)
+  // 20 pixels/unit is close when entering from full detail, but would stay
+  // simplified if buildings inherited the performance level's hysteresis.
+  updateSceneryDetail(scene, camera, 900, 0, 45, "desktop", 2)
+  updateSceneryDetail(scene, camera, 900, .3, 45, "desktop", 2)
+  expect(buildingDetail(scene)).toBe(0)
+  expect(sceneryDetailStatus(scene)?.current).toBe(2)
+})
+
+it("still closes and reopens interiors with settled zoom while FPS detail stays reduced", () => {
+  const scene = new THREE.Scene(), camera = new THREE.OrthographicCamera(-18, 18, 18, -18)
+  const update = (view: number, time: number) => {
+    camera.top = view / 2; camera.bottom = -view / 2
+    updateSceneryDetail(scene, camera, 900, time, view, "desktop", 2)
+    expect(sceneryDetailStatus(scene)?.current).toBe(2)
+    return buildingDetail(scene)
+  }
+  expect(update(36, 0)).toBe(0)
+  expect(update(60, .3)).toBe(0)
+  expect(update(60, .5)).toBe(1)
+  expect(update(140, .8)).toBe(1)
+  expect(update(140, 1)).toBe(2)
+  expect(update(36, 1.3)).toBe(2)
+  expect(update(36, 1.5)).toBe(0)
 })
 
 it("defers layer changes until zoom input and the camera tween settle, including reversals", () => {

--- a/lib/game/render/scenery-detail.ts
+++ b/lib/game/render/scenery-detail.ts
@@ -6,6 +6,7 @@ export type SceneryProfile = "desktop" | "mobile"
 interface DetailState {
   current: SceneryDetail
   pending: SceneryDetail
+  zoom: SceneryDetail
   zooming: boolean
   target: number
   density: number
@@ -36,8 +37,9 @@ export function updateSceneryDetail(scene: THREE.Scene, camera: THREE.Camera, he
   const density = viewSize > 0 ? height / viewSize : Infinity
   let state = details.get(scene)
   if (!state) {
-    const initial = Math.max(minimum, chooseSceneryDetail(density, 0, profile)) as SceneryDetail
-    state = { current: initial, pending: initial, zooming: false, target, density, changedAt: time,
+    const zoom = chooseSceneryDetail(density, 0, profile)
+    const initial = Math.max(minimum, zoom) as SceneryDetail
+    state = { current: initial, pending: initial, zoom, zooming: false, target, density, changedAt: time,
       profile, from: initial, fade: 1, fadeStartedAt: -Infinity }
     details.set(scene, state)
   }
@@ -52,6 +54,9 @@ export function updateSceneryDetail(scene: THREE.Scene, camera: THREE.Camera, he
   state.target = target; state.density = density; state.profile = profile
   state.pending = Math.max(minimum, chooseSceneryDetail(density, state.current, profile)) as SceneryDetail
   state.zooming = time - state.changedAt < ZOOM_QUIET_SECONDS
+  // Buildings and their interiors follow zoom alone, including its own
+  // hysteresis history; FPS pressure must not push them across a threshold.
+  if (!state.zooming) state.zoom = chooseSceneryDetail(density, state.zoom, profile)
   if (!state.zooming && state.current !== state.pending) {
     state.from = state.current; state.current = state.pending; state.fadeStartedAt = time
   }
@@ -63,6 +68,8 @@ export function updateSceneryDetail(scene: THREE.Scene, camera: THREE.Camera, he
 /** The game updates this once after the camera, before animation callbacks.
  * Standalone asset previews retain their full authored detail. */
 export function sceneryDetail(scene: THREE.Scene): SceneryDetail { return details.get(scene)?.current ?? 0 }
+/** Authored building surfaces and interior access only simplify with zoom. */
+export function buildingDetail(scene: THREE.Scene): SceneryDetail { return details.get(scene)?.zoom ?? 0 }
 export function sceneryFadeProgress(scene: THREE.Scene): number { return details.get(scene)?.fade ?? 1 }
 export function sceneryZooming(scene: THREE.Scene): boolean { return details.get(scene)?.zooming ?? false }
 export function sceneryCloseOpacity(scene: THREE.Scene): number {
@@ -74,7 +81,7 @@ export function sceneryCloseOpacity(scene: THREE.Scene): number {
 /** Opt-in browser diagnostics; ordinary rendering reads the numeric level. */
 export function sceneryDetailStatus(scene: THREE.Scene) {
   const state = details.get(scene)
-  return state ? { current: state.current, pending: state.pending, zooming: state.zooming, fade: state.fade, profile: state.profile } : undefined
+  return state ? { current: state.current, pending: state.pending, building: state.zoom, zooming: state.zooming, fade: state.fade, profile: state.profile } : undefined
 }
 
 /** Detailed crowns and their representative shapes share the original ID. */


### PR DESCRIPTION
Low FPS previously simplified building surfaces and shading and closed roof cutaways, hiding interior inventory and shrine contents even at close zoom.
Buildings and interior access now follow independent zoom detail, preserving the existing zoom thresholds and settling delay while other scenery can still adapt to frame rate.
Regression tests cover sustained low FPS, recovery, initial loading near a zoom threshold, and zooming out and back in under continued FPS pressure.
Validation: TypeScript passed and all 213 relevant rendering, building-art, and interior tests passed; one existing geometry test exceeded its default timeout and passed when rerun with a 30-second timeout.
