### PR TITLE
Rework enclave visits, recruitment, water access and happiness

### DIFF
--- a/components/game/monks.tsx
+++ b/components/game/monks.tsx
@@ -5,7 +5,7 @@ import { SceneAssetBoundary } from "./scene-assets"
 import { stepDevotion } from "@/lib/game/wellbeing"
 import { useBalanceStore } from "@/lib/game/balance-store"
 import { simRegistry } from "@/lib/game/sim"
-import { shrineLayout, shrineStations } from "@/lib/game/shrine-layout"
+import { shrineLayout, shrineStations, isRelicViewingSeat } from "@/lib/game/shrine-layout"
 import { tileToWorldX, tileToWorldZ } from "@/lib/game/map/types"
 import { monkBeds } from "@/lib/game/housing"
 import { recordWalkingPath } from "@/lib/game/footpaths"
@@ -229,7 +229,7 @@ export function Monks({ map, monks, relic, flying = false, characterScale = 1 }:
         const sim = simRegistry.current
         const sameWorld = sim && sim.world.road === map.road
         const showing = sameWorld && world.procession.stage === "idle" && [...sim.travelers.values()]
-          .some(visitor => visitor.activity === "visiting" && visitor.shrineSeat?.startsWith("queue-"))
+          .some(visitor => visitor.activity === "visiting" && isRelicViewingSeat(visitor.shrineSeat))
         s.activity = showing ? "showingRelic" : "keepingRelic"
         group.userData.activity = s.activity
         group.userData.moving = false

--- a/components/game/shrine.tsx
+++ b/components/game/shrine.tsx
@@ -19,7 +19,7 @@ import { RelicDisplay } from "./relic-display"
 import { shrineStructureParts } from "@/lib/game/building-art/structure"
 import { simRegistry } from "@/lib/game/sim"
 import { RELIC_TABLE_TOP } from "@/lib/game/building-art/early-geometry"
-import { shrineLayout } from "@/lib/game/shrine-layout"
+import { shrineLayout, isRelicViewingSeat } from "@/lib/game/shrine-layout"
 import {
   buildingObjectId,
   encodeObjectId,
@@ -40,7 +40,7 @@ export function Shrine({ map, relic, showInteriors = false }: { map: GameMap; re
     const sim = simRegistry.current
     const available = !processionRegistry.current || !relicIsCarried(processionRegistry.current)
     const showing = relicSelected || (available && sim && sim.world.road === map.road && sim.shrineKeeperReady
-      && [...sim.travelers.values()].some(s => s.activity === "visiting" && s.shrineSeat?.startsWith("queue-")))
+      && [...sim.travelers.values()].some(s => s.activity === "visiting" && isRelicViewingSeat(s.shrineSeat)))
     if (relicGroup.current) relicGroup.current.visible = near && available && !!showing
     if (veilGroup.current) {
       veilGroup.current.scale.y = showing ? .16 : 1

--- a/lib/game/hospitality.test.ts
+++ b/lib/game/hospitality.test.ts
@@ -79,9 +79,9 @@ describe("cross evangelism", () => {
       const t = traveler(id, id % 2 === 0 ? 1 : -1)
       const sim = createSim([t], map, [], obscure)
       const s = sim.travelers.get(id)!
-      expect(visitChance(t.attributes, obscure)).toBe(0)
+      expect(visitChance(t.attributes, obscure)).toBe(0.1)
       stepSim(sim, [t], map, 1.5, 0.2)
-      expect(s.rolls).toBe(2)
+      expect([1, 2]).toContain(s.rolls)
       expect(s.piety).toBe(t.attributes.piety)
       if (s.activity === "toRelic") persuaded++
       else {
@@ -92,8 +92,8 @@ describe("cross evangelism", () => {
         expect(s.rolls).toBe(2)
       }
     }
-    expect(persuaded).toBeGreaterThan(30)
-    expect(persuaded).toBeLessThan(70)
+    expect(persuaded).toBeGreaterThan(120)
+    expect(persuaded).toBeLessThan(175)
   })
 
   it("does not roll evangelism when the ordinary visit roll succeeds", () => {
@@ -148,7 +148,7 @@ describe("monk evangelism at the junction", () => {
     return monk
   }
 
-  it("persuades about 5% of uninterested travelers in both directions, once per pass", () => {
+  it("adds evangelism to the base ten percent visit chance in both directions, once per pass", () => {
     const { map, traveler } = fixture()
     preacher(map)
     let persuaded = 0
@@ -156,7 +156,7 @@ describe("monk evangelism at the junction", () => {
       const t = traveler(id, id % 2 === 0 ? 1 : -1), sim = createSim([t], map, [], obscure)
       stepSim(sim, [t], map, 1.5, .2)
       const s = sim.travelers.get(id)!
-      expect(s.rolls).toBe(2)
+      expect([1, 2]).toContain(s.rolls)
       if (s.activity === "toRelic") persuaded++
       else {
         s.progress = map.site!.junction
@@ -164,8 +164,8 @@ describe("monk evangelism at the junction", () => {
         expect(s.rolls).toBe(2)
       }
     }
-    expect(persuaded).toBeGreaterThan(30)
-    expect(persuaded).toBeLessThan(70)
+    expect(persuaded).toBeGreaterThan(120)
+    expect(persuaded).toBeLessThan(175)
   })
 
   it.each(["open", "unaffordable", "blocked", "recalled"])("respects shrine access and recall: %s", access => {
@@ -416,7 +416,7 @@ describe("shrine hospitality", () => {
     expect(visitChance({ ...a, piety: 100 }, holy)).toBeGreaterThan(visitChance(a, holy))
     expect(visitChance({ ...a, hunger: 0 }, obscure)).toBe(0.1)
     expect(visitChance({ ...a, hunger: 0 }, obscure, DEFAULT_BALANCE.rules.drawCap)).toBeCloseTo(0.6)
-    expect(visitChance({ ...a, thirst: 35 }, obscure)).toBe(0)
+    expect(visitChance({ ...a, thirst: 35 }, obscure)).toBe(0.1)
   })
 
   it.each([1, -1] as const)("does not turn desperate travelers back toward the shrine (direction %i)", (direction) => {
@@ -433,7 +433,7 @@ describe("shrine hospitality", () => {
     expect(s.direction).toBe(direction)
   })
 
-  it("does not lure ordinary passersby with a job vacancy or moderate needs", () => {
+  it("offers a visit before considering any job vacancy", () => {
     for (let id = 0; id < 40; id++) {
       const { map, camp, trees, traveler } = fixture()
       const t = traveler(id, id % 2 === 0 ? 1 : -1)
@@ -444,8 +444,9 @@ describe("shrine hospitality", () => {
       sim.shrineRenown = 20
       run(sim, [t], map, 1)
       const s = sim.travelers.get(id)!
-      expect(s.activity).toBe("walking")
-      expect((s.progress - map.site!.junction) * t.direction).toBeGreaterThan(0)
+      expect(s.employer).toBeNull()
+      expect(["walking", "toRelic"]).toContain(s.activity)
+      if (s.activity === "walking") expect((s.progress - map.site!.junction) * t.direction).toBeGreaterThan(0)
     }
   })
 
@@ -464,7 +465,8 @@ describe("shrine hospitality", () => {
       }
     }
     expect(established).toBeGreaterThan(early)
-    expect(early).toBeLessThan(9) // Under one visit per ten initial passersby across these worlds.
+    expect(early).toBeGreaterThanOrEqual(5)
+    expect(early).toBeLessThanOrEqual(15) // About one visit per ten initial passersby.
     // Three generated worlds, twice over: slow, but the only end-to-end check.
   }, 30000)
 })
@@ -633,6 +635,8 @@ describe("woodcutter huts", () => {
     const sim = createEstablishedShrine([t], builtMap, holy)
     sim.buildings = woodcutterHuts(builtMap)
     sim.trees = trees
+    // This test exercises delivery accounting with an already hired worker.
+    Object.assign(sim.travelers.get(0)!, { employer: sim.buildings[0].id, home: builtMap.buildings.find(b => b.buildType === "house")!.id, activity: "idle", timer: 0 })
     syncTimberSpending(sim, bought.settlement.spentWood)
     run(sim, [t], builtMap, 450, () => sim.wood > 0)
     expect(sim.travelers.get(0)!.employer).toBe(bought.settlement.structures[0].id)
@@ -900,7 +904,7 @@ describe("houses, counters and posts", () => {
       const place = { ...def, id: `${type}-0`, buildType: type, label: def.label, x: 13, z: 9, rotation: 0 as const }
       map.buildings.push(place)
       addHouse(map)
-      const people = Array.from({ length: 4 }, (_, id) => {
+      const people = Array.from({ length: 24 }, (_, id) => {
         const t = devout(traveler(id))
         t.attributes.jobless = true
         return t
@@ -929,7 +933,7 @@ describe("houses, counters and posts", () => {
     map.buildings.push(camp)
     addHouse(map)
     addHouse(map, { x: 6, z: 12 })
-    const people = Array.from({ length: 4 }, (_, id) => {
+    const people = Array.from({ length: 24 }, (_, id) => {
       const t = devout(traveler(id))
       t.attributes.jobless = true
       return t
@@ -937,7 +941,7 @@ describe("houses, counters and posts", () => {
     const sim = createEstablishedShrine(people, map, holy)
     sim.buildings = jobBuildings(map)
     sim.trees = trees
-    run(sim, people, map, 400, () => [...sim.travelers.values()].filter(s => s.home).length === 3)
+    run(sim, people, map, 1200, () => [...sim.travelers.values()].filter(s => s.home).length === 3)
     const settled = [...sim.travelers.values()].filter(s => s.home)
     expect(settled.length).toBe(3)
     // Two beds to a house, so the third settler goes to the second house.
@@ -960,6 +964,7 @@ describe("houses, counters and posts", () => {
     const sim = createSim([vendor], map, [], obscure)
     sim.buildings = jobBuildings(map)
     const s = sim.travelers.get(id)!
+    Object.assign(s, { visits: 1, marketInterest: true })
     run(sim, [vendor], map, 300, () => s.activity === "posted")
     expect(s.employer).toBe(stall.id)
     expect(s.activity).toBe("posted")
@@ -985,6 +990,7 @@ describe("houses, counters and posts", () => {
     const sim = createSim([vendor], map, [], obscure)
     sim.buildings = jobBuildings(map)
     const keeper = sim.travelers.get(vendor.id)!
+    Object.assign(keeper, { visits: 1, marketInterest: true })
     run(sim, [vendor], map, 300, () => keeper.activity === "posted")
     expect(keeper.activity).toBe("posted")
 
@@ -1300,7 +1306,7 @@ describe("traveling monks and housing limits", () => {
     const { traveler } = fixture()
     const attributes = traveler(0).attributes
     expect(visitChance(attributes, obscure, 0, DEFAULT_BALANCE, 0, "friar")).toBe(0.6)
-    expect(visitChance(attributes, obscure, 0, DEFAULT_BALANCE, 0, "peasant")).toBe(0)
+    expect(visitChance(attributes, obscure, 0, DEFAULT_BALANCE, 0, "peasant")).toBe(0.1)
   })
 
   it("admits some visiting monks to free shelter beds, preserving their identity and arrival", () => {
@@ -1353,7 +1359,7 @@ describe("traveling monks and housing limits", () => {
 
   it("limits new workers to completed house beds even when more jobs are open", () => {
     const { map, camp, trees, traveler } = fixture()
-    const people = Array.from({ length: 30 }, (_, id) => traveler(id))
+    const people = Array.from({ length: 100 }, (_, id) => traveler(id))
     const sim = createSim(people, map)
     sim.buildings = [camp]; sim.trees = trees
     const completeVisits = () => {
@@ -1495,7 +1501,7 @@ describe("choosing tavern company or free water", () => {
         expect(s.activity).toBe("fromWater")
         expect(s.thirst).toBe(100)
         expect(s.gold).toBe(10)
-        expect(s.happiness).toBe(80)
+        expect(s.happiness).toBeGreaterThanOrEqual(80)
       }
     }
   })
@@ -1531,4 +1537,48 @@ describe("choosing tavern company or free water", () => {
       expect(s.waterVisit).toBeUndefined()
     } else expect(s.tavernVisit).toBeUndefined()
   })
+})
+
+it("rewards every completed viewing and independently hires about ten percent when jobs and beds are available", () => {
+  let hired = 0, gifts = 0
+  for (let id = 0; id < 1000; id++) {
+    const { map, camp, trees, traveler } = fixture()
+    addHouse(map)
+    const t = traveler(id)
+    Object.assign(t.attributes, { happiness: 40, piety: 40, gold: 20, jobless: id % 2 === 0 })
+    const sim = createSim([t], map, [], holy)
+    Object.assign(sim.balance.rules, { hungerDecay: 0, thirstDecay: 0, staminaDecay: 0, happinessDecay: 0, pietyDecay: 0 })
+    sim.buildings = [camp]; sim.trees = trees
+    const s = sim.travelers.get(id)!, plan = shrineVisitPlan(map, id, 0)!, end = plan.route.at(-1)!
+    Object.assign(s, { activity: "visiting", timer: 0, shrineRoute: plan.route, shrineSeat: plan.seat,
+      branchProgress: plan.route.length - 1, x: tileToWorldX(map, end.x), z: tileToWorldZ(map, end.z) })
+    stepSim(sim, [t], map, 1.5, .1)
+    expect(s.visits).toBe(1)
+    expect(s.happiness).toBe(60)
+    expect(s.piety).toBeGreaterThan(40)
+    expect(s.employer).toBeNull()
+    run(sim, [t], map, 60, () => s.activity === "walking" || !!s.employer)
+    if (s.employer) hired++
+    if (sim.shrineGold > 0) gifts++
+    expect(s.offeringMade).toBe(true)
+  }
+  expect(hired).toBeGreaterThan(75)
+  expect(hired).toBeLessThan(125)
+  expect(gifts).toBeGreaterThan(200)
+  expect(gifts).toBeLessThan(800)
+}, 20000)
+
+it("sends an enclave water visitor on to see the relic", () => {
+  const { map, traveler } = fixture()
+  map.buildings.push({ ...BUILD_CATALOG.find(b => b.id === "well")!, id: "well", buildType: "well", x: 6, z: 6 })
+  const t = traveler(0)
+  t.attributes.thirst = 5
+  const sim = createSim([t], map, [], holy), s = sim.travelers.get(0)!
+  Object.assign(sim.balance.rules, { thirstDecay: 0, hungerDecay: 0, staminaDecay: 0 })
+  stepSim(sim, [t], map, 1.5, .1)
+  expect(s.activity).toBe("toWater")
+  expect(s.enclaveVisitPending).toBe(true)
+  run(sim, [t], map, 100, () => s.visits > 0)
+  expect(s.thirst).toBe(100)
+  expect(s.visits).toBe(1)
 })

--- a/lib/game/map/generate-map.test.ts
+++ b/lib/game/map/generate-map.test.ts
@@ -164,7 +164,8 @@ describe("generateMap", () => {
             const onApproach = map.site!.branch.some(p => p.x === hovel.x + dx && p.z === hovel.z + dz)
             const onShelterPath = (dz === -1 && dx >= (door.z < hovel.z ? 0 : -1) && dx <= (door.z < hovel.z ? 1 : 0)) ||
               (door.z >= hovel.z && ((dx === -1 && dz >= -1) || (dz === hovel.d && dx <= 1)))
-            expect(onApproach || onShelterPath, `seed ${seed} only the approach and shelter connection are paved`).toBe(true)
+            const onWaterPath = map.buildingAccessTiles?.some(p => p.x === hovel.x + dx && p.z === hovel.z + dz)
+            expect(onApproach || onShelterPath || onWaterPath, `seed ${seed} only the approach, shelter and rear well connections are paved`).toBe(true)
           }
         }
       }

--- a/lib/game/map/seeded-water.test.ts
+++ b/lib/game/map/seeded-water.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import { BUILD_CATALOG } from "../balance"
 import { buildingEntry } from "../building-rotation"
+import { shrineLayout } from "../shrine-layout"
 import { settlementRoute } from "../settlement-route"
 import { createSim, stepSim } from "../sim"
 import { townResidents } from "../town-residents"
@@ -111,6 +112,11 @@ describe("generated drinking water", () => {
     const map = generateMap({ seed })
     const well = map.buildings.find(b => b.id === FOUNDING_WELL_ID)!
     expect(well).toBeDefined()
+    const shrine = map.buildings.find(b => b.id === map.site!.hovelId)!
+    const layout = shrineLayout(shrine, map.site!.door)
+    const dx = well.x + (well.w - 1) / 2 - shrine.x - Math.floor(shrine.w / 2)
+    const dz = well.z + (well.d - 1) / 2 - shrine.z - Math.floor(shrine.d / 2)
+    expect(dx * Math.round(Math.sin(layout.rotation)) + dz * Math.round(Math.cos(layout.rotation))).toBeLessThan(-layout.depth / 2)
     const paths: GameMap = { ...map, tiles: map.tiles.map(t => ["track", "path", "bridge"].includes(t) ? t : "forest") }
     expect(settlementRoute(paths, paths.buildings, map.site!.door, buildingEntry(well))).not.toBeNull()
     for (let z = well.z - 1; z <= well.z + well.d; z++) for (let x = well.x - 1; x <= well.x + well.w; x++) {
@@ -118,7 +124,9 @@ describe("generated drinking water", () => {
     }
     const p = map.site!.branch.reduce((best, p) => Math.hypot(p.x - well.x, p.z - well.z) < Math.hypot(best.x - well.x, best.z - well.z) ? p : best)
     const point = { x: tileToWorldX(map, p.x), z: tileToWorldZ(map, p.z), y: .2 }
-    expect(waterVisitPlan(map, well, point, point)).not.toBeNull()
+    const visit = waterVisitPlan(map, well, point, point)!
+    expect(visit).not.toBeNull()
+    expect(visit.route.some(p => p.x === tileToWorldX(map, map.site!.door.x) && p.z === tileToWorldZ(map, map.site!.door.z))).toBe(true)
     expect(well.owner).toBeUndefined()
   }, 20000)
 })

--- a/lib/game/map/seeded-water.ts
+++ b/lib/game/map/seeded-water.ts
@@ -2,6 +2,7 @@ import { BUILD_CATALOG } from "../balance"
 import { buildingApproaches, buildingEntry, rotatedFootprint, rotateBuildingPoint } from "../building-rotation"
 import { isComplete } from "../construction"
 import { makeRng } from "../rng"
+import { shrineLayout, shrinePoint } from "../shrine-layout"
 import { settlementRoute } from "../settlement-route"
 import { isWaterSource } from "../water-sources/navigation"
 import { levelBuildingGround } from "./elevation"
@@ -32,7 +33,7 @@ export function hasNearbyWater(map: GameMap, from: TilePos, radius = TOWN_WATER_
 
 /** Try a small side clearing without covering routes, entrances, water or ancient hearts. */
 function placeSource(map: GameMap, anchor: TilePos, kind: "well" | "watering-hole",
-  id: string, label: string, rotationStart = 0, townId?: string): BuildingDef | null {
+  id: string, label: string, rotationStart = 0, townId?: string, accessFrom?: TilePos, accepts = (_source: BuildingDef) => true): BuildingDef | null {
   const def = BUILD_CATALOG.find(b => b.id === kind)!
   for (let gap = 2; gap <= 4; gap++) for (let turn = 0; turn < 4; turn++) {
     const rotation = ((rotationStart + turn) % 4) as 0 | 1 | 2 | 3
@@ -45,6 +46,7 @@ function placeSource(map: GameMap, anchor: TilePos, kind: "well" | "watering-hol
       height: def.height, color: def.color, roofColor: def.roofColor,
       ...(townId || kind === "watering-hole" ? { owner: "independent" as const } : {}),
       ...(townId ? { townId } : {}) }
+    if (!accepts(source)) continue
     const patch: TilePos[] = []
     for (let z = source.z - CLEARING_MARGIN; z < source.z + source.d + CLEARING_MARGIN; z++)
       for (let x = source.x - CLEARING_MARGIN; x < source.x + source.w + CLEARING_MARGIN; x++) {
@@ -52,7 +54,7 @@ function placeSource(map: GameMap, anchor: TilePos, kind: "well" | "watering-hol
       }
     if (patch.some(p => {
       const terrain = tileAt(map, p.x, p.z)
-      return Math.min(p.x, p.z, map.width - 1 - p.x, map.depth - 1 - p.z) < ROUTE_EDGE_INSET
+      return Math.min(p.x, p.z, map.width - 1 - p.x, map.depth - 1 - p.z) < (accessFrom ? CLEARING_MARGIN : ROUTE_EDGE_INSET)
         || !terrain || terrain === "water" || terrain === "bridge" || terrain === "darkwood"
         || !!map.water?.depth[p.z * map.width + p.x]
         || map.buildings.some(b => distanceToBuilding(p, b) < 1)
@@ -74,11 +76,11 @@ function placeSource(map: GameMap, anchor: TilePos, kind: "well" | "watering-hol
     for (const p of patch) if (isWoods(candidate.tiles[p.z * map.width + p.x])) candidate.tiles[p.z * map.width + p.x] = "clearing"
     for (const p of footprint) candidate.tiles[p.z * map.width + p.x] = kind === "well" ? "grass" : "clearing"
     candidate.elevation = levelBuildingGround(candidate, source)
-    const route = settlementRoute(candidate, candidate.buildings, anchor, entry, true)
-    if (!route || route.length > 12 || route.some(p => {
+    const route = settlementRoute(candidate, candidate.buildings, accessFrom ?? anchor, entry, true)
+    if (!route || route.length > (accessFrom ? 60 : 12) || route.some(p => {
       const terrain = tileAt(map, p.x, p.z)
       return terrain === "water" || terrain === "bridge" || terrain === "darkwood" ||
-        Math.min(p.x, p.z, map.width - 1 - p.x, map.depth - 1 - p.z) < ROUTE_EDGE_INSET
+        Math.min(p.x, p.z, map.width - 1 - p.x, map.depth - 1 - p.z) < (accessFrom ? CLEARING_MARGIN : ROUTE_EDGE_INSET)
     })) continue
     for (const p of route) {
       const i = p.z * map.width + p.x
@@ -96,13 +98,22 @@ function placeSource(map: GameMap, anchor: TilePos, kind: "well" | "watering-hol
   return null
 }
 
-/** Keep the well near the enclave, beside the final stretch approaching the chapel. */
+/** The water path continues past the church door and around to its rear. */
 export function addFoundingWell(map: GameMap): void {
-  const branch = map.site?.branch ?? []
-  const preferred = Math.max(0, branch.length - 10)
-  const anchors = branch.map((p, i) => ({ p, score: Math.abs(i - preferred) }))
-    .sort((a, b) => a.score - b.score)
-  for (const { p } of anchors) if (placeSource(map, p, "well", FOUNDING_WELL_ID, "Enclave well")) return
+  const site = map.site, shrine = map.buildings.find(b => b.id === site?.hovelId)
+  if (!site || !shrine || map.buildings.some(b => b.id === FOUNDING_WELL_ID)) return
+  const { depth, rotation } = shrineLayout(shrine, site.door)
+  const sin = Math.round(Math.sin(rotation)), cos = Math.round(Math.cos(rotation))
+  const behind = (b: BuildingDef) => {
+    for (const x of [b.x, b.x + b.w - 1]) for (const z of [b.z, b.z + b.d - 1]) {
+      if ((x - shrine.x - Math.floor(shrine.w / 2)) * sin + (z - shrine.z - Math.floor(shrine.d / 2)) * cos >= -depth / 2 - 1) return false
+    }
+    return true
+  }
+  for (let distance = 3; distance <= 30; distance++) for (const side of [0, -4, 4, -8, 8, -12, 12, -16, 16]) {
+    const anchor = shrinePoint(shrine, site.door, side, -Math.ceil(depth / 2) - distance)
+    if (placeSource(map, anchor, "well", FOUNDING_WELL_ID, "Enclave well", 0, undefined, site.door, behind)) return
+  }
 }
 
 /** Seeded chance encounters, with spacing but no regular interval or guaranteed count. */

--- a/lib/game/monks.ts
+++ b/lib/game/monks.ts
@@ -10,7 +10,7 @@ import { deriveSeed, makeRng, SEED_STREAM } from "./rng"
 
 export const MONK_COUNT = 4
 export const MONK_VISIT_CHANCE = 0.6
-export const MONK_JOIN_CHANCE = 0.35
+export const MONK_JOIN_CHANCE = 0.1
 
 export interface MonkAttributes {
   /** Years. */

--- a/lib/game/relic.test.ts
+++ b/lib/game/relic.test.ts
@@ -33,7 +33,7 @@ describe("relic draw", () => {
   it("forecasts an independent evangelism roll only for travelers who would decline", () => {
     const traveler = { ...who(0, 100), hunger: 100, thirst: 100 }
     const obscure = { sanctity: 0, spectacle: 0, doubt: 100 }
-    expect(visitChance(traveler, obscure, 0, DEFAULT_BALANCE, 0.05)).toBeCloseTo(0.05)
+    expect(visitChance(traveler, obscure, 0, DEFAULT_BALANCE, 0.05)).toBeCloseTo(0.145)
     const balance = structuredClone(DEFAULT_BALANCE)
     for (const [ordinary, expected] of [[0.2, 0.24], [0.5, 0.525], [1, 1]]) {
       balance.rules.hospitalityBaseChance = ordinary
@@ -56,7 +56,7 @@ describe("relic draw", () => {
     expect(visitChance(traveler, obscure, 100, balance)).toBeCloseTo(0.325)
   })
 
-  it("starts with rare visitors and attracts a wider crowd as renown grows", () => {
+  it("starts with about one visitor in ten and attracts a wider crowd as renown grows", () => {
     let early = 0, established = 0, count = 0
     for (let seed = 1; seed <= 20; seed++) {
       const relic = generateRelic(seed)
@@ -66,16 +66,16 @@ describe("relic draw", () => {
         count++
       }
     }
-    expect(early / count).toBeGreaterThan(0)
-    expect(early / count).toBeLessThan(0.03)
+    expect(early / count).toBeGreaterThanOrEqual(0.1)
+    expect(early / count).toBeLessThan(0.12)
     expect(established).toBeGreaterThan(early * 2)
   })
 
-  it("keeps ordinary and moderately needy passersby on their way at founding renown", () => {
+  it("gives ordinary and moderately needy passersby a ten percent chance at founding renown", () => {
     for (const renown of [0, 10, 20, 30]) {
       for (const piety of [0, 30, 60, 80]) {
-        expect(visitChance({ ...who(piety, 0), hunger: 30, thirst: 30 }, holy, renown)).toBe(0)
-        expect(visitChance({ ...who(piety, 0), hunger: 30, thirst: 30 }, dubious, renown)).toBe(0)
+        expect(visitChance({ ...who(piety, 0), hunger: 30, thirst: 30 }, holy, renown)).toBe(0.1)
+        expect(visitChance({ ...who(piety, 0), hunger: 30, thirst: 30 }, dubious, renown)).toBe(0.1)
       }
     }
     expect(visitChance(who(95, 20), holy, 0)).toBeGreaterThan(0)
@@ -84,13 +84,13 @@ describe("relic draw", () => {
   it("only draws food and water need below the threshold, never tiredness alone", () => {
     const obscure = { sanctity: 0, spectacle: 0, doubt: 100 }
     const traveler = { ...who(0, 100), hunger: 100, thirst: 100, stamina: 0 }
-    for (const renown of [0, 30, 100]) expect(visitChance(traveler, obscure, renown)).toBe(0)
+    for (const renown of [0, 30, 100]) expect(visitChance(traveler, obscure, renown)).toBe(0.1)
     for (const need of ["hunger", "thirst"] as const) {
-      expect(visitChance({ ...traveler, [need]: 20 }, obscure, 0)).toBe(0)
-      expect(visitChance({ ...traveler, [need]: 10 }, obscure, 0)).toBeCloseTo(0.05)
+      expect(visitChance({ ...traveler, [need]: 20 }, obscure, 0)).toBe(0.1)
+      expect(visitChance({ ...traveler, [need]: 10 }, obscure, 0)).toBeCloseTo(0.1)
       expect(visitChance({ ...traveler, [need]: 30 }, obscure, 100)).toBeCloseTo(0.3)
     }
-    expect(visitChance({ ...traveler, hunger: 60, thirst: 60 }, obscure, 100)).toBe(0)
+    expect(visitChance({ ...traveler, hunger: 60, thirst: 60 }, obscure, 100)).toBe(0.1)
   })
 
   it("applies live piety, need and hospitality strength settings", () => {
@@ -99,8 +99,8 @@ describe("relic draw", () => {
     expect(visitChance(who(80, 0), holy, 0, balance)).toBeGreaterThan(0)
     balance.rules.hospitalityNeedThreshold = 40
     balance.rules.hospitalityRenownBonus = 0.2
-    expect(visitChance(who(0, 100), holy, 0, balance)).toBe(0)
-    expect(visitChance({ ...who(0, 100), hunger: 20 }, holy, 0, balance)).toBeCloseTo(0.05)
+    expect(visitChance(who(0, 100), holy, 0, balance)).toBe(0.1)
+    expect(visitChance({ ...who(0, 100), hunger: 20 }, holy, 0, balance)).toBeCloseTo(0.1)
     expect(visitChance({ ...who(0, 100), thirst: 0 }, { sanctity: 0, spectacle: 0, doubt: 100 }, 100, balance)).toBeCloseTo(0.3)
   })
 

--- a/lib/game/relic.ts
+++ b/lib/game/relic.ts
@@ -143,8 +143,8 @@ export function hospitalityNeedThreshold(shrineRenown: number, balance: GameBala
 
 /**
  * The chance, 0–1, that this traveler turns down the branch when they reach
- * the junction. Early visitors are exceptionally pious or desperate for food
- * or water. Renown broadens those motives, but never creates a motive by itself.
+ * the junction. About one in ten early passersby visits; exceptional piety and
+ * urgent needs can raise that chance. Renown broadens those motives, but never creates a motive by itself.
  * Evangelism gives those who decline one independent second chance. The sim
  * rolls each decision separately (see sim.ts); the HUD rounds their combined chance.
  */
@@ -161,7 +161,7 @@ export function visitChance(who: TravelerAttributes, stats: RelicStats, shrineRe
   const hospitalityReach = Math.min(1, r.hospitalityBaseChance + r.hospitalityRenownBonus * reputation)
   const hospitality = Math.max(0, Math.min(1, (threshold - need) / threshold)) * hospitalityReach
   // Traveling brothers seek the enclave even before its relic is well known.
-  const ordinary = Math.max(devotion, hospitality, calling === "friar" ? MONK_VISIT_CHANCE : 0)
+  const ordinary = Math.max(0.1, devotion, hospitality, calling === "friar" ? MONK_VISIT_CHANCE : 0)
   return ordinary + (1 - ordinary) * Math.max(0, Math.min(1, evangelism))
 }
 

--- a/lib/game/shrine-layout.ts
+++ b/lib/game/shrine-layout.ts
@@ -46,3 +46,8 @@ export function shrineStations(building: Pick<BuildingDef,"x"|"z"|"w"|"d">, door
     queueCapacity: Math.max(1, layout.depth - 2),
   }
 }
+
+/** Queue visitors and gathered companies both ask the keeper to uncover the relic. */
+export function isRelicViewingSeat(seat?: string): boolean {
+  return !!seat && (seat.startsWith("queue-") || seat.startsWith("group-"))
+}

--- a/lib/game/shrine-navigation.test.ts
+++ b/lib/game/shrine-navigation.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 import { buildingStepAllowed, shrineFurnitureClear } from "./building-navigation"
 import { monkWander, type WanderSpot } from "./monk-wander"
-import { shrineLayout, shrineSeats, shrineStations } from "./shrine-layout"
+import { shrineLayout, shrineSeats, shrineStations, isRelicViewingSeat } from "./shrine-layout"
 import { shrineExitPlan, shrineVisitPlan } from "./shrine-visit"
 import { processionGrounds } from "./relic-procession"
 import { tileToWorldX, tileToWorldZ, type GameMap, type TilePos } from "./map/types"
@@ -16,6 +16,22 @@ function fixture(direction: number): GameMap {
 }
 
 describe("church circulation", () => {
+  it.each([0, 1, 2, 3])("reserves twenty distinct group places inside the nave (view %i)", direction => {
+    const map = fixture(direction), occupied = new Set<string>(), points = new Set<string>()
+    for (let id = 0; id < 20; id++) {
+      const plan = shrineVisitPlan(map, id, 0, occupied, undefined, false, true)!
+      expect(plan, `group visitor ${id}`).not.toBeNull()
+      expect(isRelicViewingSeat(plan.seat)).toBe(true)
+      expect(shrineFurnitureClear(map.buildings[0], map.site!.door, plan.route.at(-1)!, plan.point!)).toBe(true)
+      occupied.add(plan.seat)
+      points.add(JSON.stringify(plan.point))
+    }
+    expect(occupied.size).toBe(20)
+    expect(points.size).toBe(20)
+    expect(shrineVisitPlan(map, 30, 0, occupied)).toBeNull()
+    expect(isRelicViewingSeat("prayer-0")).toBe(false)
+  })
+
   it.each([0, 1, 2, 3])("keeps prayer, queue and the offering-box exit reachable (view %i)", direction => {
     const map = fixture(direction), shrine = map.buildings[0], seats = shrineSeats(shrine, map.site!.door)
     const stations = shrineStations(shrine, map.site!.door)

--- a/lib/game/shrine-visit.ts
+++ b/lib/game/shrine-visit.ts
@@ -1,5 +1,5 @@
 import { shrineLayout, shrineSeats, shrineStations, shrinePoint } from "./shrine-layout"
-import { buildingStepAllowed, shrineGates } from "./building-navigation"
+import { buildingStepAllowed, shrineFurnitureClear, shrineGates } from "./building-navigation"
 import { tileToWorldX, tileToWorldZ, type GameMap, type TilePos } from "./map/types"
 import { settlementRoute, shrineApproach } from "./settlement-route"
 
@@ -14,22 +14,36 @@ export function shrineDonation(piety: number, gold: number, rng: () => number): 
   return Math.min(Math.max(0, Math.floor(gold)), 1 + Math.floor(rng() * (1 + Math.floor(devotion * 9))))
 }
 
-/** Reserve an aisle queue place or an open floor space for private prayer. */
-export function shrineVisitPlan(map: GameMap, visitor: number, visits: number, occupied: ReadonlySet<string> = new Set(), from?: TilePos, prayer = (visitor + visits) % 4 === 3) {
+/** Reserve a queue place, private prayer spot, or place in a company’s shared viewing. */
+export function shrineVisitPlan(map: GameMap, visitor: number, visits: number, occupied: ReadonlySet<string> = new Set(), from?: TilePos, prayer = (visitor + visits) % 4 === 3, group = false) {
   const site = map.site
   const shrine = map.buildings.find(b => b.id === site?.hovelId)
   if (!site || !shrine) return null
   const gate = shrineGates(shrine, site.door)[0]
   // A full enclave turns visitors away before any route is planned for them.
   const stations = shrineStations(shrine, site.door)
-  const places = prayer ? shrineSeats(shrine, site.door) : Array.from({ length: stations.queueCapacity }, (_, i) => ({ id: `queue-${i}`, tile: stations.viewing }))
+  // One company occupies the nave together. Subtile places keep the largest
+  // twenty-person companies inside even the small founding church.
+  const groupPlaces: { id: string; tile: TilePos; point: TilePos }[] = []
+  if (group) for (let z = shrine.z; z < shrine.z + shrine.d; z++) for (let x = shrine.x; x < shrine.x + shrine.w; x++) {
+    const tile = { x, z }
+    if (!buildingStepAllowed(map, map.buildings, tile, tile, true) || (x === stations.keeper.x && z === stations.keeper.z)) continue
+    for (const dx of [-.2, .2]) for (const dz of [-.2, .2]) {
+      const point = { x: x + dx, z: z + dz }
+      if (shrineFurnitureClear(shrine, site.door, tile, point)) groupPlaces.push({ id: `group-${x}-${z}-${dx}-${dz}`, tile, point })
+    }
+  }
+  groupPlaces.sort((a, b) => Math.hypot(a.point.x - stations.viewing.x, a.point.z - stations.viewing.z)
+    - Math.hypot(b.point.x - stations.viewing.x, b.point.z - stations.viewing.z))
+  if (group ? [...occupied].some(id => !id.startsWith("group-")) : [...occupied].some(id => id.startsWith("group-"))) return null
+  const places = group ? groupPlaces : prayer ? shrineSeats(shrine, site.door) : Array.from({ length: stations.queueCapacity }, (_, i) => ({ id: `queue-${i}`, tile: stations.viewing }))
   const place = places.find(p => !occupied.has(p.id))
   if (!place || !buildingStepAllowed(map, map.buildings, gate.outside, gate.inside, true)) return null
   const branch = shrineApproach(map, from)
   if (!branch.length) return null
   const inside = settlementRoute(map, map.buildings, gate.inside, place.tile, false, true)
   const approach = settlementRoute(map, map.buildings, site.door, gate.outside)
-  return inside && approach ? { seat: place.id, route: [...branch, ...approach.slice(1), ...inside] } : null
+  return inside && approach ? { seat: place.id, point: group ? groupPlaces.find(p => p.id === place.id)!.point : undefined, route: [...branch, ...approach.slice(1), ...inside] } : null
 }
 
 /** Exit by the side of the nave, visiting the wall box before the single door.

--- a/lib/game/sim.ts
+++ b/lib/game/sim.ts
@@ -1,7 +1,7 @@
 import { ensurePartyTransport, stepPartyPacks, seatParty, parkParty, movePartyCart, turnPartyCart } from "./transport/party"
 import { seatPoint } from "./transport/party-assets"
 import { animalWalkSpeed } from "./transport/assets"
-import { stepDevotion, HAPPINESS_THRESHOLD, TAVERN_HAPPINESS_GAIN } from "./wellbeing"
+import { stepDevotion, stepHappiness, RELIC_HAPPINESS_GAIN, HAPPINESS_THRESHOLD, TAVERN_HAPPINESS_GAIN } from "./wellbeing"
 import { isWaterSource, waterVisitPlan, WATER_SEEK_THRESHOLD, WATER_SEEK_RADIUS, WATER_VISIT_SECONDS, type WaterVisit } from "./water-sources/navigation"
 import { naturalWaterStop, WATER_THIRST_THRESHOLD, WATER_DRINK_SECONDS } from "./natural-water"
 import { tavernWalkingRoute } from "./tavern-navigation"
@@ -83,7 +83,7 @@ import { TRAVELER_TYPES, type Traveler } from "./travelers"
  *  - At the shrine junction, faith, hospitality and evangelism draw visitors
  *    down the branch. The brothers restore their needs and bestow piety before
  *    they return to the road; each visit spreads the shrine's renown.
- *  - Jobless visitors may settle into a woodcutter hut slot, walk to a reserved
+ *  - Visitors may settle into a woodcutter hut slot, walk to a reserved
  *    tree, fell it and haul logs home. Legs never tire on the road.
  *  - Stamina below 20 → leave the road for the nearest open ground (grass, dirt,
  *    or a forest-floor clearing — never solid woods or the road itself) and
@@ -376,6 +376,10 @@ export interface SimTraveler {
   /** Reserved until the visitor has left the shrine approach. */
   shrineSeat?: string
   shrineQueueOrder?: number
+  shrineGroupPoint?: TilePos
+  enclaveVisitPending?: boolean
+  /** A vendor considers keeping a stall only after seeing the relic. */
+  marketInterest?: boolean
   offeringProgress?: number
   offeringMade?: boolean
   /** Road lane used when entering the shrine, including a reversed approach for shelter. */
@@ -697,6 +701,12 @@ function shrineWorldPoint(map: GameMap, s: SimTraveler): WorldPoint {
   const diverted = route[0].x !== site.branch[0].x || route[0].z !== site.branch[0].z
   const lane = diverted ? 0 : s.lane * laneBlend
   const point = routeWorldPoint(map, route, s.branchProgress, lane)
+  if (s.shrineGroupPoint) {
+    const end = route.at(-1)!
+    const blend = Math.max(0, s.branchProgress - (route.length - 2))
+    point.x += (s.shrineGroupPoint.x - end.x) * blend
+    point.z += (s.shrineGroupPoint.z - end.z) * blend
+  }
   if (s.branchProgress < 1) {
     const start = routeWorldPoint(map, route, 0, lane)
     const roadLane = s.activity === "toRelic" ? s.branchEntryLane : s.direction * s.laneOffset
@@ -1094,7 +1104,7 @@ function openSlot(sim: SimState, building: PlacedBuilding): number | null {
 
 /** Unskilled applicants can fill any open slot; only a vendor keeps a stall. */
 function findJob(sim: SimState, s: SimTraveler, map: GameMap): { building: PlacedBuilding; slot: number } | undefined {
-  if (!s.jobless || s.employer) return undefined
+  if (s.employer) return undefined
   for (const building of sim.buildings) {
     if (building.owner === "independent") continue
     const def = BUILDING_KINDS[building.kind]
@@ -1172,6 +1182,7 @@ function startTavernTrip(sim: SimState, s: SimTraveler, map: GameMap,
     if (!physicalNeed && building?.buildType !== "tavern") continue
     const plan = building && tavernVisitPlan(map, building, from, occupied, s)
     if (!plan) continue
+    if (!s.employer && s.partyId === undefined && map.buildings.find(b => b.id === plan.buildingId)?.owner !== "independent") s.enclaveVisitPending = true
     s.tavernVisit = { plan, served: false, returnTo }
     s.walkFrom = { x: s.x, y: s.y, z: s.z }; s.walkT = 0; s.targetId = null
     s.offRoadRoute = [...plan.route, plan.counter.point]
@@ -1218,11 +1229,23 @@ function startWaterTrip(sim: SimState, s: SimTraveler, map: GameMap,
     const plan = waterVisitPlan(map, source, s, back)
     if (!plan) continue
     if (s.activity === "toRelic" || s.activity === "fromRelic") plan.visit.resumeActivity = s.activity
+    if (!s.employer && s.partyId === undefined && s.activity === "walking" && source.owner !== "independent") s.enclaveVisitPending = true
     s.waterVisit = plan.visit; s.offRoadRoute = plan.route; s.walkT = 0; s.targetId = null
     s.activity = "toWater"
     return true
   }
   return false
+}
+
+function refillWater(sim: SimState, s: SimTraveler): void {
+  s.thirst = 100
+  const party = s.partyId === undefined ? undefined : sim.parties.get(s.partyId)
+  if (!party) return
+  party.thirst = 100
+  for (const id of party.members) {
+    const member = sim.travelers.get(id)
+    if (member) member.thirst = 100
+  }
 }
 
 function leaveWater(s: SimTraveler) {
@@ -1370,34 +1393,15 @@ function finishVisit(sim: SimState, s: SimTraveler, map: GameMap): void {
   s.visits++
   sim.visits++
   s.piety = Math.min(100, s.piety + 4 + sim.relic.sanctity / 25)
+  s.happiness = Math.min(100, s.happiness + RELIC_HAPPINESS_GAIN)
+  if (s.convoy) s.marketInterest = nextRoll(s) < .1
   s.shrineRoute = exit.route
   s.branchProgress = exit.route.length - 1
   s.offeringProgress = exit.offeringProgress
   s.activity = "fromRelic"
 }
 
-function settleAfterVisit(sim: SimState, s: SimTraveler, t: Traveler, map: GameMap,
-  travelers: readonly Traveler[] = [], householdHome?: string): void {
-  if (!householdHome && t.party?.partnerId !== undefined && s.partyId !== undefined) {
-    const partner = sim.travelers.get(t.party.partnerId)
-    const identity = travelers.find(other => other.id === t.party!.partnerId)
-    const party = sim.parties.get(s.partyId)
-    if (!partner || !identity || partner.activity !== "walking" || partner.partyVisitAborted ||
-      !party?.visitStarted.includes(partner.id)) return
-    const home = findHome(sim, s, map, 2)
-    const house = map.buildings.find(b => b.id === home)
-    if (!home || !house || ![s, partner].every(person => settlementRoute(map, map.buildings,
-      { x: worldToTileX(map, person.x), z: worldToTileZ(map, person.z) }, buildingEntry(house), false, true))) return
-    // Check both people's opportunities; either partner can get the first job.
-    for (const [applicant, person, companion] of [[s, t, partner], [partner, identity, s]] as const) {
-      settleAfterVisit(sim, applicant, person, map, travelers, home)
-      if (!applicant.employer) continue
-      companion.home = home; companion.jobless = true; companion.activity = "idle"; companion.timer = 0
-      for (const member of [applicant, companion]) { member.partyId = undefined; member.partyWaiting = false; member.partySpeed = undefined }
-      return
-    }
-    return
-  }
+function settleAfterVisit(sim: SimState, s: SimTraveler, t: Traveler, map: GameMap): void {
   if (t.type.id === "friar") {
     const bed = vacantMonkBed(map, sim.joinedMonks.values())
     if (bed && nextRoll(s) < MONK_JOIN_CHANCE) {
@@ -1415,9 +1419,9 @@ function settleAfterVisit(sim: SimState, s: SimTraveler, t: Traveler, map: GameM
     }
     return
   }
-  const home = householdHome ?? s.home ?? findHome(sim, s, map)
+  const home = s.home ?? findHome(sim, s, map)
   const job = s.shrineParking || !home ? undefined : findJob(sim, s, map)
-  if (job && nextRoll(s) < (t.attributes.skills.some((skill) => BUILDING_KINDS[job.building.kind].trades.includes(skill)) ? 0.9 : 0.65)) {
+  if (job && nextRoll(s) < 0.1) {
     const route = settlementRoute(map, [...map.buildings, ...sim.buildings],
       { x: worldToTileX(map, s.x), z: worldToTileZ(map, s.z) },
       buildingEntry(job.building), false, true, s.shrineSeat)
@@ -1538,7 +1542,7 @@ function stepTravelParties(sim: SimState, travelers: Traveler[], map: GameMap, d
       }
       if (cart.phase === "parked" && cart.intent) {
         party.stage = "visiting"; party.elapsed = 0; party.retry = 0
-        party.visitPending = [...party.members]; party.visitStarted = []; cart.intent = undefined
+        party.visitPending = [...party.members]; party.visitStarted = []; party.viewingTogether = false; cart.intent = undefined
       }
       if ((cart.phase === "parked" && !cart.intent && party.stage === "traveling") || cart.phase === "boarding") {
         if (cart.phase === "parked" && party.retry <= 0) {
@@ -1573,11 +1577,10 @@ function stepTravelParties(sim: SimState, travelers: Traveler[], map: GameMap, d
     }
     if (party.stage === "visiting") {
       if (party.visitPending.some(id => !party.members.includes(id))) party.visitPending = party.visitPending.filter(id => party.members.includes(id))
-      // Admission is asked for a few companions at a time; every attempt plans
-      // real routes, so a large company files in over several seconds.
+      // Reserve the whole company in one pass, then wait for everyone at the relic.
       if (party.retry <= 0 && party.visitPending.length) {
         party.retry = 2
-        for (const id of party.visitPending.slice(0, 3)) {
+        for (const id of [...party.visitPending]) {
           const s = sim.travelers.get(id)!
           if (tryRoadVisit(sim, s, identities.get(id)!, map, counters, s.direction, s.progress, characterScale,
             { x: worldToTileX(map, s.x), z: worldToTileZ(map, s.z) }, true)) {
@@ -1587,6 +1590,7 @@ function stepTravelParties(sim: SimState, travelers: Traveler[], map: GameMap, d
           }
         }
       }
+      if (!party.visitPending.length && members.every(s => s.activity === "visiting")) party.viewingTogether = true
       // A closed or saturated enclave cannot keep unadmitted companions forever.
       if (party.elapsed > 120) {
         party.visitPending = []
@@ -1598,15 +1602,12 @@ function stepTravelParties(sim: SimState, travelers: Traveler[], map: GameMap, d
       }
       for (const s of members) if (s.activity === "walking") hold(s)
       if (!party.visitPending.length && members.every(s => s.activity === "walking")) {
-        const considered = new Set<number>()
         for (const s of members) {
-          if (considered.has(s.id) || s.home || s.employer || s.partyVisitAborted || !party.visitStarted.includes(s.id)) continue
+          if (s.home || s.employer || s.partyVisitAborted || !party.visitStarted.includes(s.id)) continue
           const t = identities.get(s.id)!
-          considered.add(s.id)
-          if (t.party?.partnerId !== undefined) considered.add(t.party.partnerId)
-          settleAfterVisit(sim, s, t, map, travelers)
+          settleAfterVisit(sim, s, t, map)
         }
-        // Recruitment may convert a traveler to a monk or admit a household.
+        // Recruitment removes each new resident from the departing company.
         syncTravelParties(sim.parties, travelers, sim.travelers)
         if (!sim.parties.has(party.id)) continue
         party.stage = "traveling"; party.cooldown = 45; party.elapsed = 0
@@ -1615,6 +1616,32 @@ function stepTravelParties(sim: SimState, travelers: Traveler[], map: GameMap, d
         regroupParty(party, members.filter(s => s.partyId === party.id), length, seconds, characterScale)
         continue
       } else { party.reason = party.visitPending.length ? "Waiting for room at the enclave" : "Waiting for companions to finish visiting"; continue }
+    }
+    if (party.waterCarrier !== undefined) {
+      const carrier = sim.travelers.get(party.waterCarrier)
+      if (carrier && carrier.activity !== "walking") {
+        for (const s of members) if (s !== carrier) hold(s)
+        party.reason = "Refilling the company’s water"
+        continue
+      }
+      if (carrier && carrier.thirst > party.thirst) {
+        party.thirst = carrier.thirst
+        for (const s of members) s.thirst = party.thirst
+      }
+      party.waterCarrier = undefined
+      regroupParty(party, members, length, seconds, characterScale)
+    }
+    party.waterRetry = Math.max(0, (party.waterRetry ?? 0) - dt)
+    if (party.thirst < WATER_SEEK_THRESHOLD && !party.waterRetry && members.every(s => s.activity === "walking")) {
+      party.waterRetry = 5
+      const carrier = members.find(s => !s.partyRiding)
+      const sources = map.buildings.filter(isWaterSource)
+      if (carrier && (startWaterTrip(sim, carrier, map, sources, { x: carrier.x, y: carrier.y, z: carrier.z }) || startNaturalWaterTrip(carrier, map))) {
+        party.waterCarrier = carrier.id
+        for (const s of members) if (s !== carrier) hold(s)
+        party.reason = "Refilling the company’s water"
+        continue
+      }
     }
     const onRoad = members.every(s => s.partyRiding || (s.activity === "walking" && !s.roadShortcut && !s.track))
     if (!onRoad) {
@@ -1645,7 +1672,7 @@ function stepTravelParties(sim: SimState, travelers: Traveler[], map: GameMap, d
           continue
         }
         party.stage = "visiting"; party.elapsed = 0; party.retry = 0
-        party.visitPending = [...party.members]; party.visitStarted = []
+        party.visitPending = [...party.members]; party.visitStarted = []; party.viewingTogether = false
         party.reason = "Visiting the enclave together"
         for (const s of members) hold(s)
         continue
@@ -1764,7 +1791,7 @@ function tryRoadVisit(sim: SimState, s: SimTraveler, t: Traveler, map: GameMap,
   const persuaded = evangelism > 0 && nextRoll(s) < evangelism
   // A traveler drawn by need heads for the counter, not the relic.
   // Wagons and horses stay on the road; only walkers turn aside for a meal.
-  if ((ordinaryVisit || persuaded) && served && !needsParking &&
+  if (!partyVisit && (ordinaryVisit || persuaded) && served && !needsParking &&
     (socialNeed || Math.min(s.hunger, s.thirst) < hospitalityNeedThreshold(renown, sim.balance)) &&
     startTavernTrip(sim, s, map, shrineCounters, null)) {
     s.partyVisitAborted = false
@@ -1774,7 +1801,9 @@ function tryRoadVisit(sim: SimState, s: SimTraveler, t: Traveler, map: GameMap,
   const occupiedSeats = new Set([...sim.travelers.values()].flatMap(other =>
     other.shrineSeat && (["toParking","toRelic","visiting","fromRelic","offering"].includes(other.activity) ||
       other.waterVisit?.resumeActivity) ? [other.shrineSeat] : []))
-  const visit = wantsVisit ? shrineVisitPlan(map, s.id, s.visits, occupiedSeats, from) : null
+  const otherCompany = partyVisit && s.partyId !== undefined && [...sim.travelers.values()].some(other =>
+    other.partyId !== s.partyId && other.shrineSeat?.startsWith("group-"))
+  const visit = wantsVisit && !otherCompany ? shrineVisitPlan(map, s.id, s.visits, occupiedSeats, from, partyVisit ? false : undefined, partyVisit && s.partyId !== undefined) : null
   let visitRoute = visit?.route ?? null
   let parking: ShrineParking | null = null
   if (visitRoute && needsParking) {
@@ -1790,6 +1819,7 @@ function tryRoadVisit(sim: SimState, s: SimTraveler, t: Traveler, map: GameMap,
     s.branchProgress = 0
     s.shrineRoute = visitRoute
     s.shrineSeat = visit!.seat
+    s.shrineGroupPoint = visit!.point
     s.admissionPaid = 0
     s.offeringMade = false
     s.offeringProgress = undefined
@@ -1907,9 +1937,9 @@ export function stepSim(
     const socialBreak = s.happiness < HAPPINESS_THRESHOLD && s.gold >= DRINK_PRICE
       && (tavernCounters.length > 1 || (tavernCounters.length === 1 && tavernCounters[0].id !== s.employer))
     const inChurch = s.activity === "visiting" || s.activity === "offering"
-    stepDevotion(s, dt, inChurch, !processionNearby && s.activity === "visiting" && !s.shrineSeat?.startsWith("queue-"), sim.balance)
+    stepDevotion(s, dt, inChurch, !processionNearby && s.activity === "visiting" && !!s.shrineSeat?.startsWith("prayer-"), sim.balance)
     const socializing = s.activity === "sitting" && (s.tavernVisit?.meal || s.tavernVisit?.drink)
-    if (!socializing) s.happiness = Math.max(0, s.happiness - sim.balance.rules.happinessDecay * hours)
+    stepHappiness(s, hours, !!s.employer, !!socializing, sim.balance)
     if (processionNearby) {
       if (dt > 0 && sim.procession) blessByProcession(sim.procession, `traveler:${s.id}`, s)
       s.moveSpeed = 0; continue
@@ -2060,9 +2090,9 @@ export function stepSim(
         s.y = at.y
         s.z = at.z
         if (inbound && s.branchProgress >= branch.length - 1) {
-          if (!s.shrineSeat?.startsWith("queue-") || (sim.shrineKeeperReady && (!sim.procession || sim.procession.stage === "idle"))) {
+          if (s.shrineSeat?.startsWith("prayer-") || (sim.shrineKeeperReady && (!sim.procession || sim.procession.stage === "idle"))) {
             s.activity = "visiting"
-            s.timer = s.shrineSeat?.startsWith("queue-") ? 6 : 2 * GAME_HOUR_SECONDS
+            s.timer = s.shrineSeat?.startsWith("prayer-") ? 2 * GAME_HOUR_SECONDS : 6
           }
         } else if (!inbound && !s.offeringMade && s.offeringProgress !== undefined && s.branchProgress <= s.offeringProgress) {
           s.activity = "offering"
@@ -2071,18 +2101,20 @@ export function stepSim(
           s.lane = s.direction * s.laneOffset
           s.horseRest = undefined
           s.shrineSeat = undefined
+          s.shrineGroupPoint = undefined
           if (s.shrineParking) {
             s.shrineParking.walking = false; s.shrineParking.distance = 0
             s.activity = "fromParking"
           } else {
             s.activity = "walking"; s.shrineRoute = null; s.visitCooldown = 30; s.diversionCheck = undefined
-            if (!s.partyVisitAborted && s.partyId === undefined) settleAfterVisit(sim, s, t, map, travelers)
+            if (!s.partyVisitAborted && s.partyId === undefined) settleAfterVisit(sim, s, t, map)
           }
         }
         break
       }
       case "visiting": {
-        if (s.shrineSeat?.startsWith("queue-") && (!sim.shrineKeeperReady || (sim.procession && sim.procession.stage !== "idle"))) break
+        if (s.shrineSeat?.startsWith("group-") && (s.partyId === undefined || !sim.parties.get(s.partyId)?.viewingTogether)) break
+        if (!s.shrineSeat?.startsWith("prayer-") && (!sim.shrineKeeperReady || (sim.procession && sim.procession.stage !== "idle"))) break
         s.timer -= dt
         if (s.timer <= 0) finishVisit(sim, s, map)
         break
@@ -2178,7 +2210,7 @@ export function stepSim(
       case "idle": {
         s.workScale = characterScale
         if (dt > 0 && s.home && !s.employer && s.jobless && s.timer <= 0) {
-          settleAfterVisit(sim, s, t, map, travelers, s.home)
+          settleAfterVisit(sim, s, t, map)
           if (s.employer) break
           s.timer = GAME_HOUR_SECONDS
         }
@@ -2308,7 +2340,7 @@ export function stepSim(
         if (s.naturalWaterVisit) {
           s.timer -= dt
           if (s.timer < 1e-8) {
-            s.thirst = 100
+            refillWater(sim, s)
             const visit = s.naturalWaterVisit
             startOffRoadWalk(s, "fromWater")
             if (visit.buildings === map.buildings) s.offRoadRoute = [...visit.route]
@@ -2320,7 +2352,7 @@ export function stepSim(
         // Water answers thirst only; no money, food or stamina changes hands.
         s.thirst = Math.min(100, s.thirst + 100 * Math.min(dt, s.timer) / WATER_VISIT_SECONDS)
         s.timer = Math.max(0, s.timer - dt)
-        if (s.timer < 1e-8) { s.timer = 0; s.thirst = 100; leaveWater(s) }
+        if (s.timer < 1e-8) { s.timer = 0; refillWater(sim, s); leaveWater(s) }
         break
       }
       case "fromWater": {
@@ -2402,6 +2434,11 @@ export function stepSim(
       case "fleeing": {
         // The company already placed them on its shared path this step.
         if (s.partyCarried) break
+        if (s.enclaveVisitPending) {
+          s.enclaveVisitPending = false
+          if (map.site && nextRoll(s) < .95 && tryRoadVisit(sim, s, t, map, [], s.direction, s.progress, characterScale,
+            { x: worldToTileX(map, s.x), z: worldToTileZ(map, s.z) }, true)) break
+        }
         const grouped = s.partyId !== undefined
         // A hungry traveler may consider a shrine ahead on their own route.
         // Never turn them back toward a junction they have already passed.
@@ -2433,9 +2470,9 @@ export function stepSim(
         if (dt > 0 && (s.activity === "walking" || s.activity === "seeking") && !isVendor && startNaturalWaterTrip(s, map)) break
         if (townCounter && Math.min(s.hunger, s.thirst) < SERVING_THRESHOLD &&
           startTavernTrip(sim, s, map, [townCounter], null)) break
-        // An empty market stall on the shrine's ground draws a passing vendor
-        // to settle: they leave the road, take the stall, and keep it for good.
-        if (isVendor && !s.employer && !s.track && ahead >= 0 && ahead <= 6 && !s.shrineParking &&
+        // A vendor who chose to stay after viewing the relic can claim an
+        // empty market stall, parking their cart before taking the post.
+        if (isVendor && s.visits > 0 && s.marketInterest && !s.employer && !s.track && ahead >= 0 && ahead <= 6 && !s.shrineParking &&
           s.marketCheck !== Math.floor(s.progress)) {
           s.marketCheck = Math.floor(s.progress)
           const home = findHome(sim, s, map)

--- a/lib/game/transport/party.test.ts
+++ b/lib/game/transport/party.test.ts
@@ -113,28 +113,23 @@ describe("party transport", () => {
     expect(wrapped).toBe(true)
     expect(party.transport!.seats.every(id=>sim.travelers.get(id)!.progress===party.transport!.progress)).toBe(true)
   })
-  it("lets a couple settle after visiting and assigns a remaining passenger to drive", () => {
-    const { sim, run, party, map, travelers } = fixture()
-    travelers[0].party!.partnerId = 1; travelers[1].party!.partnerId = 0
-    for (const id of [0, 1]) { travelers[id].attributes.jobless = true; travelers[id].attributes.skills = ["cooking"]; sim.travelers.get(id)!.jobless = true }
+  it("assigns a remaining passenger to drive when an individual visitor stays", () => {
+    const { sim, run, party, map } = fixture()
     sim.shrineRenown = 10000
     map.site = { hovelId: "shrine", door: { x: 35, z: 14 }, junction: 35, branch: Array.from({length:5},(_,i)=>({x:35,z:10+i})) }
-    map.buildings.push({ id: "shrine", label: "Shrine", x: 34, z: 15, w: 3, d: 3, height: 1, color: "tan", roofColor: "brown" },
-      { ...BUILD_CATALOG.find(b=>b.id==="house")!, id:"house", buildType:"house", x:43,z:14 },
-      { ...BUILD_CATALOG.find(b=>b.id==="tavern")!, id:"tavern", buildType:"tavern", x:48,z:14 })
-    sim.buildings=jobBuildings(map)
-    sim.travelers.set(-1,{...sim.travelers.get(0)!,id:-1,employer:"tavern",home:null,partyId:undefined,activity:"posted",jobSlot:0})
-    let visited=false
-    for(let tick=0;tick<4500;tick++) {
-      run(.1);visited ||= party.stage === "visiting"
-      if(visited && party.transport?.phase==="road" && party.stage==="traveling")break
+    map.buildings.push({ id: "shrine", label: "Shrine", x: 34, z: 15, w: 3, d: 3, height: 1, color: "tan", roofColor: "brown" })
+    let visited = false
+    for (let tick = 0; tick < 4500; tick++) {
+      run(.1); visited ||= party.stage === "visiting"
+      if (visited && party.stage === "traveling") break
     }
-    expect(visited).toBe(true)
     expect(sim.visits).toBe(8)
-    expect(sim.travelers.get(0)!.home).toBe("house")
-    expect(sim.travelers.get(1)!.home).toBe("house")
-    expect(party.transport!.seats).not.toContain(0)
-    expect(party.transport!.seats).not.toContain(1)
+    // Recruitment is covered by the visit tests; exercise the transport handoff.
+    const driver = sim.travelers.get(party.transport!.seats[0])!
+    Object.assign(driver, { home: "house", employer: "tavern", activity: "idle" })
+    for (let tick = 0; tick < 4500 && party.transport!.phase !== "road"; tick++) run(.1)
+    expect(party.transport!.seats).not.toContain(driver.id)
+    expect(party.members).not.toContain(driver.id)
     expect(party.transport!.phase).toBe("road")
     expect(sim.travelers.get(party.transport!.seats[0])!.partyRiding).toBe(true)
   })

--- a/lib/game/travel-parties.test.ts
+++ b/lib/game/travel-parties.test.ts
@@ -96,38 +96,30 @@ describe("coordinated travel", () => {
 })
 
 describe("shared stops", () => {
-  it.each([1, 2])("keeps a couple together when %i beds are available", beds => {
-    const { map, travelers, sim } = fixture(4)
+  it("lets one partner stay for a job without settling their companion", () => {
+    const { map, travelers, sim } = fixture(2)
     travelers[0].party!.partnerId = 1; travelers[1].party!.partnerId = 0
-    for (const id of [0, 1]) { travelers[id].attributes.jobless = true; travelers[id].attributes.skills = ["cooking"]; sim.travelers.get(id)!.jobless = true }
+    for (const id of [0, 1]) sim.travelers.get(id)!.jobless = true
     map.site = { hovelId: "shrine", door: { x: 28, z: 9 }, junction: 28,
       branch: Array.from({ length: 5 }, (_, i) => ({ x: 28, z: 5 + i })) }
-    map.buildings.push({ id: "shrine", label: "Shrine", x: 27, z: 10, w: 3, d: 3, height: 1, color: "tan", roofColor: "brown" })
-    const house = { ...BUILD_CATALOG.find(b => b.id === "house")!, id: "house", buildType: "house", x: 34, z: 9 }
-    const tavern = { ...BUILD_CATALOG.find(b => b.id === "tavern")!, id: "tavern", buildType: "tavern", x: 39, z: 9 }
-    map.buildings.push(house, tavern)
+    map.buildings.push({ id: "shrine", label: "Shrine", x: 27, z: 10, w: 3, d: 3, height: 1, color: "tan", roofColor: "brown" },
+      { ...BUILD_CATALOG.find(b => b.id === "house")!, id: "house", buildType: "house", x: 34, z: 9 },
+      { ...BUILD_CATALOG.find(b => b.id === "tavern")!, id: "tavern", buildType: "tavern", x: 39, z: 9 })
     sim.buildings = jobBuildings(map)
-    // Leave just one job. The second partner must be a real unemployed resident.
-    sim.travelers.set(-1, { ...sim.travelers.get(0)!, id: -1, employer: "tavern", home: null, partyId: undefined, activity: "posted", jobSlot: 0 })
-    if (beds === 1) sim.travelers.set(-2, { ...sim.travelers.get(0)!, id: -2, home: "house", partyId: undefined, activity: "idle" })
     const party = sim.parties.get(0)!
-    run(sim, travelers, map, 350, () => party.decisions > 0 && party.stage === "traveling")
-    expect(sim.visits).toBe(4)
-    const couple = [sim.travelers.get(0)!, sim.travelers.get(1)!]
-    expect(couple.map(s => s.home)).toEqual(beds === 2 ? ["house", "house"] : [null, null])
-    if (beds === 2) {
-      expect(couple.filter(s => s.employer === "tavern")).toHaveLength(1)
-      expect(party.members).toEqual([2, 3])
-      run(sim, travelers, map, 90)
-      expect(couple.every(s => s.partyId === undefined && s.home === "house")).toBe(true)
-      expect(couple.some(s => !s.employer && ["idle", "toHome", "sleeping", "toBuild", "building", "fromBuild"].includes(s.activity))).toBe(true)
-    } else expect(party.members).toEqual([0, 1, 2, 3])
+    run(sim, travelers, map, 2500, () => [...sim.travelers.values()].some(s => !!s.employer))
+    const settled = [...sim.travelers.values()].filter(s => s.employer)
+    expect(settled).toHaveLength(1)
+    expect(settled[0].visits).toBeGreaterThan(0)
+    expect(settled[0].home).toBe("house")
+    const companion = sim.travelers.get(settled[0].id === 0 ? 1 : 0)!
+    expect(companion.home).toBeNull()
+    expect(party.members).toContain(companion.id)
+    expect(party.members).not.toContain(settled[0].id)
   })
 
-
-
-  it("visits together without overbooking, then continues with members who did not settle", () => {
-    const { map, travelers, sim } = fixture(8)
+  it.each([8, 20])("views the relic together without overbooking (%i companions)", count => {
+    const { map, travelers, sim } = fixture(count)
     map.site = { hovelId: "shrine", door: { x: 28, z: 9 }, junction: 28,
       branch: Array.from({ length: 5 }, (_, i) => ({ x: 28, z: 5 + i })) }
     for (const p of map.site.branch) map.tiles[p.z * map.width + p.x] = "track"
@@ -137,10 +129,12 @@ describe("shared stops", () => {
     expect(party.stage).toBe("visiting")
     for (let i = 0; i < 3500 && (party.stage !== "traveling" || !sim.visits); i++) {
       stepSim(sim, travelers, map, 1, .1)
+      // No one completes a viewing before their companions have gathered.
+      expect([0, count]).toContain(sim.visits)
       const seats = [...sim.travelers.values()].flatMap(s => s.shrineSeat ? [s.shrineSeat] : [])
       expect(new Set(seats).size).toBe(seats.length)
     }
-    expect(sim.visits).toBe(8)
+    expect(sim.visits).toBe(count)
     expect(party.decisions).toBe(1)
     expect(party.stage).toBe("traveling")
     // A resident retains identity and position, but no longer holds up departure.
@@ -164,6 +158,21 @@ describe("shared stops", () => {
     run(sim, travelers, map, 30)
     expect(party.stage).toBe("traveling")
     expect([...sim.travelers.values()].every(s => s.activity === "walking")).toBe(true)
+  })
+})
+
+describe("company water stops", () => {
+  it.each(["well", "river"])("refills the shared supply at a %s and resumes travel", source => {
+    const { map, travelers, sim } = fixture(8)
+    if (source === "well") map.buildings.push({ ...BUILD_CATALOG.find(b => b.id === "well")!, id: "well", buildType: "well", x: 24, z: 8 })
+    else map.tiles[7 * map.width + 24] = "water"
+    for (const s of sim.travelers.values()) s.thirst = 5
+    const party = sim.parties.get(0)!, before = party.progress
+    run(sim, travelers, map, 150, () => party.thirst > 95 && party.waterCarrier === undefined)
+    expect(party.thirst).toBeGreaterThan(95)
+    expect([...sim.travelers.values()].every(s => s.thirst > 95 && s.activity === "walking")).toBe(true)
+    run(sim, travelers, map, 10)
+    expect(party.progress).toBeGreaterThan(before)
   })
 })
 

--- a/lib/game/travel-parties.ts
+++ b/lib/game/travel-parties.ts
@@ -27,6 +27,9 @@ export interface TravelParty {
   retry: number
   elapsed: number
   decisions: number
+  viewingTogether?: boolean
+  waterCarrier?: number
+  waterRetry?: number
   visitPending: number[]
   visitStarted: number[]
   /** Road progress of the formation's head. Every place in the company derives from it. */

--- a/lib/game/water-sources/navigation.ts
+++ b/lib/game/water-sources/navigation.ts
@@ -43,7 +43,12 @@ export function waterVisitPlan(map: GameMap, source: BuildingDef, from: WaterPoi
   const placement = waterSourcePlacement(map, source)
   const access = waterSourceAccessPoints(placement)[0]
   const entry = buildingEntry(source)
-  const route = workerRoute(map, from, entry)
+  // The founding source is approached through the church forecourt.
+  const door = source.id === "founding-well" ? map.site?.door : undefined
+  const forecourt = door ? { x: tileToWorldX(map, door.x), y: surfaceHeight(map, door.x, door.z), z: tileToWorldZ(map, door.z) } : undefined
+  const approachRoute = door ? workerRoute(map, from, door) : undefined
+  const onward = workerRoute(map, forecourt ?? from, entry)
+  const route = door ? approachRoute && onward && [...approachRoute, ...onward] : onward
   if (!route) return null
   const front = { x: tileToWorldX(map, entry.x), y: surfaceHeight(map, entry.x, entry.z), z: tileToWorldZ(map, entry.z) }
   // First align with the water point while outside the footprint, then enter

--- a/lib/game/wellbeing.test.ts
+++ b/lib/game/wellbeing.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { GAME_HOUR_SECONDS } from "./calendar"
-import { stepDevotion } from "./wellbeing"
+import { stepDevotion, stepHappiness } from "./wellbeing"
 
 describe("devotion over game time", () => {
   it("drains only the hours beyond a day without church, independently of tick size", () => {
@@ -31,5 +31,20 @@ describe("devotion over game time", () => {
     expect(npc.piety).toBe(100)
     stepDevotion(npc, 10000 * GAME_HOUR_SECONDS, false)
     expect(npc.piety).toBe(0)
+  })
+})
+
+describe("employment and happiness", () => {
+  it("sustains high worker happiness across days, independently of tick size", () => {
+    const whole = { happiness: 20 }, ticks = { happiness: 20 }, traveler = { happiness: 80 }
+    stepHappiness(whole, 72, true, false)
+    for (let i = 0; i < 720; i++) stepHappiness(ticks, .1, true, false)
+    stepHappiness(traveler, 72, false, false)
+    expect(whole.happiness).toBeGreaterThan(84)
+    expect(ticks.happiness).toBeCloseTo(whole.happiness, 8)
+    expect(traveler.happiness).toBe(44)
+    const paused = { happiness: 40 }
+    stepHappiness(paused, 0, true, false)
+    expect(paused.happiness).toBe(40)
   })
 })

--- a/lib/game/wellbeing.ts
+++ b/lib/game/wellbeing.ts
@@ -22,3 +22,14 @@ export function stepDevotion(s: DevotionState, dt: number, inChurch: boolean, pr
   s.piety = Math.max(0, Math.min(100, s.piety + (praying ? balance.rules.prayerPiety * hours : 0)
     - (praying ? 0 : balance.rules.pietyDecay * absence)))
 }
+
+/** A fulfilled visit lifts spirits; steady employment sustains a contented life. */
+export const RELIC_HAPPINESS_GAIN = 20
+export const EMPLOYED_HAPPINESS = 85
+export function stepHappiness(s: { happiness: number }, hours: number, employed: boolean,
+  socializing: boolean, balance: GameBalance = DEFAULT_BALANCE): void {
+  if (hours <= 0 || socializing) return
+  s.happiness = employed
+    ? s.happiness + (EMPLOYED_HAPPINESS - s.happiness) * (1 - Math.exp(-hours / 6))
+    : Math.max(0, s.happiness - balance.rules.happinessDecay * hours)
+}


### PR DESCRIPTION
Early travelers now have roughly a 10% chance to visit the relic, with parties viewing it together and individuals independently taking available work after visiting at a 10% rate when housing permits.
Enclave service visitors usually continue to the relic, the keeper uncovers it for group viewings, and completed visits boost happiness alongside piety while employed residents recover toward 85 happiness.
Move the founding well behind the church with access past its door, and let caravans stop to refill their shared water supply.
Validation: targeted simulation and navigation tests, all 84 map-generation tests, and typecheck pass; broader testing exposed pre-existing wagon-bend and bridge failures reproduced on the unchanged starting commit.
