### PR TITLE
Widen main roads and separate opposing traffic

### DIFF
--- a/components/game/terrain-tiles.tsx
+++ b/components/game/terrain-tiles.tsx
@@ -929,7 +929,7 @@ const TerrainTileBlock = memo(function TerrainTileBlock({
       : diagonalRoadSegments(map, coveredLand)
     if (regrowRoads && !tier.paved) for (const [index, roads] of segments) {
       const opacity = foundingRoadStrength(map, index)
-      segments.set(index, roads.map(s => s[4] < 2 || s[4] === 3 ? [s[0], s[1], s[2], s[3], s[4], opacity] : s))
+      segments.set(index, roads.map(s => s[4] < 2 || s[4] === 3 ? [s[0], s[1], s[2], s[3], s[4], opacity, s[6]] : s))
     }
     return segments
   }, [revision, coveredLand, traveledRoads, regrowRoads, tier.paved, wearSnapshot])
@@ -1314,9 +1314,10 @@ const TerrainTileBlock = memo(function TerrainTileBlock({
   useLayoutEffect(() => {
     const land = roadGeometry.getAttribute("aLand") as THREE.InstancedBufferAttribute
     const surface = roadGeometry.getAttribute("aSurface") as THREE.InstancedBufferAttribute
-    const road = roadWear(traffic, tier.tier), track = roadWear(relicTraffic, tier.tier)
+    const keepMedian = (map.mainRoadWidth ?? 1) > 1
+    const road = roadWear(traffic, tier.tier, keepMedian), track = roadWear(relicTraffic, tier.tier)
     roadTiles.forEach((index, i) => {
-      const wear = regrowRoads ? roadWear(foundingRoadTraffic(map, index, map.tiles[index] === "track" ? relicTraffic : traffic), tier.tier)
+      const wear = regrowRoads ? roadWear(foundingRoadTraffic(map, index, map.tiles[index] === "track" ? relicTraffic : traffic), tier.tier, keepMedian && map.tiles[index] !== "track")
         : map.tiles[index] === "track" ? track : road
       land.setY(i, wear.edge); land.setZ(i, wear.inner)
       land.setW(i, regrowRoads && !tier.paved ? foundingRoadStrength(map, index) : 1)

--- a/lib/game/map/generate-map.ts
+++ b/lib/game/map/generate-map.ts
@@ -1,3 +1,4 @@
+import { MAIN_ROAD_WIDTH, clearMainRoadVerge } from "./road-width"
 import { routeBounds, ROUTE_EDGE_INSET } from "./route-bounds"
 import { createCrossroads } from "./crossroads"
 import { straightenRoad } from "./straighten-road"
@@ -863,6 +864,7 @@ export function generateMap(options: GenerateMapOptions): GameMap {
     buildings: [hovel, shelter],
     seed,
     road,
+    mainRoadWidth: MAIN_ROAD_WIDTH,
     shortcuts,
     darkForests,
     darkForestFloor,
@@ -880,6 +882,7 @@ export function generateMap(options: GenerateMapOptions): GameMap {
   addPathSprings(map)
   addRoadsideTowns(map)
   createCrossroads(map)
+  clearMainRoadVerge(map)
   return map
 }
 

--- a/lib/game/map/road-lane.ts
+++ b/lib/game/map/road-lane.ts
@@ -1,3 +1,4 @@
+import { mainRoadWidthAt } from "./road-width"
 import { bridgeLayout } from "./bridges"
 import { diagonalRoadBend, isRoadTerrain, sampleRoadBend } from "./road"
 import { tileAt, type GameMap, type TilePos } from "./types"
@@ -31,6 +32,7 @@ function laneTile(map: GameMap, route: readonly TilePos[], i: number): LaneTile 
 }
 
 /** Sample a road tile's rendered curve, offset along its local left normal.
+ * Main-road lane offsets expand with usable width and tighten at bends/bridges.
  * Progress still counts tile centres so junctions and arrival triggers retain
  * their indices; half-integers are the shared entrances between tiles. */
 export function roadLanePoint(map: GameMap, route: readonly TilePos[], progress: number, lane: number): TilePos | null {
@@ -70,6 +72,7 @@ export function roadLanePoint(map: GameMap, route: readonly TilePos[], progress:
       dz = iz * cos + oz * sin
     }
   }
+  if (route === map.road) lane *= mainRoadWidthAt(map, progress, true)
   const length = Math.hypot(dx, dz)
   return { x: x + dz / length * lane, z: z - dx / length * lane }
 }

--- a/lib/game/map/road-width.test.ts
+++ b/lib/game/map/road-width.test.ts
@@ -1,0 +1,126 @@
+import { turningMap } from "../transport/turning-demo"
+import { cartTrafficPoint } from "../transport/route"
+import { roadCartPose, cartGroundContacts, onBridgeDeck } from "../transport/bridge-guide"
+import { cartOffset } from "../transport/assets"
+import { BASE_CHARACTER_SCALE } from "../base-person/gait"
+import { tileToWorldZ } from "./types"
+import { describe, expect, it } from "vitest"
+import { bridgeLayout } from "./bridges"
+import { mainRoadWidthAt, clearMainRoadVerge } from "./road-width"
+import { roadLanePoint } from "./road-lane"
+import { diagonalRoadSegments, distanceToRoadSegments, roadSegmentWear } from "../render/road-segments"
+import type { GameMap } from "./types"
+
+function fixture(): GameMap {
+  const map: GameMap = { width: 40, depth: 16, tiles: Array(640).fill("grass"), buildings: [], mainRoadWidth: 2,
+    road: Array.from({ length: 40 }, (_, x) => ({ x, z: 8 })) }
+  for (const p of map.road!) map.tiles[p.z * map.width + p.x] = "path"
+  return map
+}
+
+describe("two-tile main road", () => {
+  it("retains a grassy centre at heavy traffic on dirt and gravel, while paving remains solid", () => {
+    for (const traffic of [0, 30, 3000]) for (const tier of [0, 1]) {
+      const [, inner] = roadSegmentWear([0, 0, 1, 0, 0, 1, 2], traffic, traffic, tier)
+      expect(.5 - inner).toBeGreaterThanOrEqual(.17)
+    }
+    expect(roadSegmentWear([0, 0, 1, 0, 0, 1, 2], 3000, 3000, 2)[1]).toBe(1)
+  })
+
+  it("puts opposing carts on opposite sides and keeps their wheels on narrow bridge decks", () => {
+    const map = fixture(), centre = tileToWorldZ(map, 8)
+    for (let z = 0; z < map.depth; z++) for (let x = 19; x <= 21; x++) map.tiles[z * map.width + x] = "water"
+    for (let x = 19; x <= 21; x++) map.tiles[8 * map.width + x] = "bridge"
+    const layout = bridgeLayout(map), scale = BASE_CHARACTER_SCALE, wheelbase = -cartOffset("horse") * scale
+    for (const direction of [1, -1] as const) {
+      const at = cartTrafficPoint(map, 8, direction)
+      expect((centre - at.z) * direction).toBeCloseTo(.5)
+      expect(cartTrafficPoint(map, 20, direction).z).toBeCloseTo(centre)
+      let previous = roadCartPose(map, direction === 1 ? 8 : 31, direction, wheelbase, scale)
+      for (let distance = .025; distance < 23; distance += .025) {
+        const progress = (direction === 1 ? 8 : 31) + direction * distance
+        const pose = roadCartPose(map, progress, direction, wheelbase, scale, previous)
+        expect(Math.hypot(pose.x - previous.x, pose.z - previous.z)).toBeLessThan(.06)
+        for (const wheel of cartGroundContacts(pose, scale)) {
+          const tx = Math.round(wheel.x + (map.width - 1) / 2)
+          if (layout.rise[8 * map.width + tx] > 0) expect(onBridgeDeck(map, wheel.x, wheel.z)).toBe(true)
+        }
+        previous = pose
+      }
+    }
+  })
+
+  it.each(["right", "left", "s_bend", "compound_bridge"] as const)("keeps cart motion continuous through a wide %s approach", scenario => {
+    const map = turningMap(scenario)
+    map.mainRoadWidth = 2
+    const scale = BASE_CHARACTER_SCALE, wheelbase = -cartOffset("horse") * scale
+    for (const direction of [1, -1] as const) {
+      const start = direction === 1 ? 0 : map.road!.length - 1
+      let previous = roadCartPose(map, start, direction, wheelbase, scale)
+      for (let d = .025; d < map.road!.length - 1; d += .025) {
+        const pose = roadCartPose(map, start + direction * d, direction, wheelbase, scale, previous)
+        expect(Math.hypot(pose.x - previous.x, pose.z - previous.z)).toBeLessThan(.1)
+        expect(Math.hypot(pose.x - pose.hitch.x, pose.z - pose.hitch.z)).toBeLessThanOrEqual(wheelbase + 1e-7)
+        previous = pose
+      }
+    }
+  })
+
+  it("covers both verges with one continuous surface and leaves tracks at their own width", () => {
+    const map = fixture(), bins = diagonalRoadSegments(map)
+    for (const z of [7.55, 9.45]) {
+      const row = Math.floor(z), segments = bins.get(row * map.width + 10)!
+      expect(distanceToRoadSegments(.5, z - row, segments)).toBeCloseTo(.95)
+      const main = segments.find(s => s[4] === 0)!
+      expect(.5 - roadSegmentWear(main, 100, 100, 2)[0]).toBe(1)
+    }
+    expect(.5 - roadSegmentWear([0, 0, 1, 0, 1], 100, 100, 2)[0]).toBe(.5)
+    const p = roadLanePoint(map, map.road!, 10, .25)!
+    expect(p.z).toBe(7.5)
+  })
+
+  it("tapers before the bridge ramp and keeps walkers within the original deck", () => {
+    const map = fixture()
+    for (let z = 0; z < map.depth; z++) for (let x = 19; x <= 21; x++) map.tiles[z * map.width + x] = "water"
+    for (let x = 19; x <= 21; x++) map.tiles[8 * map.width + x] = "bridge"
+    const layout = bridgeLayout(map)
+    expect(mainRoadWidthAt(map, 8)).toBe(2)
+    expect(mainRoadWidthAt(map, 20)).toBe(1)
+    const bins = diagonalRoadSegments(map)
+    for (const p of map.road!) if (layout.rise[p.z * map.width + p.x] > 0) {
+      expect(bins.has(p.z * map.width + p.x)).toBe(false)
+      for (const lane of [-.28, .28]) {
+        const at = roadLanePoint(map, map.road!, p.x, lane)!
+        expect(Math.abs(at.z - p.z)).toBeCloseTo(.28)
+      }
+    }
+    for (let p = 10; p < 29; p += .01) {
+      const a = roadLanePoint(map, map.road!, p, .28)!, b = roadLanePoint(map, map.road!, p + .001, .28)!
+      expect(Math.hypot(a.x - b.x, a.z - b.z)).toBeLessThan(.002)
+    }
+  })
+
+  it("tightens walking lanes through turns without folding the inside lane backwards", () => {
+    const map = fixture()
+    map.road = [...Array.from({ length: 16 }, (_, x) => ({ x, z: 8 })), ...Array.from({ length: 7 }, (_, i) => ({ x: 15, z: 9 + i }))]
+    for (const p of map.road) map.tiles[p.z * map.width + p.x] = "path"
+    for (const lane of [-.41, .41]) for (let p = 13; p < 17; p += .01) {
+      const a = roadLanePoint(map, map.road, p, lane)!, b = roadLanePoint(map, map.road, p + .001, lane)!
+      const c = roadLanePoint(map, map.road, p, 0)!, d = roadLanePoint(map, map.road, p + .001, 0)!
+      expect((b.x - a.x) * (d.x - c.x) + (b.z - a.z) * (d.z - c.z), `lane ${lane}, progress ${p}`).toBeGreaterThan(0)
+      expect(Math.hypot(b.x - a.x, b.z - a.z)).toBeLessThan(.004)
+    }
+  })
+
+  it("clears trees beside the route without changing its centreline, water, or bridge tiles", () => {
+    const map = fixture(), road = map.road!.map(p => ({ ...p }))
+    map.tiles[7 * map.width + 10] = "forest"
+    map.tiles[7 * map.width + 11] = "water"
+    map.tiles[8 * map.width + 11] = "bridge"
+    clearMainRoadVerge(map)
+    expect(map.tiles[7 * map.width + 10]).toBe("clearing")
+    expect(map.tiles[7 * map.width + 11]).toBe("water")
+    expect(map.tiles[8 * map.width + 11]).toBe("bridge")
+    expect(map.road).toEqual(road)
+  })
+})

--- a/lib/game/map/road-width.ts
+++ b/lib/game/map/road-width.ts
@@ -1,0 +1,69 @@
+import { elevationStep } from "./elevation"
+import { bridgeLayout } from "./bridges"
+import { tileAt, type GameMap } from "./types"
+
+/** Main roads have two tiles of usable ground; tracks and bridge decks retain one. */
+export const MAIN_ROAD_WIDTH = 2
+const profiles = new WeakMap<GameMap, { width: number[]; lanes: number[] }>()
+
+function profile(map: GameMap) {
+  const old = profiles.get(map)
+  if (old) return old
+  const road = map.road ?? [], bridges = bridgeLayout(map)
+  const width = road.map(p => {
+    const index = p.z * map.width + p.x
+    if (bridges.rise[index] > 0 || tileAt(map, p.x, p.z) === "bridge") return 1
+    // A bank, cliff or existing building can still make a local pinch point.
+    for (let z = p.z - 1; z <= p.z + 1; z++) for (let x = p.x - 1; x <= p.x + 1; x++) {
+      const terrain = tileAt(map, x, z)
+      if (terrain === "water" || terrain === "bridge" || map.elevation?.cliffs[z * map.width + x]
+        || map.buildings.some(b => x >= b.x && x < b.x + b.w && z >= b.z && z < b.z + b.d)) return 1
+    }
+    return map.mainRoadWidth ?? 1
+  })
+  // Start narrowing before a landing, and finish widening after its ramp.
+  const taper = (values: number[], reach: number) => values.map((value, i) => {
+    for (let j = Math.max(0, i - reach); j <= Math.min(values.length - 1, i + reach); j++)
+      value = Math.min(value, values[j] + Math.abs(i - j) / reach)
+    return value
+  })
+  const surface = taper(width, 3)
+  const walking = [...surface]
+  for (let i = 1; i < road.length - 1; i++) {
+    const a = road[i - 1], p = road[i], b = road[i + 1]
+    if ((p.x - a.x) * (b.z - p.z) === (p.z - a.z) * (b.x - p.x)) continue
+    // The authored Bezier's tightest radius is smaller than half a tile.
+    // Narrow through the whole bend, then ease back out on either straight.
+    for (let j = i - 1; j <= i + 1; j++) walking[j] = Math.min(walking[j], .7)
+  }
+  const lanes = taper(walking, 2)
+  const result = { width: surface, lanes }
+  profiles.set(map, result)
+  return result
+}
+
+export function mainRoadWidthAt(map: GameMap, progress: number, walking = false): number {
+  if ((map.mainRoadWidth ?? 1) <= 1 || !map.road?.length) return 1
+  const values = walking ? profile(map).lanes : profile(map).width
+  const p = Math.max(0, Math.min(values.length - 1, progress)), i = Math.floor(p)
+  const t = p - i, smooth = t * t * (3 - 2 * t)
+  return values[i] + (values[Math.min(i + 1, values.length - 1)] - values[i]) * smooth
+}
+
+/** Clear extra forest verge without adding parallel route tiles or changing junctions. */
+export function clearMainRoadVerge(map: GameMap): void {
+  if ((map.mainRoadWidth ?? 1) <= 1) return
+  for (const p of map.road ?? []) for (let z = p.z - 1; z <= p.z + 1; z++) for (let x = p.x - 1; x <= p.x + 1; x++) {
+    const terrain = tileAt(map, x, z)
+    if (terrain !== "forest" && terrain !== "darkwood") continue
+    const index = z * map.width + x, origin = p.z * map.width + p.x
+    const connected = x === p.x || z === p.z
+      ? Number.isFinite(elevationStep(map.elevation, origin, index))
+      : [{ x, z: p.z }, { x: p.x, z }].some(v => {
+        const via = v.z * map.width + v.x, ground = tileAt(map, v.x, v.z)
+        return ground !== null && ["path", "track", "grass", "clearing", "dirt", "sand"].includes(ground)
+          && Number.isFinite(elevationStep(map.elevation, origin, via)) && Number.isFinite(elevationStep(map.elevation, via, index))
+      })
+    if (connected) map.tiles[index] = "clearing"
+  }
+}

--- a/lib/game/map/road.ts
+++ b/lib/game/map/road.ts
@@ -124,15 +124,16 @@ export const WEAR_PAVED: RoadWear = { edge: 0, inner: 1 }
 /**
  * The rut edges for a stretch of road carrying `traffic` travelers. The main
  * road and the track to the relic carry different crowds, so each is worn by
- * its own count. Paved tiers ignore traffic (see RoadTierDef.paved).
+ * its own count. Wide main roads retain their median; paving covers it.
  */
-export function roadWear(traffic: number, tier: number = DEFAULT_ROAD_TIER): RoadWear {
+export function roadWear(traffic: number, tier: number = DEFAULT_ROAD_TIER, keepMedian = false): RoadWear {
   if (ROAD_TIERS[clampRoadTier(tier)].paved) return WEAR_PAVED
   const t = Math.min(1, Math.max(0, (Number.isFinite(traffic) ? traffic : 0) / TRAFFIC_FOR_BARE_ROAD))
   const k = t * t * (3 - 2 * t)
   return {
     edge: WEAR_UNTRODDEN.edge + (WEAR_TRODDEN.edge - WEAR_UNTRODDEN.edge) * k,
-    inner: WEAR_UNTRODDEN.inner + (WEAR_TRODDEN.inner - WEAR_UNTRODDEN.inner) * k,
+    // Opposing lanes widen outward on the main road, preserving its grassy spine.
+    inner: keepMedian ? .32 : WEAR_UNTRODDEN.inner + (WEAR_TRODDEN.inner - WEAR_UNTRODDEN.inner) * k,
   }
 }
 

--- a/lib/game/map/types.ts
+++ b/lib/game/map/types.ts
@@ -114,6 +114,8 @@ export interface GameMap {
    * order a traveller crosses it. Steps over rivers are bridge tiles.
    */
   road?: TilePos[]
+  /** Physical width around the main centreline; omitted on legacy authored maps. */
+  mainRoadWidth?: number
   /**
    * Secondary tracks: each a shorter, more dangerous walk through a dark
    * forest between two points on the road. Present on generated maps that

--- a/lib/game/render/road-segments.ts
+++ b/lib/game/render/road-segments.ts
@@ -1,9 +1,12 @@
+import { roadLanePoint } from "../map/road-lane"
+import { mainRoadWidthAt } from "../map/road-width"
+import { bridgeLayout } from "../map/bridges"
 import { diagonalRoadBend, isRoadTerrain, roadWear, sampleRoadBend, TRAFFIC_FOR_BARE_ROAD } from "../map/road"
 import { tileAt, type GameMap } from "../map/types"
 import { contactAppearance } from "./path-appearance"
 
-/** Tile-local endpoints, source (0 main, 1 branch, 2 corridor, 3 cart corner, 4 actual foot/wheel contact), and optional compaction. */
-export type RoadSegment = readonly [number, number, number, number, number, number?]
+/** Tile-local endpoints, source (0 main, 1 branch, 2 corridor, 3 cart corner, 4 actual foot/wheel contact), optional compaction, and optional main-road width. */
+export type RoadSegment = readonly [number, number, number, number, number, number?, number?]
 export interface TraveledRoad { ax: number; az: number; bx: number; bz: number; wear: number; contact?: boolean }
 
 /** Local compaction uses the same rut profile as the game, independently of global traffic. */
@@ -17,8 +20,8 @@ export function roadSegmentWear(segment: RoadSegment, traffic: number, relicTraf
   }
   const local = segment[4] === 2
   const depth = Math.min(1, Math.max(0, segment[5] ?? 0))
-  const wear = roadWear(local ? depth * TRAFFIC_FOR_BARE_ROAD : segment[4] === 1 ? relicTraffic : traffic, tier)
-  return [wear.edge, wear.inner, segment[4], local ? Math.min(1, depth / .2) : segment[5] ?? 1]
+  const wear = roadWear(local ? depth * TRAFFIC_FOR_BARE_ROAD : segment[4] === 1 ? relicTraffic : traffic, tier, segment[4] === 0 && segment[6] !== undefined)
+  return [wear.edge - ((segment[6] ?? 1) - 1) / 2, wear.inner, segment[4], local ? Math.min(1, depth / .2) : segment[5] ?? 1]
 }
 
 /** Includes the widest worn verge and its noise/antialiasing fringe. */
@@ -72,9 +75,39 @@ export function diagonalRoadSegments(map: GameMap, excluded: ReadonlySet<number>
     const terrain = tileAt(map, x, z)
     return isRoadTerrain(terrain) || terrain === "grass" || terrain === "clearing" || terrain === "dirt" || terrain === "sand"
   }
+  if ((map.mainRoadWidth ?? 1) > 1 && map.road) {
+    const road = map.road, bridges = bridgeLayout(map)
+    for (let i = 0; i < road.length; i++) {
+      const p = road[i]
+      if (bridges.rise[p.z * map.width + p.x] > 0 || tileAt(map, p.x, p.z) === "bridge") continue
+      const from = Math.max(0, i - .5), to = Math.min(road.length - 1, i + .5)
+      const previous = road[Math.max(0, i - 1)], next = road[Math.min(road.length - 1, i + 1)]
+      const straight = previous.x === next.x || previous.z === next.z
+      const steps = straight && mainRoadWidthAt(map, from) === mainRoadWidthAt(map, to) ? 1 : 8
+      let a = roadLanePoint(map, road, from, 0)
+      if (!a) continue
+      for (let step = 1; step <= steps; step++) {
+        const progress = from + (to - from) * step / steps
+        const b = roadLanePoint(map, road, progress, 0)
+        if (!b) continue
+        const width = mainRoadWidthAt(map, progress - (to - from) / steps / 2)
+        const reach = width / 2 + .2
+        for (let z = Math.max(0, Math.floor(Math.min(a.z, b.z) + .5 - reach)); z <= Math.min(map.depth - 1, Math.floor(Math.max(a.z, b.z) + .5 + reach)); z++) {
+          for (let x = Math.max(0, Math.floor(Math.min(a.x, b.x) + .5 - reach)); x <= Math.min(map.width - 1, Math.floor(Math.max(a.x, b.x) + .5 + reach)); x++) {
+            if (!available(x, z) || bridges.rise[z * map.width + x] > 0) continue
+            const index = z * map.width + x, segments = bins.get(index) ?? []
+            segments.push([a.x + .5 - x, a.z + .5 - z, b.x + .5 - x, b.z + .5 - z, 0, 1, width])
+            bins.set(index, segments)
+          }
+        }
+        a = b
+      }
+    }
+  }
+  const main = (map.mainRoadWidth ?? 1) > 1 ? new Set(map.road?.map(p => p.z * map.width + p.x)) : new Set<number>()
   for (let z = 0; z < map.depth; z++) {
     for (let x = 0; x < map.width; x++) {
-      if (blocked.has(z * map.width + x)) continue
+      if (blocked.has(z * map.width + x) || main.has(z * map.width + x)) continue
       const bend = diagonalRoadBend(map, x, z)
       if (!bend) continue
       const steps = bend.straight ? 1 : 12

--- a/lib/game/render/road-shape.ts
+++ b/lib/game/render/road-shape.ts
@@ -96,9 +96,11 @@ export const ROAD_SHAPE_GLSL = /* glsl */ `
           localWear = wear;
         }
       } else if (wear.z < 0.5) {
-        distanceToTrack.x = min(distanceToTrack.x, distance);
-        mainWear = wear.xy;
-        mainOpacity = wear.w;
+        if (distance < distanceToTrack.x) {
+          distanceToTrack.x = distance;
+          mainWear = wear.xy;
+          mainOpacity = wear.w;
+        }
       } else {
         distanceToTrack.y = min(distanceToTrack.y, distance);
         trackWear = wear.xy;

--- a/lib/game/render/terrain-blocks.ts
+++ b/lib/game/render/terrain-blocks.ts
@@ -48,7 +48,7 @@ export interface TerrainBlockState {
 export function terrainBlockState(map: TerrainBlockState["map"], blocks: readonly TerrainBlockBounds[], previous?: TerrainBlockState): TerrainBlockState {
   const old = previous?.map
   const reset = !old || old.tiles !== map.tiles || old.width !== map.width || old.depth !== map.depth
-    || old.water !== map.water || old.seed !== map.seed || old.road !== map.road || old.site !== map.site
+    || old.water !== map.water || old.seed !== map.seed || old.road !== map.road || old.mainRoadWidth !== map.mainRoadWidth || old.site !== map.site
     || old.shortcuts !== map.shortcuts || old.elevation?.settings !== map.elevation?.settings
   const footprints = blocks.map(b => JSON.stringify(map.buildings.filter(building =>
     building.x < b.endX + 2 && building.x + building.w > b.x - 2

--- a/lib/game/sim.ts
+++ b/lib/game/sim.ts
@@ -596,7 +596,7 @@ function routeWorldPoint(
   }
   const x = tileToWorldX(map, tx), z = tileToWorldZ(map, tz)
   const nearBridge = surfaces.nearBridge[i0] === 2 || surfaces.nearBridge[i0 + 1] === 2
-  const point = { x, z, y: nearBridge ? walkingSurface(map,x,z).height : ay + (by-ay)*frac }
+  const point = { x, z, y: (nearBridge || (route === map.road && (map.mainRoadWidth ?? 1) > 1)) ? walkingSurface(map,x,z).height : ay + (by-ay)*frac }
   return point
 }
 
@@ -605,10 +605,10 @@ function roadWorldPoint(map: GameMap, p: number, lane: number): WorldPoint {
 }
 
 /** Where someone stands when set down on the road at `progress`; wagons keep to the cart line. */
-export function roadPosition(map: GameMap, t: Pick<Traveler, "type">, progress: number, lane: number): WorldPoint {
+export function roadPosition(map: GameMap, t: Pick<Traveler, "type"> & Partial<Pick<Traveler, "direction">>, progress: number, lane: number): WorldPoint {
   const at = roadWorldPoint(map, progress, lane)
   if (t.type.id === "vendor") {
-    Object.assign(at, convoyPoint(map, progress))
+    Object.assign(at, convoyPoint(map, progress, BASE_CHARACTER_SCALE, t.direction ?? 1))
     at.y = walkingSurface(map, at.x, at.z).height
   }
   return at
@@ -673,7 +673,7 @@ function currentRoutePoint(map: GameMap, s: SimTraveler): WorldPoint {
   }
   const point = roadWorldPoint(map, s.progress, s.lane)
   if (!s.convoy) return point
-  const cart = convoyPoint(map, s.progress, s.convoyScale)
+  const cart = convoyPoint(map, s.progress, s.convoyScale, s.direction)
   return { ...cart, y: walkingSurface(map, cart.x, cart.z).height }
 }
 
@@ -840,8 +840,8 @@ export function createSim(
       const place = slots[slot]
       member.progress = ((origin - party.direction * place.behind) % length + length) % length
       member.direction = party.direction
-      member.laneOffset = place.lane
-      member.lane = party.direction * place.lane
+      member.laneOffset = (map.mainRoadWidth ?? 1) > 1 ? .28 + place.lane * .28 : place.lane
+      member.lane = party.direction * member.laneOffset
       Object.assign(member, roadWorldPoint(map, member.progress, member.lane))
     }
     party.formed = true
@@ -1722,7 +1722,8 @@ function stepTravelParties(sim: SimState, travelers: Traveler[], map: GameMap, d
         if (gap > 0) { moved = Math.min(gap, naturalSpeed(s) * dt); s.progress = gap - moved <= 1e-9 ? place : wrap(s.progress + direction * moved) }
       }
       s.direction = direction
-      s.laneOffset = slots[i].lane
+      s.laneOffset = (map.mainRoadWidth ?? 1) > 1 && !party.singleFile && !(cart && i === 0)
+        ? .28 + slots[i].lane * .28 : slots[i].lane
       s.partySpeed = moved / dt
       s.partyWaiting = !party.formed && moved <= 1e-9
       if (i > 0 && !refreshFollowers) continue

--- a/lib/game/transport/bridge-guide.ts
+++ b/lib/game/transport/bridge-guide.ts
@@ -3,7 +3,7 @@ import { insideBridgeCorner } from "../map/bridge-corners"
 import type { GameMap } from "../map/types"
 import { CART_WHEEL_X, CART_WIDTH_SCALE, RIG_TO_WORLD } from "./assets"
 import { cartOnRoute, followCart, type CartPose } from "./follow"
-import { advanceCartProgress, cartRoutePoint, DEFAULT_CART_TURN_RADIUS } from "./route"
+import { advanceCartProgress, cartTrafficPoint, DEFAULT_CART_TURN_RADIUS } from "./route"
 
 export function cartGroundContacts(pose: CartPose, scale: number) {
   const half=CART_WHEEL_X*CART_WIDTH_SCALE*RIG_TO_WORLD*scale
@@ -39,7 +39,7 @@ function ranges(map:GameMap) {
  * A two-tile ground transition avoids a snap when entering/leaving the assist. */
 export function roadCartPose(map:GameMap,progress:number,direction:1|-1,wheelbase:number,scale:number,
   previous?:CartPose,radius=DEFAULT_CART_TURN_RADIUS):CartPose {
-  const point=(p:number)=>cartRoutePoint(map,p,radius),hitch=point(progress)
+  const point=(p:number)=>cartTrafficPoint(map,p,direction,radius),hitch=point(progress)
   if(previous&&Math.hypot(hitch.x-previous.hitch.x,hitch.z-previous.hitch.z)<1e-8)return {...previous,distance:0}
   // The visual body can articulate independently. The ground blend still
   // needs the drawbar's heading, otherwise each step tries to realign the
@@ -55,7 +55,11 @@ export function roadCartPose(map:GameMap,progress:number,direction:1|-1,wheelbas
   const gap=Math.min(...bridges.map(r=>Math.max(0,r.start-last,first-r.end)))
   const t=Math.max(0,1-gap/2),weight=t*t*(3-2*t)
   if(!weight)return free
-  const x=free.x+(target.x-free.x)*weight,z=free.z+(target.z-free.z)*weight
+  let x=free.x+(target.x-free.x)*weight,z=free.z+(target.z-free.z)*weight
+  // Merging from a side lane adds lateral travel on the approach. The blended
+  // axle may shorten its hitch gap, but must never stretch the rigid drawbar.
+  const gapToHitch=Math.hypot(x-hitch.x,z-hitch.z)
+  if(gapToHitch>wheelbase){x=hitch.x+(x-hitch.x)*wheelbase/gapToHitch;z=hitch.z+(z-hitch.z)*wheelbase/gapToHitch}
   const distance=previous?Math.hypot(x-previous.x,z-previous.z):0
   // Face the axle's actual movement, including the ground transition. Looking
   // at the hitch rotates the cart too early when the horse has cleared a bend.

--- a/lib/game/transport/navigation.ts
+++ b/lib/game/transport/navigation.ts
@@ -4,7 +4,7 @@ import { marketLayout, marketYardContains } from "../market-layout"
 import type { TreePlacement } from "../trees/placement"
 import { pastureSegmentClear, type StallObstacle } from "./stall"
 import { cartGroundContacts, onBridgeDeck } from "./bridge-guide"
-import { cartRoutePoint } from "./route"
+import { cartTrafficPoint } from "./route"
 import { tileToWorldX, tileToWorldZ, worldToTileX, worldToTileZ, tileAt, type GameMap } from "../map/types"
 import { buildingAt } from "../settlement"
 import { bridgeCornerAt, bridgeLayout } from "../map/bridges"
@@ -15,9 +15,9 @@ import { RIG_TO_WORLD, CART_WIDTH_SCALE, type Puller } from "./assets"
 import { alignCart, cartOnRoute, followCart, type CartPose } from "./follow"
 import { roadsideStall, roundRoute, routeLength, routePoint, type Point } from "./roadside"
 
-/** Only wagons ease into wider turns; the terrain and walking lanes stay fixed. */
-export function convoyPoint(map: GameMap, progress: number, _scale = BASE_CHARACTER_SCALE): Point {
-  return cartRoutePoint(map, progress)
+/** Cart lanes ease through broad turns and keep left like the walking traffic. */
+export function convoyPoint(map: GameMap, progress: number, _scale = BASE_CHARACTER_SCALE, direction: 1 | -1 = 1): Point {
+  return cartTrafficPoint(map, progress, direction)
 }
 
 /** Shared oriented footprints for carts, shafts and unmounted horses. */
@@ -161,20 +161,20 @@ export function parkingTree(map: GameMap, pose: CartPose, trees: readonly TreePl
 export function shrineParking(map: GameMap, progress: number, direction: 1 | -1, wheelbase: number, puller: Puller, scale: number,
   occupied: readonly CartPose[] = [], context: ParkingContext = { trees: [] }, requireTree = true): ShrineParking | null {
   const reserved = { ...context, obstacles: [...(context.obstacles ?? []), ...occupied.flatMap(pose => convoyBounds(pose, "horse", scale))] }
-  const start = convoyPoint(map, progress, scale), ahead = convoyPoint(map, progress + direction * 0.1, scale)
+  const start = convoyPoint(map, progress, scale, direction), ahead = convoyPoint(map, progress + direction * 0.1, scale, direction)
   const heading = Math.atan2(ahead.x - start.x, ahead.z - start.z)
-  const initial = cartOnRoute(progress, direction, wheelbase, p => convoyPoint(map, p, scale))
+  const initial = cartOnRoute(progress, direction, wheelbase, p => convoyPoint(map, p, scale, direction))
   for (const depth of [1.5, 2, 2.5, 3]) for (const side of [1, -1]) for (const advance of [5, 6, 7]) {
     const returnProgress = progress + direction * advance
     if (returnProgress < 0 || returnProgress > map.road!.length - 1) continue
     const local = (along: number, across: number) => ({ x: start.x + Math.sin(heading) * along + Math.cos(heading) * across * side,
       z: start.z + Math.cos(heading) * along - Math.sin(heading) * across * side })
-    const park = local(2 + wheelbase, depth), end = convoyPoint(map, returnProgress, scale)
+    const park = local(2 + wheelbase, depth), end = convoyPoint(map, returnProgress, scale, direction)
     const departure = local(2.6 + wheelbase, depth)
     // Pull forward onto the road; never ask the horse to reverse the wagon.
     if ((end.x - departure.x) * Math.sin(heading) + (end.z - departure.z) * Math.cos(heading) < 0.5) continue
     const entry = roundRoute([start, local(0.4, 0), local(1.4, depth), park], 0.4)
-    const exit = roundRoute([park, departure, end, convoyPoint(map, returnProgress + direction * 0.5, scale)], 0.4)
+    const exit = roundRoute([park, departure, end, convoyPoint(map, returnProgress + direction * 0.5, scale, direction)], 0.4)
     let pose = initial, parked = initial, valid = true
     for (const route of [entry, exit]) {
       const length = routeLength(route)

--- a/lib/game/transport/road-diversion.ts
+++ b/lib/game/transport/road-diversion.ts
@@ -21,7 +21,7 @@ export function cartRoadDiversion(map: GameMap, initial: CartPose, progress: num
   for (let distance = .1; distance <= lookahead; distance += .1) {
     const next = advanceCartProgress(map, at, direction * .1)
     if (next < 0 || next > last) break
-    const hitch = convoyPoint(map, next)
+    const hitch = convoyPoint(map, next, scale, direction)
     const heading = Math.atan2(hitch.x - pose.hitch.x, hitch.z - pose.hitch.z)
     pose = roadCartPose(map, next, direction, wheelbase, scale, pose)
     if (!convoyBuildingsClear(map, pose, puller, scale, heading) || !convoyBuildingsClear(map, pose, puller, scale)) {
@@ -41,7 +41,7 @@ export function cartRoadDiversion(map: GameMap, initial: CartPose, progress: num
   for (let beyond = wheelbase + 2; beyond <= wheelbase + 12; beyond += 2) {
     const end = advanceCartProgress(map, blocked, direction * beyond)
     if (end < 0 || end > last) break
-    const to = convoyPoint(map, end), ahead = convoyPoint(map, advanceCartProgress(map, end, direction * .1))
+    const to = convoyPoint(map, end, scale, direction), ahead = convoyPoint(map, advanceCartProgress(map, end, direction * .1), scale, direction)
     const heading = Math.atan2(ahead.x - to.x, ahead.z - to.z)
     const drive = cartPath(map, initial, to, puller, scale, context, heading)
     if (!drive) continue

--- a/lib/game/transport/route.ts
+++ b/lib/game/transport/route.ts
@@ -1,3 +1,4 @@
+import { mainRoadWidthAt } from "../map/road-width"
 import { crossroadIslandAt } from "../map/crossroads"
 import { tileToWorldX, tileToWorldZ, worldToTileX, worldToTileZ, tileAt, type GameMap } from "../map/types"
 import { bridgeLayout, bridgeCornerAt, surfaceHeight } from "../map/bridges"
@@ -94,6 +95,17 @@ export function cartRoutePoint(map:GameMap,progress:number,radius=DEFAULT_CART_T
   const {a,b,t}=segment(route,progress,"progress")
   return {x:a.x+(b.x-a.x)*t,z:a.z+(b.z-a.z)*t}
 }
+/** Keep left relative to travel, matching pedestrians. Narrow ramps and tight
+ * corners merge toward the existing cart line before the timber crossing. */
+export function cartTrafficPoint(map: GameMap, progress: number, direction: 1 | -1, radius = DEFAULT_CART_TURN_RADIUS): Point {
+  const centre = cartRoutePoint(map, progress, radius)
+  const lane = direction * .5 * Math.max(0, mainRoadWidthAt(map, progress, true) - 1)
+  if (!lane) return centre
+  const before = cartRoutePoint(map, progress - .05, radius), after = cartRoutePoint(map, progress + .05, radius)
+  const dx = after.x - before.x, dz = after.z - before.z, length = Math.hypot(dx, dz)
+  return length > 1e-8 ? { x: centre.x + dz / length * lane, z: centre.z - dx / length * lane } : centre
+}
+
 /** Advance by physical travel so the cart does not speed up at a tile boundary. */
 export function advanceCartProgress(map:GameMap,progress:number,distance:number,radius=DEFAULT_CART_TURN_RADIUS) {
   const route=cartRoute(map,radius);if(route.length<2)return progress

--- a/lib/game/travel-parties.test.ts
+++ b/lib/game/travel-parties.test.ts
@@ -49,6 +49,20 @@ describe("travel party generation", () => {
 })
 
 describe("coordinated travel", () => {
+  it.each([1, -1] as const)("uses its own half of a wide road with room between companions (%i)", direction => {
+    const { map, travelers } = fixture(12, direction)
+    map.mainRoadWidth = 2
+    const sim = createSim(travelers, map)
+    for (const party of sim.parties.values()) party.transportInitialized = true
+    for (const elapsed of [0, 10]) {
+      if (elapsed) run(sim, travelers, map, elapsed)
+      const offsets = [...sim.travelers.values()].map(s => (tileToWorldZ(map, 5) - s.z) * direction)
+      expect(Math.min(...offsets)).toBeGreaterThan(.3)
+      expect(Math.max(...offsets)).toBeLessThan(.85)
+      expect(Math.max(...offsets) - Math.min(...offsets)).toBeGreaterThan(.2)
+    }
+  })
+
   it.each([1, -1] as const)("keeps different personal paces together across the edge seam (%i)", direction => {
     const { map, travelers, sim } = fixture(8, direction)
     const starts = [...sim.travelers.values()].map(s => s.progress)


### PR DESCRIPTION
Widen generated main roads to two tiles, clear reachable verges, and preserve a grassy median on dirt and gravel so opposing groups have more room.
Walkers and carts keep left relative to travel, tightening through bends and tapering into existing one-tile bridges; parking and diversion routes follow the same lanes, and bridge guidance preserves drawbar length.

Validation includes passing typecheck and targeted road, group, cart, bridge, parking, and hospitality tests, plus browser comparisons of straight roads, turns, and crossings with no page errors.
The broader test run found 25 pre-existing failures in `lib/game/map/bridges.test.ts` and `lib/game/transport/party.test.ts`, all reproduced on the unchanged base code.
