### PR TITLE
Make repeated Ent cheat codes toggle the setting off

### DIFF
--- a/components/game/cheat-bar.tsx
+++ b/components/game/cheat-bar.tsx
@@ -3,8 +3,9 @@
 import { useEffect, useRef, useState } from "react"
 
 /** Return opens the console without stealing Enter from existing HUD controls. */
-export function CheatBar({ onBlasterPastor, onLastMarch, blasterPastor = false }: {
+export function CheatBar({ onBlasterPastor, onLastMarch, blasterPastor = false, lastMarch = false }: {
   blasterPastor?: boolean
+  lastMarch?: boolean
   onBlasterPastor: () => void
   onLastMarch: () => void
 }) {
@@ -76,7 +77,9 @@ export function CheatBar({ onBlasterPastor, onLastMarch, blasterPastor = false }
               close()
             } else if (/^(the)?lastmarchoftheents$/i.test(code.trim())) {
               onLastMarch()
-              setMessage("The Ents are waking… About 1 in 100 trees will stroll, resting a minute between walks.")
+              setMessage(lastMarch
+                ? "The Ents are sleeping — the trees are rooted once more."
+                : "The Ents are waking… About 1 in 100 trees will stroll, resting a minute between walks.")
               close()
             } else {
               setMessage("Unknown cheat code. Try again.")

--- a/components/game/game-shell.tsx
+++ b/components/game/game-shell.tsx
@@ -422,7 +422,7 @@ export function GameShell({
         }}
         onSeedChange={setSeed}
       />
-      {revealPhase === "complete" && <CheatBar blasterPastor={blasterPastor} onBlasterPastor={() => setBlasterPastor(active => !active)} onLastMarch={() => setLastMarch(true)} />}
+      {revealPhase === "complete" && <CheatBar blasterPastor={blasterPastor} lastMarch={lastMarch} onBlasterPastor={() => setBlasterPastor(active => !active)} onLastMarch={() => setLastMarch(active => !active)} />}
     </div>
   )
 }


### PR DESCRIPTION
Entering `lastmarchoftheents` a second time now turns the setting off and confirms that the trees are rooted again. Both spellings, with or without `the`, share the toggle, making all current setting cheats behave consistently with `blasterpastor`.

Validation: `npm run typecheck`; 13 passing tests across the existing Ent and monk-flight suites; Playwright smoke check in the actual `/play` game covering repeated on/off cycles for both cheats, case/whitespace handling, mixed Ent aliases, and removal of live Ents when disabled.
