### PR TITLE
Prevent nuns from taking settlement jobs

### DIFF
--- a/lib/game/hospitality.test.ts
+++ b/lib/game/hospitality.test.ts
@@ -1282,7 +1282,7 @@ describe("shrine visits beside a covered junction", () => {
 })
 
 
-describe("traveling monks and housing limits", () => {
+describe("traveling monks, nuns and housing limits", () => {
   function finishPrayer(sim: SimState, people: Traveler[], map: GameMap) {
     for (const s of sim.travelers.values()) {
       if (s.employer) continue
@@ -1355,6 +1355,29 @@ describe("traveling monks and housing limits", () => {
     leaveChurch(sim, people, map)
     expect(sim.joinedMonks.size).toBe(0)
     expect([...sim.travelers.values()].every(s => s.activity === "walking")).toBe(true)
+  })
+
+  it.each([false, true])("keeps visiting nuns out of settlement jobs even with housing and vacancies (jobless: %s)", (jobless) => {
+    const { map, camp, trees, traveler } = fixture()
+    addHouse(map)
+    const people = Array.from({ length: 40 }, (_, id) => {
+      const person = { ...traveler(id), type: TRAVELER_TYPES.nun }
+      person.attributes.jobless = jobless
+      return person
+    })
+    const sim = createSim(people, map)
+    sim.buildings = [camp]
+    sim.trees = trees
+    finishPrayer(sim, people, map)
+    leaveChurch(sim, people, map)
+    expect(sim.visits).toBe(people.length)
+    expect(sim.joinedMonks.size).toBe(0)
+    expect(sim.travelers.size).toBe(people.length)
+    for (const visitor of sim.travelers.values()) {
+      expect(visitor.employer).toBeNull()
+      expect(visitor.home).toBeNull()
+      expect(visitor.activity).toBe("walking")
+    }
   })
 
   it("limits new workers to completed house beds even when more jobs are open", () => {

--- a/lib/game/sim.ts
+++ b/lib/game/sim.ts
@@ -1419,6 +1419,8 @@ function finishVisit(sim: SimState, s: SimTraveler, map: GameMap): void {
 }
 
 function settleAfterVisit(sim: SimState, s: SimTraveler, t: Traveler, map: GameMap): void {
+  // Nuns retain their religious calling instead of taking settlement jobs.
+  if (t.type.id === "nun") return
   if (t.type.id === "friar") {
     const bed = vacantMonkBed(map, sim.joinedMonks.values())
     if (bed && nextRoll(s) < MONK_JOIN_CHANCE) {


### PR DESCRIPTION
Nuns could accept woodcutting and other settlement jobs after visiting the shrine despite having a religious calling. Exclude nuns from settlement recruitment so they finish their visit and return to the road.

Regression tests cover nuns with either jobless state when housing and woodcutting vacancies are available. Validation: 131 related tests passed (one existing simulation timeout passed on an isolated rerun), and `npm run typecheck` passed.
