### PR TITLE
Distribute lumber evenly in low rows with capped visual fullness

### DIFF
--- a/components/game/buildings.tsx
+++ b/components/game/buildings.tsx
@@ -127,7 +127,7 @@ export function Buildings({ map, characterScale = 1.5, showInteriors = false }: 
               {piles.filter((pile) => pile.campId === building.id).map((pile) => {
                 const store = building.buildType === "storehouse"
                 const [x, z] = store ? pileOffset(pile.slot) : workshopPileOffset(pile.slot, local.w, local.d, building.layoutSeed)
-                return <group key={pile.id} position={[x, store ? 0.35 : 0.08, store ? z * 0.5 - 0.1 : z]}><WoodPile pile={pile} objectId={pileObjectId(piles.indexOf(pile))} /></group>
+                return <group key={pile.id} position={[x, store ? 0.35 : 0.08, store ? z * 0.5 - 0.1 : z]}><WoodPile pile={pile} objectId={pileObjectId(piles.indexOf(pile))} availableWidth={store ? local.w / 2 - .2 : local.w / 3 - .16} /></group>
               })}</CloseScenery>
             </group>
           )

--- a/components/game/wood-pile.tsx
+++ b/components/game/wood-pile.tsx
@@ -4,45 +4,43 @@ import { useLayoutEffect, useMemo, useRef } from "react"
 import * as THREE from "three"
 import { selectElement } from "@/lib/game/selection"
 import { encodeObjectId, OUTLINE_ID_LAYER_MASK } from "@/lib/game/render/outline"
-import { WOOD_PER_LOG, pileLogCount, type WoodPile as Pile } from "@/lib/game/trees/timber"
+import type { WoodPile as Pile } from "@/lib/game/trees/timber"
 import { WOOD_LOG, woodLogScale } from "@/lib/game/wood-log"
+import { WOOD_PILE_LAYOUT, woodPileLogs } from "@/lib/game/wood-pile"
 import { useWoodLogGeometry, WoodLogMaterials } from "./wood-log"
 
