### PR TITLE
Start all travellers fully fed, hydrated and rested

### DIFF
--- a/lib/game/town-residents.test.ts
+++ b/lib/game/town-residents.test.ts
@@ -38,8 +38,10 @@ describe("town households", () => {
     expect(residents).toHaveLength(2)
     expect(new Set(travelers.map(t => t.id)).size).toBe(2)
     for (const resident of residents) {
+      expect(resident.traveler.attributes).toMatchObject({ hunger: 100, thirst: 100, stamina: 100 })
       expect(sim.travelers.get(resident.traveler.id)).toMatchObject({
         employer: "town-tavern", home: "town-house", jobless: false, activity: "posted", jobSlot: resident.jobSlot,
+        hunger: 100, thirst: 100, stamina: 100,
       })
     }
     const staffed = (id: string) => [...sim.travelers.values()].some(s => s.employer === id && s.activity === "posted")

--- a/lib/game/town-residents.ts
+++ b/lib/game/town-residents.ts
@@ -19,7 +19,7 @@ export function townResidents(map: GameMap) {
         type: TRAVELER_TYPES.peasant, pace: 1, direction: 1,
         offset: town.junction / Math.max(1, (map.road?.length ?? 1) - 1),
         attributes: { age: 28 + jobSlot * 5, gold: 40, piety: 30, happiness: 75, status: 25,
-          hunger: 100 - jobSlot * 20, thirst: 100 - jobSlot * 20, stamina: 100 - jobSlot * 15,
+          hunger: 100, thirst: 100, stamina: 100,
           jobless: false, skills: [...BUILDING_KINDS.tavern.trades] },
       }
       return { traveler, building, jobSlot, home: house.id }

--- a/lib/game/travelers.test.ts
+++ b/lib/game/travelers.test.ts
@@ -38,13 +38,14 @@ describe("generateTravelers", () => {
       expect(travelers.some(t => t.type.id === "vendor")).toBe(true)
     }
   })
-  it("starts passing travelers supplied for their own journey", () => {
+  it("starts every passing traveler fully fed, hydrated and rested", () => {
     for (const seed of [1, 42, 12345]) {
       for (const { attributes } of generateTravelers(seed, 100)) {
         expect(attributes.happiness).toBeGreaterThanOrEqual(60)
         expect(attributes.happiness).toBeLessThanOrEqual(90)
-        expect(attributes.hunger).toBeGreaterThanOrEqual(80)
-        expect(attributes.thirst).toBeGreaterThanOrEqual(80)
+        expect(attributes.hunger).toBe(100)
+        expect(attributes.thirst).toBe(100)
+        expect(attributes.stamina).toBe(100)
       }
     }
   })

--- a/lib/game/travelers.ts
+++ b/lib/game/travelers.ts
@@ -179,10 +179,10 @@ export const TRAVELER_TYPES: Record<TravelerTypeId, TravelerTypeDef> = {
   },
 }
 
-/** Passing travelers start supplied for their own journey. */
-const HUNGER: StatRange = { min: 80, max: 100 }
-const THIRST: StatRange = { min: 80, max: 100 }
-const STAMINA: StatRange = { min: 40, max: 100 }
+/** Start fully supplied and rested; keep the rolls to preserve the seeded cast. */
+const HUNGER: StatRange = { min: 100, max: 100 }
+const THIRST: StatRange = { min: 100, max: 100 }
+const STAMINA: StatRange = { min: 100, max: 100 }
 
 const FIRST_NAMES = {
   Male: [


### PR DESCRIPTION
Road travellers and founding town residents now start with hunger, thirst, and stamina at 100%. Fixed stat ranges preserve the existing seeded cast and movement. Saved progress and normal need decay retain their existing behavior.

Validation:
- TypeScript check and production build passed; Vercel preview passed.
- All 130 focused traveller, simulation, party, weariness, and save tests passed.
- Full suite: 1,885 passed, 22 timed out, and one bridge map-generation test failed. All 451 tests in the 12 timeout-affected suites passed when rerun with one worker and a 30-second default timeout.
- The bridge failure (`foundSite`, `generate-map.ts:994`) reproduces on the unchanged parent commit; it is unrelated to traveller initialization.
