### PR TITLE
Keep party carts moving around roadside buildings

### DIFF
--- a/lib/game/sim.ts
+++ b/lib/game/sim.ts
@@ -1596,6 +1596,15 @@ function stepTravelParties(sim: SimState, travelers: Traveler[], map: GameMap, d
       continue
     }
     const head = members[0]
+    if (cart && !party.diversion) {
+      const check = Math.floor(cart.progress) * 2 + (party.direction === 1 ? 1 : 0)
+      if (cart.diversionCheck !== check || cart.diversionBuildings !== map.buildings) {
+        cart.diversionCheck = check
+        cart.diversionBuildings = map.buildings
+        party.diversion = cartRoadDiversion(map, cart.pose, cart.progress, party.direction,
+          cart.animal, characterScale, () => parkingContext(sim, head, characterScale)) ?? undefined
+      }
+    }
     const ahead = map.site ? party.direction * partyRoadDelta(map.site.junction, party.progress, length) : Infinity
     if (party.formed && party.cooldown <= 0 && ahead >= 0 && ahead <= 7) {
       party.cooldown = 45; party.decisions++
@@ -1669,7 +1678,7 @@ function stepTravelParties(sim: SimState, travelers: Traveler[], map: GameMap, d
         party.reason = "Turning back together"
       }
       party.singleFile = bridgeInColumn(map, party.progress, party.direction, span, length)
-      if (!party.diversion) party.diversion = findRoadDiversion(map, blockedRoad(map), head, party.progress, party.direction,
+      if (!cart && !party.diversion) party.diversion = findRoadDiversion(map, blockedRoad(map), head, party.progress, party.direction,
         p => roadWorldPoint(map, p, 0)) ?? undefined
     }
     const direction = party.direction, travel = party.speed * dt

--- a/lib/game/transport/party.test.ts
+++ b/lib/game/transport/party.test.ts
@@ -17,10 +17,11 @@ import { partyFormation, partyRoadDelta } from "../travel-parties"
 import { BASE_CHARACTER_SCALE } from "../base-person/gait"
 import { LINEAR_MOVEMENT } from "../motion"
 import { COATS } from "./coats"
-import { partyLoadout } from "./party"
+import { ensurePartyTransport, movePartyCart, partyLoadout } from "./party"
 import { createAnimalRig } from "./animal-rig"
 import { animalStride, RIG_TO_WORLD } from "./assets"
 import { animalLeg } from "./animal-pose"
+import { convoyBuildingsClear } from "./navigation"
 
 function fixture(id = 0, count = 8, direction: 1 | -1 = 1) {
   const map: GameMap = { width: 100, depth: 30, seed: 42, tiles: Array(3000).fill("grass"), buildings: [], road: Array.from({ length: 100 }, (_, x) => ({ x, z: 10 })), shortcuts: [] }
@@ -34,6 +35,49 @@ function fixture(id = 0, count = 8, direction: 1 | -1 = 1) {
 }
 
 describe("party transport", () => {
+  it.each((["donkey", "horse", "ox"] as const).flatMap(animal =>
+    ([1, -1] as const).flatMap(direction => [.1, 1.25].flatMap(dt => [false, true].map(stopped => ({ animal, direction, dt, stopped }))))))(
+    "takes the whole company past an inside bend with $animal, direction $direction, dt $dt, already stopped $stopped", ({ animal, direction, dt, stopped }) => {
+    const id = Array.from({ length: 100 }, (_, id) => id).find(id => partyLoadout(id, 4).cart?.animal === animal)!
+    const { map, travelers } = fixture(id, 4, direction)
+    map.road = [
+      ...Array.from({ length: 41 }, (_, x) => ({ x, z: 10 })),
+      ...Array.from({ length: 10 }, (_, z) => ({ x: 40, z: z + 11 })),
+      ...Array.from({ length: 59 }, (_, x) => ({ x: x + 41, z: 20 })),
+    ]
+    for (const p of map.road) map.tiles[p.z * map.width + p.x] = "path"
+    map.buildings = [{ id: "tavern", buildType: "tavern", label: "Tavern", x: 37, z: 11, w: 3, d: 3,
+      height: 1, color: "tan", roofColor: "brown" }]
+    for (const t of travelers) t.offset = (direction === 1 ? 30 : 49) / (map.road.length - 1)
+    const sim = createSim(travelers, map)
+    sim.balance = { ...DEFAULT_BALANCE, rules: { ...DEFAULT_BALANCE.rules, hungerDecay: 0, thirstDecay: 0, staminaDecay: 0 } }
+    const party = sim.parties.get(id)!
+    if (stopped) {
+      // Resume a wagon already stranded by the old road-only movement.
+      ensurePartyTransport(party, [...sim.travelers.values()], map, BASE_CHARACTER_SCALE)
+      let blocked = false
+      for (let tick = 0; tick < 500 && !blocked; tick++) {
+        blocked = !movePartyCart(party, map, BASE_CHARACTER_SCALE, 1, .1)
+      }
+      expect(blocked).toBe(true)
+      party.progress = party.transport!.progress
+      party.formed = false
+    }
+    let diverted = false, passed = false
+    for (let tick = 0; tick < Math.ceil(100 / dt); tick++) {
+      stepSim(sim, travelers, map, 1, dt)
+      const cart = party.transport!
+      expect(cart).toBeDefined()
+      expect(convoyBuildingsClear(map, cart.pose, animal, BASE_CHARACTER_SCALE)).toBe(true)
+      diverted ||= !!party.diversion
+      passed = travelers.every(t => direction * (sim.travelers.get(t.id)!.progress - 40) > 8)
+      if (passed && !party.diversion) break
+    }
+    expect(passed, party.reason).toBe(true)
+    expect(diverted).toBe(true)
+    expect(party.diversion).toBeUndefined()
+  })
+
   it("keeps riders separate, moves the cart and leaves room for walkers", () => {
     const { sim, run, party } = fixture()
     run(.1)

--- a/lib/game/transport/party.ts
+++ b/lib/game/transport/party.ts
@@ -9,6 +9,7 @@ import { followCart, type CartPose } from "./follow"
 import { convoyBuildingsClear, parkingClear, shrineParking, type ParkingContext, type ShrineParking } from "./navigation"
 import { routeLength, routePoint } from "./roadside"
 import { advanceCartProgress } from "./route"
+import { driveRouteSegment } from "./building-parking"
 import { seatPoint, type PassengerCart, type PackAnimal } from "./party-assets"
 
 export interface PartyTransport {
@@ -24,6 +25,9 @@ export interface PartyTransport {
   animalDistance: number
   animalHeading: number
   retry: number
+  /** Check the whole convoy ahead once per road tile/direction or building edit. */
+  diversionCheck?: number
+  diversionBuildings?: GameMap["buildings"]
 }
 export interface PartyPack { kind: PackAnimal; handler: number; progress: number; pose: CartPose; distance: number }
 
@@ -107,11 +111,20 @@ export function movePartyCart(party: TravelParty, map: GameMap, scale: number, s
     const length = map.road!.length - 1, cut = party.diversion
     const span = cut ? party.direction * (cut.end - cut.start) : 0
     const along = cut && span > 0 ? party.direction * partyRoadDelta(cart.progress, cut.start, length) / span : -1
-    if (cut && along >= -1e-9 && along < 1) {
-      // The detour was planned around the footprint for the whole company; the
-      // wagon follows the same points, keeping road progress in step with them.
+    // Wrapped progress can round just below the endpoint; let the wagon leave
+    // while its followers still need the shared detour behind it.
+    if (cut && along >= -1e-9 && along < 1 - 1e-9) {
+      // Follow every planned bend, even when a large tick crosses waypoints.
+      // Cutting straight to its endpoint can drag the trailing axle into a wall.
       const distance = Math.min(cut.length, Math.max(0, along) * cut.length + travel)
-      pose = followCart(previous, routePoint(diversionPoints(cut), distance), wheelbase)
+      let axleDistance = 0
+      const next = driveRouteSegment(previous, diversionPoints(cut), Math.max(0, along) * cut.length, distance,
+        wheelbase, (p, heading) => {
+          axleDistance += p.distance
+          return convoyBuildingsClear(map, p, cart.animal, scale, heading)
+        })
+      if (!next || !convoyBuildingsClear(map, next, cart.animal, scale)) return false
+      pose = { ...next, distance: axleDistance }
       progress = distance >= cut.length ? ((cut.end % length) + length) % length
         : ((cut.start + party.direction * distance / cut.length * span) % length + length) % length
     } else {


### PR DESCRIPTION
Party wagons could stop permanently beside a building on the inside of a road bend, holding their companions there. They now use the existing full-convoy detour planner before reaching the obstruction, including when resuming an already-stopped wagon.

Detour movement follows every planned waypoint with swept building-clearance checks. A tolerance at the rejoin point prevents floating-point rounding from trapping the wagon while companions finish the shared route.

Validation:
- 24 regression cases cover donkey, horse and ox carts, both directions, small/large ticks, and already-stopped carts. The 12 approach cases fail before the fix.
- Full suite: 1,935 passed; one existing bridge-generation failure reproduced on unmodified main (`foundSite`, `generate-map.ts:994`).
- Production build, TypeScript check, and base/population/monk asset checks pass.
- Browser simulation smoke check: all eight party wagons advanced through 60 simulated seconds without page errors.
