### PR TITLE
Fix sprite rotation and synchronize preview cameras

### DIFF
--- a/components/building-lab/building-preview.tsx
+++ b/components/building-lab/building-preview.tsx
@@ -16,6 +16,7 @@ function Camera({ view, footprint }: { view: number; footprint: number }) {
     camera.lookAt(0, 1.3, 0)
     if ("zoom" in camera) camera.zoom = Math.min(size.width, size.height) / (footprint * 1.3 + 1.5)
     camera.updateProjectionMatrix()
+    camera.updateMatrixWorld()
   }, [camera, size, view, footprint])
   return null
 }

--- a/components/building-lab/map-comparison.tsx
+++ b/components/building-lab/map-comparison.tsx
@@ -48,6 +48,7 @@ function SceneCamera({ recipe, zoom }: { recipe: BuildingRecipe; zoom: number })
     camera.lookAt(0, TILE_HEIGHT + 0.6, 0)
     if (camera instanceof THREE.OrthographicCamera) camera.zoom = Math.min(size.width, size.height) / (Math.max(buildingDimensions(recipe).width, buildingDimensions(recipe).depth) * 1.42 + 5) * zoom
     camera.updateProjectionMatrix()
+    camera.updateMatrixWorld()
     invalidate()
   }, [camera, size, recipe.width, recipe.depth, recipe.view, zoom, invalidate])
   return null

--- a/components/game/environment-sprites.tsx
+++ b/components/game/environment-sprites.tsx
@@ -3,7 +3,7 @@
 import { SceneAssetBoundary } from "./scene-assets"
 
 import { memo, useEffect, useLayoutEffect, useMemo, useRef } from "react"
-import { useFrame, useLoader } from "@react-three/fiber"
+import { useLoader } from "@react-three/fiber"
 import * as THREE from "three"
 import { usePixelWorldTexel } from "@/components/pixel-canvas"
 import { BOULDER_SIZES, ENVIRONMENT_KINDS, type EnvironmentPlacement } from "@/lib/game/environment/elements"
@@ -12,6 +12,7 @@ import { foliageMaterial } from "@/lib/game/trees/foliage/material"
 import { configureSpriteDepthTexture } from "@/lib/game/render/sprite-depth"
 import { OUTLINE_ID_LAYER_MASK } from "@/lib/game/render/outline"
 import { blockKey } from "@/lib/game/render/blocks"
