### PR TITLE
Fix carts and grazing animals getting stuck around obstacles

### DIFF
--- a/lib/game/sim.ts
+++ b/lib/game/sim.ts
@@ -21,6 +21,7 @@ import type { WildlifeWorld } from "./wildlife/simulation"
 import { cartPath, driveSegment, driveRouteSegment, marketParking, type MarketParking } from "./transport/building-parking"
 import { roadCartPose } from "./transport/bridge-guide"
 import { cartRoadDiversion } from "./transport/road-diversion"
+import { recoverCart } from "./transport/recovery"
 import { blockedRoad, findRoadDiversion, takeRoadShortcut, retireBypassedRoad, exploresRoadShortcut, type WalkingShortcut } from "./walking-shortcuts"
 import { createFootpaths, HEAVY_PATH_WEAR, recordWalkingPath, regrowFootpaths, type Footpaths } from "./footpaths"
 import { knightMounted, knightLoadout, knightTravelSpeed, knightWalkStride, type HorseRest } from "./knights"
@@ -337,6 +338,8 @@ export interface SimTraveler {
   shrineParking?: ShrineParking
   marketParking?: MarketParking
   cartPose?: CartPose
+  cartRecovery?: boolean
+  cartRecoveryRetry?: number
   marketCheck?: number
   cartRouteBlocked?: { x: number; z: number; buildings: GameMap["buildings"] }
   /** Wagons use their own road clearance profile instead of pedestrian lanes. */
@@ -665,7 +668,8 @@ function finishConvoyMove(s: SimTraveler, transportBefore: SimTraveler | null, m
   else {
     const check = s.diversionCheck, buildings = s.diversionBuildings
     Object.assign(s, transportBefore)
-    s.moveSpeed = 0; s.diversionCheck = check; s.diversionBuildings = buildings
+    s.moveSpeed = 0; s.cartRecovery = true
+    s.diversionCheck = check; s.diversionBuildings = buildings
   }
 }
 
@@ -720,7 +724,7 @@ function shrineWorldPoint(map: GameMap, s: SimTraveler): WorldPoint {
 }
 
 /** Nearby live obstacles and reservations are shared by shrine and market parking. */
-function parkingContext(sim: SimState, s: SimTraveler, scale: number): ParkingContext {
+function parkingContext(sim: SimState, s: SimTraveler, scale: number, traffic = false): ParkingContext {
   const nearby = (p: { x: number; z: number }) => Math.hypot(p.x - s.x, p.z - s.z) < 16 + scale * 4
   const trees: Array<{ tree: TreePlacement; index: number }> = []
   treeSpatialIndex(sim.trees).forEachWithin(s.x, s.z, 16 + scale * 4, (tree, index) => {
@@ -736,8 +740,20 @@ function parkingContext(sim: SimState, s: SimTraveler, scale: number): ParkingCo
       const puller = cartLoadout(other.id).puller
       if (puller !== "hand") add(convoyBounds(alignCart(other.stallRoute.park, other.stallRoute.heading, 0), puller, scale))
     }
+    if (other.pasture) {
+      const animal = other.pasture
+      for (const point of [animal, animal.home]) add([{ ...point, heading: 0,
+        halfWidth: animal.clearance, halfLength: animal.clearance }])
+    }
     if (other.shrineParking) add(convoyBounds(other.shrineParking.parked, other.convoy ? cartLoadout(other.id).puller : "horse", scale))
     if (other.marketParking) add(convoyBounds(other.marketParking.parked, cartLoadout(other.id).puller, scale))
+    if (traffic && other.convoy && other.cartPose && !other.stallRoute && !other.shrineParking && !other.marketParking)
+      add(convoyBounds(other.cartPose, cartLoadout(other.id).puller, scale))
+  }
+  for (const party of sim.parties.values()) {
+    if (party.id === s.partyId || !party.transport) continue
+    const cart = party.transport
+    if (traffic || cart.phase === "parked" || cart.phase === "boarding") add(convoyBounds(cart.pose, cart.animal, scale))
   }
   return { trees: trees.sort((a, b) => a.index - b.index).map(entry => entry.tree), obstacles, people }
 }
@@ -1529,6 +1545,25 @@ function stepTravelParties(sim: SimState, travelers: Traveler[], map: GameMap, d
     if (cart) {
       cart.distance = cart.animalDistance = 0
       cart.retry = Math.max(0, cart.retry - dt)
+      cart.recoveryRetry = Math.max(0, (cart.recoveryRetry ?? 0) - dt)
+      if (cart.recovery && !cart.recoveryRetry && dt > 0) {
+        cart.recoveryRetry = 3
+        const context = parkingContext(sim, members[0], characterScale, true)
+        const recovery = recoverCart(map, cart.pose, cart.progress, party.direction, cart.animal, characterScale, context)
+        if (recovery) {
+          cart.pose = recovery.pose; cart.progress = recovery.progress; cart.phase = "road"
+          cart.parking = undefined; cart.intent = undefined; cart.recovery = false
+          party.progress = recovery.progress; party.diversion = recovery.route; party.formed = false
+        }
+      }
+      if (cart.phase === "road" && !party.diversion && dt > 0) {
+        const check = Math.floor(cart.progress) * 2 + (party.direction === 1 ? 1 : 0)
+        if (cart.diversionCheck !== check || cart.diversionBuildings !== map.buildings) {
+          cart.diversionCheck = check; cart.diversionBuildings = map.buildings
+          party.diversion = cartRoadDiversion(map, cart.pose, cart.progress, party.direction, cart.animal, characterScale,
+            () => parkingContext(sim, members[0], characterScale)) ?? undefined
+        }
+      }
       if (cart.seats.some(id => !party.members.includes(id))) cart.seats = cart.seats.filter(id => party.members.includes(id))
       if (!cart.seats.length) cart.seats = [members[0].id]
       if (cart.phase === "parking" || cart.phase === "leaving") {
@@ -1928,6 +1963,26 @@ export function stepSim(
     if (s.herding && !["toSheep", "herding"].includes(s.activity)) releaseSheep(s, sim.wildlife)
     s.herdingRetry = Math.max(0, (s.herdingRetry ?? 0) - dt)
     s.convoyScale = characterScale
+    s.cartRecoveryRetry = Math.max(0, (s.cartRecoveryRetry ?? 0) - dt)
+    if (s.convoy && dt > 0 && (s.cartRecovery || s.pasture?.stranded) && !s.cartRecoveryRetry) {
+      s.cartRecoveryRetry = 3
+      const puller = cartLoadout(s.id).puller
+      const initial = s.cartPose ?? roadCartPose(map, s.progress, s.direction, -cartOffset(puller) * characterScale, characterScale)
+      const recovery = recoverCart(map, initial, s.progress, s.direction, puller, characterScale, parkingContext(sim, s, characterScale, true))
+      if (recovery) {
+        // Release the invalid stop and its reservations before taking the new route.
+        if (s.marketParking) { s.employer = null; s.buildingTask = undefined; s.home = null }
+        s.cartPose = recovery.pose; s.progress = recovery.progress
+        s.x = recovery.pose.hitch.x; s.z = recovery.pose.hitch.z
+        s.y = walkingSurface(map, s.x, s.z).height
+        s.roadShortcut = recovery.route; s.cartRecovery = false
+        pastureObstacles = undefined
+        s.shrineParking = undefined; s.marketParking = undefined; s.stallRoute = undefined; s.pasture = undefined
+        s.shrineRoute = null; s.shrineSeat = undefined; s.spot = null; s.walkFrom = null; s.offRoadRoute = null; s.track = null
+        s.diversionCheck = undefined; s.cartRouteBlocked = undefined
+        s.activity = "walking"; s.timer = 30; s.visitCooldown = 30
+      }
+    }
     // Riders wait for a passing procession; prayer poses begin once on foot.
     // A vendor who has taken over a stall has left the wagon for good.
     const riding = s.partyRiding || (t.type.id === "knight" ? knightMounted(s.activity, s.horseRest) :
@@ -2022,7 +2077,13 @@ export function stepSim(
             if (stall) pastureObstacles.push(...stall.obstacles)
           }
         }
-        s.pasture.obstacles = pastureObstacles
+        s.pasture.obstacles = [...pastureObstacles]
+        for (const other of vendors) {
+          if (other === s || !other.pasture) continue
+          const animal = other.pasture
+          s.pasture.obstacles.push({ x: animal.x, z: animal.z, heading: 0,
+            halfWidth: animal.clearance, halfLength: animal.clearance })
+        }
       }
       stepPasture(map, s.pasture, dt, Math.max(0.01, targetSpeed), s.activity === "packingShop")
     }
@@ -2043,7 +2104,7 @@ export function stepSim(
           }
           parking.pose = next
         }
-        if (parking.distance < 0) { Object.assign(s, transportBefore); s.moveSpeed = 0; break }
+        if (parking.distance < 0) { Object.assign(s, transportBefore); s.moveSpeed = 0; s.cartRecovery = true; break }
         const point = parking.pose.hitch
         s.x = point.x; s.z = point.z; s.y = surfaceHeight(map, worldToTileX(map, s.x), worldToTileZ(map, s.z))
         if (parking.distance >= length) {

--- a/lib/game/transport/building-parking.ts
+++ b/lib/game/transport/building-parking.ts
@@ -43,7 +43,10 @@ export function driveRouteSegment(pose: CartPose, route: readonly Point[], start
 export function cartPath(map: GameMap, initial: CartPose, goal: Point, puller: Puller, scale: number,
   context: ParkingContext, goalHeading?: number): { entry: Point[]; parked: CartPose } | null {
   const wheelbase = -cartOffset(puller) * scale
-  const clear = (pose: CartPose, heading: number) => parkingClear(map, pose, puller, scale, context, false, heading)
+  // Playback also checks the animal aligned with the shafts after each tick.
+  // A route that only clears its instantaneous travel heading can jam mid-turn.
+  const clear = (pose: CartPose, heading: number) => parkingClear(map, pose, puller, scale, context, false, heading) &&
+    parkingClear(map, pose, puller, scale, context)
   if (!clear(initial, initial.heading)) return null
   const headings = goalHeading === undefined ? Array.from({ length: 8 }, (_, i) => i * Math.PI / 4) : [goalHeading]
   if (!headings.some(heading => clear(alignCart(goal, heading, wheelbase), heading))) return null

--- a/lib/game/transport/navigation.ts
+++ b/lib/game/transport/navigation.ts
@@ -194,6 +194,10 @@ export function shrineParking(map: GameMap, progress: number, direction: 1 | -1,
 /** Roadside shops need convoy clearance on either verge; animals graze without a tether. */
 export function stallParking(map: GameMap, from: Point, progress: number, direction: 1 | -1, wheelbase: number, scale: number, puller: Puller, context: ParkingContext) {
   return roadsideStall(map, from, progress, direction, wheelbase, scale, puller, pitch => {
+    // The unfolded display and sign need space too, not just the arriving cart.
+    if (pitch.obstacles.some(box => (context.obstacles ?? []).some(other => overlaps(box, other))) ||
+      context.trees.some(tree => !pastureSegmentClear(tree, tree, pitch.obstacles, (tree.shape?.trunkRadius ?? .18) * (tree.scale ?? 1) + .08)) ||
+      (context.people ?? []).some(person => !pastureSegmentClear(person, person, pitch.obstacles, .2))) return false
     const parked = alignCart(pitch.park, pitch.heading, wheelbase)
     if (!parkingClear(map, parked, puller, scale, context, true)) return false
     let pose = alignCart(from, pitch.heading, wheelbase)

--- a/lib/game/transport/party.test.ts
+++ b/lib/game/transport/party.test.ts
@@ -11,7 +11,7 @@ import { poseDriver } from "./driver"
 import { createSim, stepSim, GAME_DAY_SECONDS } from "../sim"
 import { TRAVELER_TYPES, type Traveler } from "../travelers"
 import { BUILD_CATALOG, DEFAULT_BALANCE } from "../balance"
-import type { GameMap } from "../map/types"
+import { worldToTileX, worldToTileZ, type GameMap } from "../map/types"
 import { jobBuildings } from "../settlement"
 import { partyFormation, partyRoadDelta } from "../travel-parties"
 import { BASE_CHARACTER_SCALE } from "../base-person/gait"
@@ -35,6 +35,23 @@ function fixture(id = 0, count = 8, direction: 1 | -1 = 1) {
 }
 
 describe("party transport", () => {
+  it.each([1, -1] as const)("recovers the passenger wagon after construction covers it in direction %s", direction => {
+    const id = Array.from({ length: 100 }, (_, i) => i).find(i => partyLoadout(i, 4).cart)!
+    const { map, travelers, sim, party, run } = fixture(id, 4, direction)
+    ensurePartyTransport(party, [...sim.travelers.values()], map, BASE_CHARACTER_SCALE)
+    const cart = party.transport!, start = cart.progress
+    map.buildings = [{ id: "new", label: "New", x: worldToTileX(map, cart.pose.hitch.x), z: worldToTileZ(map, cart.pose.hitch.z),
+      w: 2, d: 2, height: 1, color: "", roofColor: "" }]
+    for (let i = 0; i < 200; i++) {
+      stepSim(sim, travelers, map, 1, .1)
+      if (cart.recovery === false) break
+    }
+    expect(cart.recovery).toBe(false)
+    expect(convoyBuildingsClear(map, cart.pose, cart.animal, BASE_CHARACTER_SCALE)).toBe(true)
+    run(10)
+    expect(Math.abs(cart.progress - start)).toBeGreaterThan(2)
+  })
+
   it.each((["donkey", "horse", "ox"] as const).flatMap(animal =>
     ([1, -1] as const).flatMap(direction => [.1, 1.25].flatMap(dt => [false, true].map(stopped => ({ animal, direction, dt, stopped }))))))(
     "takes the whole company past an inside bend with $animal, direction $direction, dt $dt, already stopped $stopped", ({ animal, direction, dt, stopped }) => {

--- a/lib/game/transport/party.ts
+++ b/lib/game/transport/party.ts
@@ -25,6 +25,8 @@ export interface PartyTransport {
   animalDistance: number
   animalHeading: number
   retry: number
+  recovery?: boolean
+  recoveryRetry?: number
   /** Check the whole convoy ahead once per road tile/direction or building edit. */
   diversionCheck?: number
   diversionBuildings?: GameMap["buildings"]
@@ -104,6 +106,7 @@ export function movePartyCart(party: TravelParty, map: GameMap, scale: number, s
   cart.distance = cart.animalDistance = 0
   if (dt <= 0 || !["road", "parking", "leaving"].includes(cart.phase)) return false
   const wheelbase = -cartOffset(cart.animal) * scale, previous = cart.pose
+  const blocked = () => { cart.recovery = true; return false }
   let pose: CartPose, progress = cart.progress, done = false, routeDistance = 0
   const travel = Math.min(speed, animalWalkSpeed(cart.animal, scale)) * dt
   if (travel <= 0 && cart.phase === "road") return true
@@ -123,7 +126,7 @@ export function movePartyCart(party: TravelParty, map: GameMap, scale: number, s
           axleDistance += p.distance
           return convoyBuildingsClear(map, p, cart.animal, scale, heading)
         })
-      if (!next || !convoyBuildingsClear(map, next, cart.animal, scale)) return false
+      if (!next || !convoyBuildingsClear(map, next, cart.animal, scale)) return blocked()
       pose = { ...next, distance: axleDistance }
       progress = distance >= cut.length ? ((cut.end % length) + length) % length
         : ((cut.start + party.direction * distance / cut.length * span) % length + length) % length
@@ -132,14 +135,14 @@ export function movePartyCart(party: TravelParty, map: GameMap, scale: number, s
       const wrapped = progress < 0 || progress >= length
       progress = ((progress % length) + length) % length
       pose = roadCartPose(map, progress, party.direction, wheelbase, scale, wrapped ? undefined : previous)
-      if (!convoyBuildingsClear(map, pose, cart.animal, scale)) return false
+      if (!convoyBuildingsClear(map, pose, cart.animal, scale)) return blocked()
     }
   } else {
     const parking = cart.parking!, route = cart.phase === "parking" ? parking.entry : parking.exit
     routeDistance = Math.min(routeLength(route), parking.distance + travel)
     pose = followCart(previous, routePoint(route, routeDistance), wheelbase)
     done = routeDistance >= routeLength(route) - 1e-6
-    if (!parkingClear(map, pose, cart.animal, scale, { trees: [] })) return false
+    if (!parkingClear(map, pose, cart.animal, scale, { trees: [] })) return blocked()
   }
   const animalDistance = Math.hypot(pose.hitch.x - previous.hitch.x, pose.hitch.z - previous.hitch.z)
   cart.animalHeading = animalDistance > 1e-7 ? Math.atan2(pose.hitch.x - previous.hitch.x, pose.hitch.z - previous.hitch.z) : cart.animalHeading

--- a/lib/game/transport/pasture.test.ts
+++ b/lib/game/transport/pasture.test.ts
@@ -1,11 +1,54 @@
 import { describe, expect, it } from "vitest"
 import { createPasture, pastureRoutes, stepPasture } from "./pasture"
 import { tileAt, worldToTileX, worldToTileZ, type GameMap } from "../map/types"
+import { obstacleDistance, pastureSegmentClear } from "./stall"
 
 function map(): GameMap {
   return { width: 9, depth: 9, buildings: [], tiles: Array.from({ length: 81 }, (_, i) => i % 9 === 4 ? "path" : "grass") }
 }
 describe("unhitched draught animals", () => {
+  it("separates overlapping grazing animals and lets both return to their hitches", () => {
+    const ground = map(), animals = [createPasture({ x: -3, z: 0 }, [], .3), createPasture({ x: -1, z: 0 }, [], .3)]
+    animals[0].x = -2.1; animals[1].x = -1.9
+    for (let i = 0; i < 80; i++) for (const animal of animals) {
+      const other = animals.find(a => a !== animal)!
+      animal.obstacles = [{ x: other.x, z: other.z, heading: 0, halfWidth: other.clearance, halfLength: other.clearance }]
+      stepPasture(ground, animal, .1, .3, true)
+    }
+    for (const animal of animals) {
+      expect(animal.ready).toBe(true)
+      expect(animal.x).toBe(animal.home.x)
+    }
+  })
+
+  it.each(["stall", "building"])("walks out of a newly overlapping %s without crossing other obstacles", kind => {
+    const ground = map(), animal = createPasture({ x: -2, z: 0 }, [], .3)
+    animal.x = -2.3
+    const obstacle = { x: -3, z: 0, heading: 0, halfWidth: .5, halfLength: .5 }
+    if (kind === "stall") animal.obstacles = [obstacle]
+    else ground.buildings = [{ id: "new", label: "New", x: 1, z: 4, w: 1, d: 1, height: 1, color: "", roofColor: "" }]
+    const wall = { x: -2, z: 1, heading: 0, halfWidth: 1, halfLength: .1 }
+    animal.obstacles.push(wall)
+    for (let i = 0; i < 30; i++) {
+      const before = { x: animal.x, z: animal.z }
+      stepPasture(ground, animal, .1, .3, true)
+      expect(Math.hypot(animal.x - before.x, animal.z - before.z)).toBeLessThanOrEqual(.030001)
+      expect(obstacleDistance(animal, obstacle)).toBeGreaterThanOrEqual(obstacleDistance(before, obstacle) - 1e-8)
+      expect(pastureSegmentClear(before, animal, [wall], animal.clearance)).toBe(true)
+    }
+    expect(animal.ready).toBe(true)
+    expect(animal.x).toBe(animal.home.x)
+  })
+
+  it("reports a newly blocked hitch so the merchant can leave an unusable pitch", () => {
+    const ground = map(), animal = createPasture({ x: -2, z: 0 }, [], .3)
+    animal.x = -1
+    animal.obstacles.push({ ...animal.home, heading: 0, halfWidth: .4, halfLength: .4 })
+    for (let i = 0; i < 40; i++) stepPasture(ground, animal, .1, .3, true)
+    expect(animal.ready).toBe(false)
+    expect(animal.stranded).toBe(true)
+  })
+
   it("cannot choose grass on the opposite side of roads, tracks or water", () => {
     for (const barrier of ["path", "track", "water", "bridge"] as const) {
       const ground = map(); ground.tiles = ground.tiles.map(tile => tile === "path" ? barrier : tile)

--- a/lib/game/transport/pasture.ts
+++ b/lib/game/transport/pasture.ts
@@ -2,13 +2,16 @@ import { tileAt, tileToWorldX, tileToWorldZ, worldToTileX, worldToTileZ, type Ga
 import { animalTravel } from "./animal-travel"
 import { buildingAt } from "../settlement"
 
-import { pastureSegmentClear, type StallObstacle } from "./stall"
+import { pastureEscapeClear, pastureSegmentClear, type StallObstacle } from "./stall"
 
 export interface PastureAnimal {
   tether?: import("../trees/placement").TreePlacement
   obstacles: StallObstacle[]; clearance: number
   x: number; z: number; heading: number; reversing: boolean; moving: boolean; distance: number; rest: number; visits: number
   home: { x: number; z: number }; route: Array<{ x: number; z: number }>; returning: boolean; ready: boolean
+  /** The old hitch can no longer be reached; the merchant must abandon this pitch. */
+  stranded?: boolean
+  blockedSeconds?: number
 }
 const key = (t: TilePos) => `${t.x},${t.z}`
 function safe(map: GameMap, t: TilePos) {
@@ -52,6 +55,39 @@ export function stepPasture(map: GameMap, animal: PastureAnimal, dt: number, spe
     return
   }
   const blocked = [...animal.obstacles, ...buildingObstacles(map)]
+  animal.stranded = false
+  const cannotReturn = () => {
+    animal.blockedSeconds = recall ? (animal.blockedSeconds ?? 0) + Math.max(0, dt) : 0
+    animal.stranded = animal.blockedSeconds >= 3
+  }
+  // A new stall or footprint can cover an animal that was already grazing.
+  // Walk out to the nearest clear grass, checking all previously clear obstacles.
+  if (!pastureSegmentClear(animal, animal, blocked, animal.clearance)) {
+    for (let radius = .25; radius <= 4; radius += .25) for (let i = 0; i < 16; i++) {
+      const angle = Math.atan2(animal.home.x - animal.x, animal.home.z - animal.z) + i * Math.PI / 8
+      const target = { x: animal.x + Math.sin(angle) * radius, z: animal.z + Math.cos(angle) * radius }
+      if (!safe(map, { x: worldToTileX(map, target.x), z: worldToTileZ(map, target.z) }) ||
+        !pastureSegmentClear(target, target, blocked, animal.clearance) ||
+        !pastureEscapeClear(animal, target, blocked, animal.clearance)) continue
+      const steps = Math.ceil(radius / .1)
+      let groundClear = true
+      for (let j = 0; j <= steps; j++) {
+        const terrain = tileAt(map, worldToTileX(map, animal.x + (target.x - animal.x) * j / steps),
+          worldToTileZ(map, animal.z + (target.z - animal.z) * j / steps))
+        if (!["grass", "clearing", "dirt"].includes(terrain ?? "")) { groundClear = false; break }
+      }
+      if (!groundClear) continue
+      const step = Math.min(radius, Math.max(0, speed * dt))
+      Object.assign(animal, animalTravel(animal.heading, target.x - animal.x, target.z - animal.z))
+      animal.x += Math.sin(angle) * step; animal.z += Math.cos(angle) * step
+      animal.distance = step; animal.moving = step > 0
+      animal.blockedSeconds = 0
+      animal.route = []; animal.returning = false; animal.ready = false
+      return
+    }
+    cannotReturn()
+    return
+  }
   const hx = worldToTileX(map, animal.home.x), hz = worldToTileZ(map, animal.home.z)
   const centre = (tile: TilePos) => tile.x === hx && tile.z === hz ? animal.home : ({ x: tileToWorldX(map, tile.x), z: tileToWorldZ(map, tile.z) })
   if (recall && !animal.returning) {
@@ -60,7 +96,7 @@ export function stepPasture(map: GameMap, animal: PastureAnimal, dt: number, spe
     // Replan from the actual position; every edge must clear the whole animal.
     const route = routes.find(path => path.at(-1)!.x === hx && path.at(-1)!.z === hz)
     if (!route && (worldToTileX(map, animal.x) !== hx || worldToTileZ(map, animal.z) !== hz)) {
-      animal.returning = false; return
+      animal.returning = false; cannotReturn(); return
     }
     animal.route = [...(route ?? []).map(centre), animal.home]
   }
@@ -76,7 +112,9 @@ export function stepPasture(map: GameMap, animal: PastureAnimal, dt: number, spe
     const target = animal.route[0], dx = target.x - animal.x, dz = target.z - animal.z, distance = Math.hypot(dx, dz)
     if (distance < 1e-6) { animal.x = target.x; animal.z = target.z; animal.route.shift(); continue }
     if (!pastureSegmentClear(animal, target, blocked, animal.clearance)) {
-      animal.route = []; animal.returning = false; animal.ready = false; return
+      animal.route = []; animal.returning = false; animal.ready = false
+      cannotReturn()
+      return
     }
     const step = Math.min(distance, remaining)
     Object.assign(animal, animalTravel(animal.heading, dx, dz))
@@ -85,5 +123,6 @@ export function stepPasture(map: GameMap, animal: PastureAnimal, dt: number, spe
     if (step === distance) { animal.x = target.x; animal.z = target.z; animal.route.shift() }
   }
   animal.moving = animal.distance > 1e-6
+  if (animal.moving || !animal.route.length) animal.blockedSeconds = 0
   if (!animal.route.length) { animal.rest = 3 + animal.visits % 4; animal.ready = recall }
 }

--- a/lib/game/transport/recovery.test.ts
+++ b/lib/game/transport/recovery.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest"
+import { createSim, stepSim } from "../sim"
+import { generateTravelers, TRAVELER_TYPES } from "../travelers"
+import { worldToTileX, worldToTileZ, type GameMap } from "../map/types"
+import { cartOffset } from "./assets"
+import { roadCartPose } from "./bridge-guide"
+import { driveSegment } from "./building-parking"
+import { convoyBuildingsClear, convoyPoint, parkingClear, stallParking } from "./navigation"
+import { recoverCart } from "./recovery"
+
+function fixture() {
+  const map: GameMap = { width: 40, depth: 20, tiles: Array(800).fill("grass"), buildings: [],
+    road: Array.from({ length: 40 }, (_, x) => ({ x, z: 10 })) }
+  for (const p of map.road!) map.tiles[p.z * map.width + p.x] = "path"
+  return map
+}
+
+describe("interrupted cart journeys", () => {
+  it("leaves room for the unfolded stall beside another grazing animal", () => {
+    const map = fixture(), progress = 8, scale = 1.5, wheelbase = -cartOffset("horse") * scale
+    const from = convoyPoint(map, progress, scale, 1)
+    const original = stallParking(map, from, progress, 1, wheelbase, scale, "horse", { trees: [] })!
+    expect(original).not.toBeNull()
+    const display = original.obstacles[1]
+    const occupied = { x: display.x, z: display.z, heading: 0, halfWidth: .2, halfLength: .2 }
+    const next = stallParking(map, from, progress, 1, wheelbase, scale, "horse", { trees: [], obstacles: [occupied] })
+    expect(next?.side).not.toBe(original.side)
+  })
+
+  it.each([.1, 1.25])("replaces an active route blocked by a new wall with dt %s", dt => {
+    const map = fixture(), traveler = generateTravelers(1, 1)[0]
+    Object.assign(traveler, { id: 8, type: TRAVELER_TYPES.vendor, direction: 1, offset: 12 / 39, pace: 1 })
+    Object.assign(traveler.attributes, { piety: 0, hunger: 100, thirst: 100, stamina: 100 })
+    const sim = createSim([traveler], map), s = sim.travelers.get(8)!
+    s.timer = 10000
+    const from = convoyPoint(map, 12), to = convoyPoint(map, 25)
+    s.roadShortcut = { from, to, start: 12, end: 25, length: 13, distance: 0 }
+    map.buildings = [{ id: "wall", label: "Wall", x: 18, z: 9, w: 2, d: 3, height: 1, color: "", roofColor: "" }]
+    let recovered = false
+    for (let i = 0; i < Math.ceil(50 / dt) && s.progress < 25; i++) {
+      stepSim(sim, [traveler], map, 1, dt)
+      recovered ||= !!s.cartRecovery
+      expect(convoyBuildingsClear(map, s.cartPose!, "horse", 1.5)).toBe(true)
+    }
+    expect(recovered).toBe(true)
+    expect(s.progress).toBeGreaterThanOrEqual(25)
+  })
+
+  it.each([1, -1] as const)("resumes after construction appears under the convoy in direction %s", direction => {
+    const map = fixture(), traveler = generateTravelers(1, 1)[0]
+    Object.assign(traveler, { id: 8, type: TRAVELER_TYPES.vendor, direction, offset: .5, pace: 1 })
+    Object.assign(traveler.attributes, { piety: 0, hunger: 100, thirst: 100, stamina: 100 })
+    const sim = createSim([traveler], map), s = sim.travelers.get(8)!
+    s.timer = 10000
+    stepSim(sim, [traveler], map, 1, .1)
+    const start = s.progress
+    map.buildings = [{ id: "new", label: "New", x: worldToTileX(map, s.x), z: worldToTileZ(map, s.z),
+      w: 2, d: 2, height: 1, color: "", roofColor: "", construction: { work: 0, required: 10 } }]
+    expect(convoyBuildingsClear(map, s.cartPose!, "horse", 1.5)).toBe(false)
+    for (let i = 0; i < 100; i++) {
+      map.buildings[0].construction!.work = Math.min(10, i)
+      stepSim(sim, [traveler], map, 1, .1)
+      if (i > 1) expect(convoyBuildingsClear(map, s.cartPose!, "horse", 1.5)).toBe(true)
+    }
+    expect(s.cartRecovery).toBe(false)
+    expect(Math.abs(s.progress - start)).toBeGreaterThan(2)
+    expect(s.moveSpeed).toBeGreaterThan(0)
+  })
+
+  it("replans around a new wall from the current clear pose without snapping to the road", () => {
+    const map = fixture(), progress = 15, scale = 1.5, wheelbase = -cartOffset("horse") * scale
+    const initial = roadCartPose(map, progress, 1, wheelbase, scale)
+    map.buildings = [{ id: "wall", label: "Wall", x: 18, z: 9, w: 2, d: 3, height: 1, color: "", roofColor: "" }]
+    const recovery = recoverCart(map, initial, progress, 1, "horse", scale, { trees: [] })!
+    expect(recovery).not.toBeNull()
+    expect(recovery.pose).toBe(initial)
+    expect(recovery.route).toBeDefined()
+    const route = recovery.route!
+    let pose = initial
+    for (const point of [...(route.via ?? []), route.to]) {
+      const next = driveSegment(pose, point, wheelbase, (p, heading) => parkingClear(map, p, "horse", scale, { trees: [] }, false, heading))
+      expect(next).not.toBeNull()
+      pose = next!
+    }
+  })
+
+  it("does not recover onto water or another reserved cart", () => {
+    const map = fixture(), initial = roadCartPose(map, 15, 1, -cartOffset("horse") * 1.5, 1.5)
+    map.buildings = [{ id: "new", label: "New", x: 15, z: 10, w: 1, d: 1, height: 1, color: "", roofColor: "" }]
+    const context = { trees: [], obstacles: [{ x: 0, z: 0, heading: 0, halfWidth: 40, halfLength: 20 }] }
+    expect(recoverCart(map, initial, 15, 1, "horse", 1.5, context)).toBeNull()
+    map.tiles.fill("water")
+    expect(recoverCart(map, initial, 15, 1, "horse", 1.5, { trees: [] })).toBeNull()
+  })
+})

--- a/lib/game/transport/recovery.ts
+++ b/lib/game/transport/recovery.ts
@@ -1,0 +1,46 @@
+import type { GameMap } from "../map/types"
+import { cartOffset, type Puller } from "./assets"
+import { roadCartPose } from "./bridge-guide"
+import { cartPath, driveSegment } from "./building-parking"
+import type { CartPose } from "./follow"
+import { convoyBuildingsClear, parkingClear, type ParkingContext } from "./navigation"
+import { advanceCartProgress } from "./route"
+import { routeLength } from "./roadside"
+import type { WalkingShortcut } from "../walking-shortcuts"
+
+/** Rejoin nearby traffic after a construction edit invalidates a maneuver.
+ * Only a convoy already inside a new footprint may be set down elsewhere;
+ * otherwise every step of the replacement route must pass normal clearance. */
+export function recoverCart(map: GameMap, initial: CartPose, progress: number, direction: 1 | -1,
+  puller: Puller, scale: number, context: ParkingContext): { pose: CartPose; progress: number; route?: WalkingShortcut } | null {
+  const wheelbase = -cartOffset(puller) * scale
+  const embedded = !convoyBuildingsClear(map, initial, puller, scale)
+  // People can move away while a convoy rejoins. Parked assets cannot.
+  const fixed = { trees: context.trees, obstacles: context.obstacles }
+  const starts = [initial]
+  if (!embedded) for (const back of [.5, 1, 2, 3]) {
+    const pose = driveSegment(initial, { x: initial.hitch.x - Math.sin(initial.heading) * back,
+      z: initial.hitch.z - Math.cos(initial.heading) * back }, wheelbase,
+    (p, heading) => parkingClear(map, p, puller, scale, fixed, false, heading) && parkingClear(map, p, puller, scale, fixed))
+    if (!pose) break
+    starts.push(pose)
+  }
+  for (const start of starts) {
+    for (const sign of embedded ? [1, -1] : [1]) {
+      for (let distance = 2; distance <= 16; distance += 2) {
+        const end = advanceCartProgress(map, progress, direction * distance * sign)
+        if (end <= 0 || end >= (map.road?.length ?? 1) - 1) continue
+        const pose = roadCartPose(map, end, direction, wheelbase, scale)
+        if (!parkingClear(map, pose, puller, scale, fixed)) continue
+        if (embedded) return { pose, progress: end }
+        const drive = cartPath(map, start, pose.hitch, puller, scale, fixed, pose.heading)
+        if (drive) {
+          const entry = start === initial ? drive.entry : [initial.hitch, ...drive.entry]
+          return { pose: initial, progress, route: { from: initial.hitch, to: pose.hitch,
+            start: progress, end, via: entry.slice(1, -1), length: routeLength(entry), distance: 0 } }
+        }
+      }
+    }
+  }
+  return null
+}

--- a/lib/game/transport/stall.ts
+++ b/lib/game/transport/stall.ts
@@ -31,6 +31,29 @@ export function stallObstacles(axle: Point, heading: number, side: number, scale
   ]
 }
 export function animalClearance(puller: Puller, scale: number) { return (puller === "horse" ? 2 : 1.9) * RIG_TO_WORLD * scale }
+
+/** Signed distance to a body: negative inside, positive outside. */
+export function obstacleDistance(point: Point, box: StallObstacle) {
+  const dx = point.x - box.x, dz = point.z - box.z
+  const x = Math.abs(dx * Math.cos(box.heading) - dz * Math.sin(box.heading)) - box.halfWidth
+  const z = Math.abs(dx * Math.sin(box.heading) + dz * Math.cos(box.heading)) - box.halfLength
+  return Math.hypot(Math.max(0, x), Math.max(0, z)) + Math.min(0, Math.max(x, z))
+}
+
+/** Existing overlaps may only shrink while escaping a newly placed obstacle. */
+export function pastureEscapeClear(a: Point, b: Point, obstacles: readonly StallObstacle[], clearance: number) {
+  const steps = Math.max(1, Math.ceil(Math.hypot(b.x - a.x, b.z - a.z) / .04))
+  return obstacles.every(box => {
+    let previous = obstacleDistance(a, box)
+    if (previous > clearance) return pastureSegmentClear(a, b, [box], clearance)
+    for (let i = 1; i <= steps; i++) {
+      const distance = obstacleDistance({ x: a.x + (b.x - a.x) * i / steps, z: a.z + (b.z - a.z) * i / steps }, box)
+      if (distance < previous - 1e-8) return false
+      previous = distance
+    }
+    return previous > clearance
+  })
+}
 /** Segment vs expanded oriented boxes: check the whole body sweep, including
  * its head while grazing, rather than only the destination tile or hoof. */
 export function pastureSegmentClear(a: Point, b: Point, obstacles: readonly StallObstacle[], clearance: number) {


### PR DESCRIPTION
Recover blocked carts and passenger wagons with bounded retries, collision-checked reversing, and replanned routes; relocate convoys already covered by construction to nearby clear road.

Reserve grazing animals, hitch positions, parked wagons, and unfolded stall footprints, and let overlapping animals separate or have merchants abandon an unreachable pitch.

Match planned animal clearance to movement playback to prevent mid-turn jams.

Validation: 373 relevant tests passed across transport, simulation, hospitality, reservations, and saves, plus `npm run typecheck`.