-/** The character's logs stacked in four columns inside a patch of the camp yard. */
-export function WoodPile({ pile, objectId }: { pile: Pile; objectId: number }) {
+/** Low rows of timber share the character's bark, cut ends and pixel renderer. */
+export function WoodPile({ pile, objectId, availableWidth }: { pile: Pile; objectId: number; availableWidth?: number }) {
   const idColor = useMemo(() => new THREE.Color(...encodeObjectId(objectId)), [objectId])
   const logs = useRef<THREE.InstancedMesh>(null)
   const ids = useRef<THREE.InstancedMesh>(null)
   const geometry = useWoodLogGeometry()
-  // A full stack represents overflow too, so abundant harvest stays under the roof.
-  const count = Math.min(24, pileLogCount(pile.wood))
+  const layout = useMemo(() => woodPileLogs(pile.wood, availableWidth), [pile.wood, availableWidth])
+  const count = layout.length
   useLayoutEffect(() => {
     if (!logs.current || !ids.current) return
     const rotation = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(1, 0, 0), Math.PI / 2)
-    const scale = woodLogScale(), radius = WOOD_LOG.radius * scale
-    const spacing = radius * 2.05
+    const scale = woodLogScale()
     const matrix = new THREE.Matrix4()
     for (let i = 0; i < count; i++) {
-      const fraction = Math.min(1, (pile.wood - i * WOOD_PER_LOG) / WOOD_PER_LOG)
-      const layer = Math.floor(i / 4), column = i % 4
-      const x = (column - 1.5) * spacing + (layer % 2) * spacing / 2
-      const y = radius + layer * spacing * Math.sqrt(3) / 2
-      matrix.compose(new THREE.Vector3(x, y, 0), rotation, new THREE.Vector3(scale, scale * fraction, scale))
+      const { x, y, length } = layout[i]
+      matrix.compose(new THREE.Vector3(x, y, 0), rotation, new THREE.Vector3(scale, length / WOOD_LOG.length, scale))
       logs.current.setMatrixAt(i, matrix)
       ids.current.setMatrixAt(i, matrix)
     }
     for (const mesh of [logs.current, ids.current]) {
+      mesh.count = count
       mesh.instanceMatrix.needsUpdate = true
       mesh.computeBoundingSphere()
     }
-  }, [count, pile.wood])
+  }, [count, layout])
   const select = (event: { delta: number; stopPropagation: () => void }) => selectElement({ kind: "pile", id: pile.id }, event)
   return (
     <group name={`wood-pile-${pile.id}`} onClick={select}>
-      <instancedMesh key={`logs-${count}`} ref={logs} args={[geometry, undefined, count]}>
+      <instancedMesh ref={logs} args={[geometry, undefined, WOOD_PILE_LAYOUT.maxLogs]}>
         <WoodLogMaterials />
       </instancedMesh>
-      <instancedMesh key={`ids-${count}`} ref={ids} args={[geometry, undefined, count]} layers-mask={OUTLINE_ID_LAYER_MASK}>
+      <instancedMesh ref={ids} args={[geometry, undefined, WOOD_PILE_LAYOUT.maxLogs]} layers-mask={OUTLINE_ID_LAYER_MASK}>
         <meshBasicMaterial color={idColor} toneMapped={false} />
       </instancedMesh>
     </group>

--- a/lib/game/building-art/structure.test.ts
+++ b/lib/game/building-art/structure.test.ts
@@ -7,7 +7,7 @@ import { structureParts, visibleStructureParts } from "./structure"
 import type { BuildingPart } from "./geometry"
 import { workshopLayout, workshopPileOffset } from "../workshop-layout"
 import { roofProfile, singlePlaneRoofRise, hasFrontAwning } from "./dimensions"
-import { WOOD_LOG, woodLogScale } from "../wood-log"
+import { WOOD_PILE_LAYOUT } from "../wood-pile"
 
 function bounds(part: BuildingPart) {
   const geometry = part.size ? new BoxGeometry(...part.size)
@@ -109,12 +109,12 @@ describe("settlement construction", () => {
     expect(parts.some(p => /-(side)$/.test(p.name) && p.layer === "roof")).toBe(false)
     const layout = workshopLayout(hut.w, hut.d)
     expect(layout.bayWidth * layout.bayDepth * 2).toBe(2)
-    const scale = woodLogScale(), radius = WOOD_LOG.radius * scale
+    const { width, length, height } = WOOD_PILE_LAYOUT
     const occupied: Box3[] = []
     for (let slot=0;slot<4;slot++) {
       const [x,z] = workshopPileOffset(slot,hut.w,hut.d)
-      const stack = new Box3(new Vector3(x-1.5*radius*2.05-radius,0,z-WOOD_LOG.length*scale/2),
-        new Vector3(x+2*radius*2.05+radius,.8,z+WOOD_LOG.length*scale/2))
+      const stack = new Box3(new Vector3(x-width/2,.08,z-length/2),
+        new Vector3(x+width/2,.08+height,z+length/2))
       expect(stack.min.x).toBeGreaterThan(layout.storageX-layout.bayWidth/2)
       expect(stack.max.x).toBeLessThan(layout.storageX+layout.bayWidth/2)
       expect(covered(stack.min.x, stack.min.z)).toBe(true)

--- a/lib/game/trees/timber.test.ts
+++ b/lib/game/trees/timber.test.ts
@@ -3,7 +3,7 @@ import { makeRng } from "../rng"
 import { growTreePlacements } from "./dimensions"
 import { TREE_SPECIES, TREE_SPECIES_ORDER, generateTree } from "./species"
 import type { TreePlacement } from "./placement"
-import { fallenTimberDimensions, pileLogCount, treeResource, WOOD_PER_LOG, TIMBER_LOAD } from "./timber"
+import { fallenTimberDimensions, pileLogCount, treeResource, WOOD_PER_LOG, TIMBER_LOAD, stackWood, type WoodPile } from "./timber"
 
 const base: TreePlacement = { x: 0, y: 0.2, z: 0, species: "oak" }
 
@@ -67,12 +67,36 @@ describe("timber tuning and dimensions", () => {
     }
   })
 
-  it("renders one log per ten wood without the old 48-log cap", () => {
+  it("counts every stored log independently of the visual fullness cap", () => {
     expect(pileLogCount(0)).toBe(0)
     expect(pileLogCount(10)).toBe(1)
     expect(pileLogCount(40)).toBe(4)
     expect(pileLogCount(240)).toBe(24)
     expect(pileLogCount(600)).toBe(60)
     expect(pileLogCount(15)).toBe(2) // One full log and one visibly short partial log.
+  })
+
+  it("fills all rows evenly from the first deliveries and preserves overflow", () => {
+    const piles = new Map<string, WoodPile>()
+    for (let delivery = 1; delivery <= 200; delivery++) {
+      stackWood(piles, "hut", TIMBER_LOAD)
+      const amounts = Array.from(piles.values(), pile => pile.wood)
+      expect(amounts.reduce((sum, wood) => sum + wood, 0)).toBe(delivery * TIMBER_LOAD)
+      expect(amounts).toHaveLength(Math.min(4, delivery))
+      expect(Math.max(...amounts) - Math.min(...amounts)).toBeLessThanOrEqual(WOOD_PER_LOG)
+    }
+  })
+
+  it("levels old uneven stock, retaining row identities and partial loads", () => {
+    const old = { id: "old-pile", campId: "hut", slot: 2, wood: 243 }
+    const other = { id: "other-pile", campId: "store", slot: 0, wood: 50 }
+    const piles = new Map([[old.id, old], [other.id, other]])
+    stackWood(piles, "hut", 10)
+    expect(piles.get(old.id)?.wood).toBe(60)
+    expect(piles.get(other.id)).toEqual(other)
+    const stock = Array.from(piles.values()).filter(pile => pile.campId === "hut")
+    expect(stock.map(pile => pile.slot).sort()).toEqual([0, 1, 2, 3])
+    expect(stock.reduce((sum, pile) => sum + pile.wood, 0)).toBe(253)
+    expect(Math.max(...stock.map(pile => pile.wood)) - Math.min(...stock.map(pile => pile.wood))).toBeLessThanOrEqual(WOOD_PER_LOG)
   })
 })

--- a/lib/game/trees/timber.ts
+++ b/lib/game/trees/timber.ts
@@ -87,18 +87,25 @@ export interface WoodPile {
   wood: number
 }
 
-/** Four stack locations inside the yard; keep adding to the smallest stack. */
+/** Spread the stock across all four rows, including older unevenly filled saves. */
 export function stackWood(piles: Map<string, WoodPile>, campId: string, wood: number): void {
   if (wood <= 0) return
   const stacks = Array.from(piles.values()).filter((pile) => pile.campId === campId)
-  let pile = stacks.find((p) => p.wood < 24 * WOOD_PER_LOG)
-  if (!pile && stacks.length < 4) {
-    const slot = [0, 1, 2, 3].find((candidate) => !stacks.some((p) => p.slot === candidate))!
-    pile = { id: `${campId}:pile:${slot}`, campId, slot, wood: 0 }
-    piles.set(pile.id, pile)
+  const total = stacks.reduce((sum, pile) => sum + pile.wood, wood)
+  const perRow = Math.floor(total / (4 * WOOD_PER_LOG)) * WOOD_PER_LOG
+  let remainder = total - perRow * 4
+  for (let slot = 0; slot < 4; slot++) {
+    const extra = Math.min(WOOD_PER_LOG, remainder)
+    remainder -= extra
+    const amount = perRow + extra
+    const old = stacks.find(pile => pile.slot === slot)
+    if (!amount) {
+      if (old) piles.delete(old.id)
+      continue
+    }
+    const pile = old ?? { id: `${campId}:pile:${slot}`, campId, slot, wood: 0 }
+    piles.set(pile.id, { ...pile, wood: amount })
   }
-  pile ??= stacks.reduce((a, b) => a.wood < b.wood ? a : b)
-  pile.wood += wood
 }
 
 /** World offset from the yard centre; all logs stay within the footprint. */

--- a/lib/game/wood-pile.test.ts
+++ b/lib/game/wood-pile.test.ts
@@ -1,0 +1,36 @@
+import { expect, it } from "vitest"
+import { WOOD_PILE_LAYOUT, woodPileLogs } from "./wood-pile"
+import { PERSON_HEIGHT } from "./world-scale"
+import { WOOD_PER_LOG } from "./trees/timber"
+
+it("spreads logs along the ground before building supported courses, bounded by person height", () => {
+  const { columns, radius, spacing } = WOOD_PILE_LAYOUT
+  const ground = woodPileLogs(columns * WOOD_PER_LOG)
+  expect(new Set(ground.map(log => log.y)).size).toBe(1)
+  expect(ground.at(-1)!.x - ground[0].x).toBeGreaterThan(.5)
+  const full = woodPileLogs(10000)
+  expect(Math.max(...full.map(log => log.y + radius))).toBeLessThanOrEqual(PERSON_HEIGHT)
+  for (const log of full.filter(log => log.y > radius)) {
+    const below = full.filter(other => Math.abs(other.y - log.y + WOOD_PILE_LAYOUT.layerHeight) < 1e-9)
+    // Interior logs nest between neighbours; outer logs remain inside the row's footprint.
+    expect(below.some(other => Math.abs(Math.abs(other.x - log.x) - spacing / 2) < 1e-9)).toBe(true)
+  }
+})
+
+it("stops growing at full stock while preserving partial log lengths", () => {
+  const full = WOOD_PILE_LAYOUT.maxLogs * WOOD_PER_LOG
+  expect(woodPileLogs(0)).toEqual([])
+  expect(woodPileLogs(-10)).toEqual([])
+  expect(woodPileLogs(15)[1].length).toBeCloseTo(WOOD_PILE_LAYOUT.length / 2)
+  expect(woodPileLogs(full)).toEqual(woodPileLogs(full * 100))
+})
+
+it("fits the narrower timber bays in older two-tile huts without growing taller", () => {
+  const width = 2 / 3 - .16
+  const full = woodPileLogs(10000, width)
+  expect(full.length).toBeLessThan(WOOD_PILE_LAYOUT.maxLogs)
+  for (const log of full) {
+    expect(Math.abs(log.x) + WOOD_PILE_LAYOUT.radius).toBeLessThan(width / 2)
+    expect(log.y + WOOD_PILE_LAYOUT.radius).toBeLessThanOrEqual(PERSON_HEIGHT)
+  }
+})

--- a/lib/game/wood-pile.ts
+++ b/lib/game/wood-pile.ts
@@ -1,0 +1,36 @@
+import { PERSON_HEIGHT } from "./world-scale"
+import { WOOD_LOG, woodLogScale } from "./wood-log"
+import { pileLogCount, WOOD_PER_LOG } from "./trees/timber"
+
+const scale = woodLogScale()
+const radius = WOOD_LOG.radius * scale
+const spacing = radius * 2.05
+const layerHeight = spacing * Math.sqrt(3) / 2
+const columns = 6
+const layers = Math.max(1, 1 + Math.floor((PERSON_HEIGHT - radius * 2) / layerHeight))
+
+/** Long, low rows; alternate courses nest between the logs below them. */
+export const WOOD_PILE_LAYOUT = {
+  radius, spacing, layerHeight, columns, layers,
+  length: WOOD_LOG.length * scale * 2,
+  width: (columns - 1) * spacing + radius * 2,
+  height: radius * 2 + (layers - 1) * layerHeight,
+  maxLogs: Math.ceil(layers / 2) * columns + Math.floor(layers / 2) * (columns - 1),
+} as const
+
+/** Full stalls keep a bounded silhouette even when their inventory exceeds it. */
+export function woodPileLogs(wood: number, availableWidth = WOOD_PILE_LAYOUT.width) {
+  const rowColumns = Math.max(2, Math.min(columns, 1 + Math.floor((availableWidth - radius * 2 + 1e-9) / spacing)))
+  const maxLogs = Math.ceil(layers / 2) * rowColumns + Math.floor(layers / 2) * (rowColumns - 1)
+  const count = Math.min(maxLogs, pileLogCount(wood))
+  const logs: Array<{ x: number; y: number; length: number }> = []
+  for (let layer = 0; logs.length < count; layer++) {
+    const width = rowColumns - layer % 2
+    for (let column = 0; column < width && logs.length < count; column++) {
+      const fraction = Math.min(1, (wood - logs.length * WOOD_PER_LOG) / WOOD_PER_LOG)
+      logs.push({ x: (column - (width - 1) / 2) * spacing,
+        y: radius + layer * layerHeight, length: WOOD_PILE_LAYOUT.length * fraction })
+    }
+  }
+  return logs
+}


### PR DESCRIPTION
Timber deliveries now balance stock across all four storage rows, including previously uneven stock, while preserving every delivered unit.
Stored logs form longer, staggered rows capped around person height and sized to fit each bay, including narrower huts from older saves; full stalls retain excess timber in inventory without growing visually.
The renderer reuses bounded instance buffers as stock changes, with matching selection geometry.
Validated with 152 targeted tests, `npm run typecheck`, and Playwright checks of full and partial stock, selection, and a character beside the rows in the game renderer.