+import { spriteRow } from "@/lib/game/character-assets"
 
 export function EnvironmentField({ placements }: { placements: EnvironmentPlacement[] }) {
   const [small, large] = useMemo(() => [placements.filter(p => !p.boulderSize), placements.filter(p => p.boulderSize)], [placements])
@@ -38,7 +39,9 @@ function SpriteField({ placements, large = false }: { placements: EnvironmentPla
 }
 
 export interface ScenerySpritePlacement {
-  x: number; y: number; z: number; yaw: number; brightness: number; row: number
+  x: number; y: number; z: number; brightness: number; row: number
+  /** World-space yaw, with the same sign as Object3D.rotation.y. */
+  yaw: number
   idColor?: readonly [number, number, number]
 }
 
@@ -70,10 +73,6 @@ export function ScenerySpriteField({ placements, atlas, frame }: {
     previous.current = out
     return [...out]
   }, [placements])
-  useFrame(({ camera }) => {
-    const yaw = Math.atan2(camera.matrixWorld.elements[8], camera.matrixWorld.elements[10])
-    view.value = (Math.round(yaw / (Math.PI * 2 / frame.directions)) + frame.directions) % frame.directions
-  })
   useEffect(() => () => { color.dispose(); depth.dispose(); materials.forEach(m => m.dispose()) }, [color, depth, materials])
   return <group name="environment-sprites">
     {blocks.map(([key, block]) => <SpriteBlock key={key} placements={block} materials={materials} frame={frame} />)}
@@ -86,7 +85,7 @@ const SpriteBlock = memo(function SpriteBlock({ placements, materials, frame }: 
     const g = new THREE.PlaneGeometry(1, 1)
     g.translate(0, frame.anchor[1] / frame.cellSize - .5, 0)
     g.setAttribute("foliageFrame", new THREE.InstancedBufferAttribute(new Float32Array(placements.flatMap(p => [
-      Math.round(p.yaw / (Math.PI * 2 / frame.directions)) % frame.directions,
+      spriteRow(p.yaw, 0, frame.directions),
       p.row,
     ])), 2))
     // Small scenery occludes hidden outlines without adding a contour of its own.

--- a/components/game/water-sources.tsx
+++ b/components/game/water-sources.tsx
@@ -7,6 +7,6 @@ import { SceneAssetBoundary } from "./scene-assets"
 
 /** Shared scenery sprites for placed water sources and the asset gallery. */
 export function WaterSources({ placements }: { placements: (WaterSourcePlacement & { idColor?: readonly [number, number, number] })[] }) {
-  const sprites = useMemo(() => placements.map(p => ({ ...p, yaw: -p.yaw, brightness: 1, row: WATER_SOURCE_KINDS.indexOf(p.kind) })), [placements])
+  const sprites = useMemo(() => placements.map(p => ({ ...p, brightness: 1, row: WATER_SOURCE_KINDS.indexOf(p.kind) })), [placements])
   return <SceneAssetBoundary><ScenerySpriteField placements={sprites} atlas={WATER_SOURCE_ATLAS} frame={WATER_SOURCE_FRAME} /></SceneAssetBoundary>
 }

--- a/components/preview-canvas.tsx
+++ b/components/preview-canvas.tsx
@@ -63,6 +63,8 @@ function CameraAim({ view, zoom }: { view: number; zoom: number }) {
     camera.lookAt(0, 0, 0)
     camera.zoom = zoom
     camera.updateProjectionMatrix()
+    // Sprite animation and culling read the matrix before Three renders.
+    camera.updateMatrixWorld()
   }, [camera, view, zoom])
   return null
 }

--- a/lib/game/character-assets.test.ts
+++ b/lib/game/character-assets.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest"
+import { Matrix4, Vector3 } from "three"
+import { CART } from "./transport/assets"
 import { CHARACTER_ASSETS, characterVisual, selectionPlaybackRate, spriteFrame, spriteRow } from "./character-assets"
 import { validateCharacterAssets } from "./character-asset-store"
 
@@ -14,6 +16,19 @@ describe("camera-relative sprite facing", () => {
     expect(spriteRow(0, -Math.PI / 4)).toBe(7)
     expect(spriteRow(0, Math.PI / 8 - 0.001)).toBe(0)
     expect(spriteRow(0, Math.PI / 8 + 0.001)).toBe(1)
+  })
+  it.each([8, CART.directions])("matches baked geometry through forward and reverse camera turns with %i directions", directions => {
+    const step = 2 * Math.PI / directions
+    // An asymmetric landmark makes reversed rotations detectable.
+    const landmark = new Vector3(.43, .57, .39)
+    for (let facing = 0; facing < directions; facing++) for (let view = -directions; view <= directions; view++) {
+      const heading = facing * step, yaw = view * step
+      const row = spriteRow(heading, yaw, directions)
+      const actual = landmark.clone().applyMatrix4(new Matrix4().makeRotationY(heading))
+        .applyMatrix4(new Matrix4().makeRotationY(-yaw))
+      const baked = landmark.clone().applyMatrix4(new Matrix4().makeRotationY(-row * step))
+      expect(actual.distanceTo(baked)).toBeLessThan(1e-12)
+    }
   })
   it("loops walking frames and holds a passing pose when stationary", () => {
     expect([0, 0.25, 0.5, 0.75, 1].map((s) => spriteFrame(s, 4))).toEqual([0, 1, 2, 3, 0])

--- a/lib/game/trees/foliage/material.test.ts
+++ b/lib/game/trees/foliage/material.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest"
+import * as THREE from "three"
+import { foliageMaterial } from "./material"
+import { FOLIAGE_FRAME } from "./design"
+import { ENT_FRAME } from "../ent-rig"
+import { BOULDER_FRAME, ENVIRONMENT_FRAME } from "../../environment/sprites"
+import { WATER_SOURCE_FRAME } from "../../water-sources/assets"
+import { cameraOffset, yawForView } from "../../render/iso"
+
+const layouts = [
+  { name: "wells and watering holes", frame: WATER_SOURCE_FRAME },
+  { name: "shrubs, grass, stones, boulders, groundcover and flowers", frame: ENVIRONMENT_FRAME },
+  { name: "large boulder groups", frame: BOULDER_FRAME },
+  { name: "all tree species, ancient trees and snags", frame: FOLIAGE_FRAME },
+  { name: "all Ent species and poses", frame: ENT_FRAME },
+]
+
+describe("scenery rotation at render time", () => {
+  it.each(layouts)("updates $name for each actual render camera without an animation tick", ({ frame }) => {
+    const color = new THREE.Texture(), depth = new THREE.Texture(), crop = new THREE.DataTexture()
+    const scene = new THREE.Scene(), group = new THREE.Group(), mesh = new THREE.Mesh(), camera = new THREE.OrthographicCamera()
+    const renderer = { getCurrentViewport: (target: THREE.Vector4) => target.set(0, 0, 640, 480) } as THREE.WebGLRenderer
+    const views = [{ value: -1 }, { value: -1 }]
+    const materials = views.map((view, index) => foliageMaterial(color, depth, view, { value: 0 }, index === 1, frame, crop))
+    try {
+      // Change direction repeatedly within a single tick, across both wrap boundaries.
+      for (const index of [0, 1, 2, 3, 4, -1, -2, -3, -4, 0]) {
+        camera.position.set(...cameraOffset(yawForView(index)))
+        camera.lookAt(0, 0, 0); camera.updateMatrixWorld()
+        const expected = ((1 + index * 2) % 8 + 8) % 8
+        for (const material of materials) material.onBeforeRender(renderer, scene, camera, mesh.geometry, mesh, group)
+        expect(views.map(view => view.value)).toEqual([expected, expected])
+      }
+      const alternate = camera.clone()
+      alternate.position.set(...cameraOffset(0)); alternate.lookAt(0, 0, 0); alternate.updateMatrixWorld()
+      for (const material of materials) material.onBeforeRender(renderer, scene, alternate, mesh.geometry, mesh, group)
+      expect(views.map(view => view.value)).toEqual([0, 0])
+      for (const material of materials) material.onBeforeRender(renderer, scene, camera, mesh.geometry, mesh, group)
+      expect(views.map(view => view.value)).toEqual([1, 1])
+    } finally {
+      materials.forEach(material => material.dispose())
+      color.dispose(); depth.dispose(); crop.dispose(); mesh.geometry.dispose(); (mesh.material as THREE.Material).dispose()
+    }
+  })
+})

--- a/lib/game/trees/foliage/material.ts
+++ b/lib/game/trees/foliage/material.ts
@@ -1,6 +1,7 @@
 import * as THREE from "three"
 import { applySpriteDepth } from "../../render/sprite-depth"
 import { FOLIAGE_FRAME } from "./design"
+import { spriteRow } from "../../character-assets"
 
 export interface FoliageSpriteFrame {
   directions: number
@@ -15,7 +16,13 @@ export function foliageMaterial(color: THREE.Texture, depth: THREE.Texture, view
   worldTexel: { value: number }, ids = false, frame: FoliageSpriteFrame = FOLIAGE_FRAME, crop?: THREE.DataTexture) {
   const viewport = new THREE.Vector4()
   const material = new THREE.MeshBasicMaterial({ map: color, alphaTest: 0.5, transparent: false, toneMapped: false, side: THREE.DoubleSide })
-  material.onBeforeRender = renderer => { renderer.getCurrentViewport(viewport) }
+  material.onBeforeRender = (renderer, _scene, camera) => {
+    renderer.getCurrentViewport(viewport)
+    // Use the camera drawing this pass, including immediate editor renders.
+    // A frame callback can still hold the previous camera pose after Rotate.
+    const m = camera.matrixWorld.elements
+    view.value = spriteRow(0, Math.atan2(m[8], m[10]), frame.directions)
+  }
   material.onBeforeCompile = shader => {
     shader.uniforms.foliageView = view
     shader.uniforms.foliageCrop = { value: crop ?? null }


### PR DESCRIPTION
Fix reversed scenery placement rotation and prevent sprites from using a stale camera pose after preview rotation controls change the view.
Scenery now uses the shared character yaw convention, water sources no longer need a separate sign flip, and the foliage material selects its atlas direction from the camera rendering each pass.
Shared and building preview cameras update their world matrices immediately, with regression tests covering scenery layouts, alternate render cameras, and 8- and 16-direction sprite geometry.
Validation: 78 targeted tests and TypeScript checks passed; browser checks exercised all four well, scenery, and tree views plus drinking and overlap previews.
