### PR TITLE
Fix mobile twist direction and snap to isometric views

### DIFF
--- a/components/game/camera-rig.tsx
+++ b/components/game/camera-rig.tsx
@@ -50,6 +50,13 @@ export function CameraRig({ map, onPlace }: { map: GameMap; onPlace?: (at: TileP
     const { pan, setHovered } = useCameraStore.getState()
 
     const gesture = new CameraGesture()
+    let needsRotationSnap = false
+    const snapRotation = () => {
+      if (!needsRotationSnap) return
+      needsRotationSnap = false
+      const { viewIndex, inputLocked } = useCameraStore.getState()
+      if (!inputLocked) useCameraStore.setState({ viewIndex: Math.round(viewIndex) })
+    }
     const point = (event: PointerEvent) => ({ x: event.clientX, y: event.clientY })
     const previousTouchAction = canvas.style.touchAction
     canvas.style.touchAction = "none"
@@ -122,8 +129,9 @@ export function CameraRig({ map, onPlace }: { map: GameMap; onPlace?: (at: TileP
         const oldYaw = displayYaw.current
         if (gesture.pinching) {
           // Touch follows the fingers directly, including during camera tweens.
-          // Clockwise fingers turn the ground clockwise, so camera yaw decreases.
-          displayYaw.current -= movement.rotation
+          // Increasing yaw turns the projected ground clockwise on screen.
+          displayYaw.current += movement.rotation
+          needsRotationSnap = true
           useCameraStore.setState({
             viewIndex: (displayYaw.current - yawForView(0)) / (Math.PI / 2),
             viewSize: displayViewSize.current,
@@ -146,6 +154,9 @@ export function CameraRig({ map, onPlace }: { map: GameMap; onPlace?: (at: TileP
     const endDrag = (event: PointerEvent) => {
       if (!gesture.has(event.pointerId)) return
       const tap = gesture.end(event.pointerId, point(event), event.type !== "pointerup")
+      // Let the existing yaw tween settle at the nearest isometric view as
+      // soon as the two-finger gesture ends, even if one finger keeps panning.
+      if (!gesture.pinching) snapRotation()
       if (event.type === "pointerup") trackEdgePointer(event)
       else edgePointer.current = null
       if (canvas.hasPointerCapture(event.pointerId)) canvas.releasePointerCapture(event.pointerId)
@@ -169,6 +180,7 @@ export function CameraRig({ map, onPlace }: { map: GameMap; onPlace?: (at: TileP
     const onBlur = () => {
       edgePointer.current = null
       gesture.clear()
+      snapRotation()
       setHovered(null)
       canvas.style.cursor = "grab"
     }

--- a/lib/game/camera-store.ts
+++ b/lib/game/camera-store.ts
@@ -33,7 +33,7 @@ interface CameraState {
   /** Camera focus point on the ground plane. */
   targetX: number
   targetZ: number
-  /** Unbounded quarter turns; fractional after a touch twist, so yaw stays continuous. */
+  /** Unbounded quarter turns; fractional during a touch twist, snapped on release. */
   viewIndex: number
   /** Orthographic frustum height in world units. */
   viewSize: number

--- a/lib/game/render/iso.ts
+++ b/lib/game/render/iso.ts
@@ -4,7 +4,7 @@
  *
  * The camera is orthographic with a fixed pitch. It orbits a `target` point on
  * the ground plane (y = 0); panning moves that target, keyboard rotation steps
- * by quarter turns, touch twists rotate freely, and zoom changes the frustum height.
+ * by quarter turns, touch twists snap on release, and zoom changes the frustum height.
  */
 
 /** True isometric: atan(1/√2) ≈ 35.264°, so a cube's top face is a regular rhombus. */


### PR DESCRIPTION
Two-finger twists now rotate the map in the same direction as the fingers. When the gesture ends, the camera smoothly settles at the nearest of the four isometric orientations, including after cancellation or losing focus. One-finger panning can continue after either finger lifts.

Validation: 63 camera/game tests passed; TypeScript check passed. Mobile Chromium touch checks cover clockwise/counterclockwise rotation, snapping across view-index boundaries, continued panning, cancellation, blur, small twists, and pinch/spread zoom.
