### PR TITLE
Fix cart selection when transport sprites are batched

### DIFF
--- a/components/game/transport-sprite.tsx
+++ b/components/game/transport-sprite.tsx
@@ -4,6 +4,7 @@ import { spriteTextureView } from "@/lib/game/render/sprite-texture"
 
 import { withTerrainCornerQueries } from "@/lib/game/map/cliff-corners"
 import { isWorldVisible } from "@/lib/game/render/visibility"
+import { markPerson } from "@/lib/game/selection"
 
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 import { useFrame, useLoader } from "@react-three/fiber"
@@ -184,8 +185,11 @@ export function TransportSprite({ passengerCart, seat = 0, calling = "peasant", 
   }, clock))
   const size = manifest.scale * characterScale
   const center = useMemo(() => new THREE.Vector2(manifest.anchor[0] / manifest.cellSize, 1 - manifest.anchor[1] / manifest.cellSize), [])
-  return <group ref={root} position={position}>
+  return <group ref={group => { root.current = group; markPerson(group) }} position={position}>
+    {/* Batching hides this source sprite only for drawing. Keep its full click
+        area active, including for passenger carts without a walker hit target. */}
     <sprite ref={body} name={kind} renderOrder={renderOrder} material={materials[0]} center={center} scale={[size, size, 1]} onClick={onClick}
+      userData-batchedPickTarget={true}
       layers-mask={selected ? 1 | (1 << SELECTED_CHARACTER_LAYER) : 1} />
     {outlineColor && <sprite ref={ids} renderOrder={renderOrder} material={materials[1]} center={center} scale={[size, size, 1]} layers-mask={OUTLINE_ID_LAYER_MASK} />}
   </group>

--- a/lib/game/selection.test.ts
+++ b/lib/game/selection.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
+import { Group, OrthographicCamera, Raycaster, Sprite, Vector2 } from "three"
 import { useBuildStore } from "./build-store"
 import { useCameraStore, type Selection } from "./camera-store"
 import { markPerson, markSelectionScenery, prioritizePeople, selectElement, selectionObjectId } from "./selection"
@@ -137,5 +138,36 @@ describe("shared selection", () => {
     layer.visible = true
     roof.object.userData.batchedPickTarget = false
     expect(prioritizePeople([roof])).toEqual([])
+  })
+
+  it.each([false, true])("keeps the full transport sprite clickable through scenery (batched: %s)", (batched) => {
+    const layer = new Group(), transport = new Group(), cart = new Sprite()
+    layer.add(transport); transport.add(cart)
+    markPerson(transport)
+    cart.userData.batchedPickTarget = true
+    cart.visible = !batched
+    cart.scale.set(3, 3, 1)
+    layer.updateMatrixWorld(true)
+    const camera = new OrthographicCamera(-2, 2, 2, -2, .1, 20)
+    camera.position.z = 10
+    camera.updateMatrixWorld(true)
+    const raycaster = new Raycaster()
+    // Click away from the axle/driver, on the outer part of the cart sprite.
+    raycaster.setFromCamera(new Vector2(.6, .3), camera)
+    const hits = raycaster.intersectObject(cart)
+    expect(hits).toHaveLength(1)
+    const tree = { object: { userData: {} }, distance: 2 }
+    markSelectionScenery(tree.object)
+    expect(prioritizePeople([tree, ...hits])).toEqual([...hits, tree])
+
+    // Hidden transport poses (such as a deployed vendor sprite) and the
+    // Characters display preference must still suppress the original target.
+    transport.visible = false
+    expect(prioritizePeople(hits)).toEqual([])
+    transport.visible = true
+    layer.visible = false
+    expect(prioritizePeople(hits)).toEqual([])
+    layer.visible = true
+    expect(prioritizePeople(hits)).toEqual(hits)
   })
 })

--- a/lib/game/selection.ts
+++ b/lib/game/selection.ts
@@ -78,7 +78,7 @@ function hasPickTag(object: PickObject | null | undefined, tag: string): boolean
  * is demoted only when a person is hit, and retained for build-tool events.
  */
 export function prioritizePeople<T extends { object: PickObject }>(hits: readonly T[]): T[] {
-  // Batched buildings keep their original surface as the exact picking mesh.
+  // Batched buildings and transport keep their original surfaces for picking.
   // Its own render visibility is off; user-hidden ancestors still reject hits.
   const visibleHits = hits.filter(hit => hit.object.userData?.batchedPickTarget === true
     ? isObjectVisible(hit.object.parent ?? {}) : isObjectVisible(hit.object))


### PR DESCRIPTION
Transport batching hid the original sprites from selection, making passenger carts and their animals difficult to click. Preserve the full transport sprite click area and give transport the same priority through trees and scenery as travelers, while continuing to reject hidden poses and layers.

Adds raycast regression coverage for batched and unbatched transport, clicks away from the center, scenery priority, and hidden ancestors. Validation: all 29 targeted selection, visibility, and sprite-transform tests passed, along with `npm run typecheck`.
