### PR TITLE
Retire redundant build options and gate guard posts at 80 renown

### DIFF
--- a/app/docs/game-specs/page.tsx
+++ b/app/docs/game-specs/page.tsx
@@ -109,7 +109,7 @@ export default function GameSpecsPage() {
               </tr>
             </thead>
             <tbody>
-              {BUILD_CATALOG.map((def) => (
+              {BUILD_CATALOG.filter(def => !def.retired).map((def) => (
                 <tr key={def.id}>
                   <th scope="row">
                     {def.label}

--- a/components/game/hud-controls.tsx
+++ b/components/game/hud-controls.tsx
@@ -80,7 +80,7 @@ export function BuildControls({ economy, open, onToggle, onClose, minimapOpen, o
   const rotation = useBuildStore((s) => s.rotation)
   const rotateBuilding = useBuildStore((s) => s.rotateBuilding)
   const hovered = useCameraStore((s) => s.hovered)
-  const catalog = useMemo(() => [...buildCatalog(balance)].sort((a, b) =>
+  const catalog = useMemo(() => buildCatalog(balance).filter(item => !item.retired).sort((a, b) =>
     a.id === "workshop" ? -1 : b.id === "workshop" ? 1 : 0), [balance])
   const renown = economy.renown?.total ?? 0
   const selected = catalog.find((item) => item.id === buildType)

--- a/components/game/tile-cursor.tsx
+++ b/components/game/tile-cursor.tsx
@@ -45,7 +45,7 @@ export function TileCursor({
     return new Float32Array([[-0.5, -0.5], [0.5, -0.5], [-0.5, 0.5], [0.5, 0.5]].flatMap(([x, z]) =>
       [x, onBridge ? (ropeHeightAt(map, hovered.x + x * 0.999, hovered.z + z * 0.999) ?? centre) - centre : groundHeight(map, hovered.x + x * 0.999, hovered.z + z * 0.999) - centre, z]))
   }, [map, hovered])
-  const build = useMemo(() => buildCatalog(balance).find((item) => item.id === buildType), [balance, buildType])
+  const build = useMemo(() => buildCatalog(balance).find((item) => item.id === buildType && !item.retired), [balance, buildType])
   const rotation=useMemo(()=>build && hovered ? placementRoofRotation(map,build,hovered,requestedRotation) : requestedRotation,[map,build,hovered,requestedRotation])
   const {layoutSeed,hearthZ,fireplace,supportId,floorHeight,tavernFlue} = build && hovered ? placementBuildingLayout(map,{...build,...rotatedFootprint(build,rotation),...hovered,rotation,buildType:build.id,id:"construction-preview"}) : {}
   const parts = useMemo(() => build ? structureParts({ ...build, buildType: build.id, layoutSeed, hearthZ, fireplace, supportId, floorHeight, tavernFlue }) : [], [build, layoutSeed, hearthZ, fireplace, supportId, floorHeight, tavernFlue])

--- a/lib/game/balance.test.ts
+++ b/lib/game/balance.test.ts
@@ -47,6 +47,17 @@ function map(): GameMap {
 }
 
 describe("balance presets", () => {
+  it("moves the old guard-post default to 80 renown while preserving custom unlocks", () => {
+    const old = JSON.parse(exportBalance(DEFAULT_BALANCE))
+    old.version = 6
+    old.balance.buildings["guard-post"].requiredRenown = 15
+    expect(importBalance(JSON.stringify(old)).balance?.buildings["guard-post"].requiredRenown).toBe(80)
+    old.balance.buildings["guard-post"].requiredRenown = 55
+    expect(importBalance(JSON.stringify(old)).balance?.buildings["guard-post"].requiredRenown).toBe(55)
+    const current = fresh()
+    current.buildings["guard-post"].requiredRenown = 15
+    expect(importBalance(exportBalance(current)).balance).toEqual(current)
+  })
   it("round-trips all defaults without sharing mutable objects", () => {
     const result = importBalance(exportBalance(DEFAULT_BALANCE))
     expect(result.balance).toEqual(DEFAULT_BALANCE)
@@ -168,6 +179,16 @@ describe("balance presets", () => {
 })
 
 describe("tuned gameplay", () => {
+  it("locks guard posts until 80 renown without charging for a locked purchase", () => {
+    const world = map(), settlement = createSettlement()
+    // The founding shrine supplies 5 renown; each completed visit adds 0.5.
+    const locked = purchaseStructure(settlement, world, [], [], "guard-post", { x: 22, z: 18 }, undefined, 149)
+    expect(locked.error).toBe("Requires 80 shrine renown.")
+    expect(locked.settlement).toBe(settlement)
+    const unlocked = purchaseStructure(settlement, world, [], [], "guard-post", { x: 22, z: 18 }, undefined, 150)
+    expect(unlocked.error).toBeNull()
+    expect(unlocked.settlement.structures[0].buildType).toBe("guard-post")
+  })
   it("uses starting funds, costs and unlocks from the supplied balance", () => {
     const balance = fresh()
     balance.rules.startingGold = 12
@@ -192,15 +213,15 @@ describe("tuned gameplay", () => {
   })
   it("revalues structures but ignores legacy passive-income tuning", () => {
     const world = map()
-    const existing = purchaseStructure(createSettlement(), world, [], [], "shelter", {
+    const existing = purchaseStructure(createSettlement(), world, [], [], "monk-shelter", {
       x: 22,
       z: 18,
     }).settlement
     existing.structures[0].construction!.work = existing.structures[0].construction!.required
     const before = structuredClone(existing)
     const balance = fresh()
-    balance.buildings.shelter.renown = 50
-    balance.buildings.shelter.goldIncome = 9
+    balance.buildings["monk-shelter"].renown = 50
+    balance.buildings["monk-shelter"].goldIncome = 9
     balance.rules.residentGold = 3
     balance.rules.residentWood = 5
     balance.rules.incomeSeconds = 6
@@ -215,7 +236,7 @@ describe("tuned gameplay", () => {
     expect(paid.resources.gold - existing.resources.gold).toBe(0)
     expect(paid.resources.wood - existing.resources.wood).toBe(0)
     expect(existing).toEqual(before)
-    expect(buildingIncomeLabel(buildCatalog(balance).find(b => b.id === "shelter")!, balance)).toBe("Adds monk housing when complete")
+    expect(buildingIncomeLabel(buildCatalog(balance).find(b => b.id === "monk-shelter")!, balance)).toBe("Adds monk housing when complete")
   })
   it("applies the tuned influence radius across the full footprint", () => {
     const balance = fresh()

--- a/lib/game/balance.ts
+++ b/lib/game/balance.ts
@@ -13,6 +13,8 @@ export interface Resources {
 
 export interface BuildDefinition {
   id: BuildId
+  /** Retained for existing worlds and artwork, but unavailable for new construction. */
+  retired?: boolean
   label: string
   category: "buildings" | "scenery"
   description: string
@@ -32,6 +34,7 @@ export interface BuildDefinition {
 export const BUILD_CATALOG: readonly BuildDefinition[] = [
   {
     id: "shelter",
+    retired: true,
     label: "Pilgrim shelter",
     category: "buildings",
     description: "A place for pilgrims to rest.",
@@ -129,6 +132,7 @@ export const BUILD_CATALOG: readonly BuildDefinition[] = [
   },
   {
     id: "wood-shelter", label: "Wood shelter", category: "buildings",
+    retired: true,
     description: "An open lean-to that keeps split wood and spare poles dry.",
     cost: { gold: 20, wood: 20 }, renown: 0, requiredRenown: 0,
     income: { gold: 0, wood: 0 }, w: 2, d: 1, height: 0.62,
@@ -136,6 +140,7 @@ export const BUILD_CATALOG: readonly BuildDefinition[] = [
   },
   {
     id: "lumberCamp", label: "Timber yard", category: "buildings",
+    retired: true,
     description: "An open yard for stacking felled timber. No doorway, so it reserves no entrance tile.",
     cost: { gold: 40, wood: 30 }, renown: 0, requiredRenown: 0,
     income: { gold: 0, wood: 0 }, w: 2, d: 2, height: 0.65,
@@ -151,7 +156,7 @@ export const BUILD_CATALOG: readonly BuildDefinition[] = [
   {
     id: "guard-post", label: "Guard post", category: "buildings",
     description: "A sheltered watch post that reassures travelers on the approach.",
-    cost: { gold: 70, wood: 50 }, renown: 4, requiredRenown: 15,
+    cost: { gold: 70, wood: 50 }, renown: 4, requiredRenown: 80,
     income: { gold: 0, wood: 0 }, w: 2, d: 2, height: 0.65,
     color: "#8c7658", roofColor: "#a59164",
   },
@@ -184,6 +189,7 @@ export const BUILD_CATALOG: readonly BuildDefinition[] = [
   },
   {
     id: "watering-hole", label: "Watering hole", category: "scenery",
+    retired: true,
     description: "A shallow earthen pool with an open dipping edge. Thirsty walkers and settlers take turns drinking here for free.",
     cost: { gold: 10, wood: 0 }, renown: 0, requiredRenown: 0,
     income: { gold: 0, wood: 0 }, w: 3, d: 2, height: .1, color: "#847657", roofColor: "#526e67",
@@ -637,7 +643,7 @@ export function validateBalance(
   }
   return { balance: clean, error: null }
 }
-export const BALANCE_VERSION = 6
+export const BALANCE_VERSION = 7
 export function exportBalance(balance: GameBalance): string {
   return JSON.stringify({ version: BALANCE_VERSION, balance }, null, 2)
 }
@@ -645,8 +651,8 @@ export function importBalance(json: string): ReturnType<typeof validateBalance> 
   try {
     const preset = record(JSON.parse(json))
     const version = preset?.version
-    if (version !== 1 && version !== 2 && version !== 3 && version !== 4 && version !== 5 && version !== BALANCE_VERSION)
-      return { balance: null, error: "Unsupported preset version. Expected version 1, 2, 3, 4, 5 or 6." }
+    if (version !== 1 && version !== 2 && version !== 3 && version !== 4 && version !== 5 && version !== 6 && version !== BALANCE_VERSION)
+      return { balance: null, error: "Unsupported preset version. Expected version 1, 2, 3, 4, 5, 6 or 7." }
     // Add defaults for new structures while retaining all authored settings.
     const saved = record(preset?.balance)
     const rules = record(saved?.rules)
@@ -673,6 +679,10 @@ export function importBalance(json: string): ReturnType<typeof validateBalance> 
         // The shepherd’s hut became the house; keep its authored tuning.
         ...(record(buildings["shepherd-hut"]) ? { house: buildings["shepherd-hut"] } : {}),
         ...buildings,
+        // Move the former default unlock later without replacing custom tuning.
+        ...(version < 7 && record(buildings["guard-post"])?.requiredRenown === 15 ? {
+          "guard-post": { ...record(buildings["guard-post"]), requiredRenown: DEFAULT_BALANCE.buildings["guard-post"].requiredRenown },
+        } : {}),
         // The hut now earns wood through deliveries; retire its old passive payment.
         ...(version === 1 && record(buildings.workshop) ? {
           workshop: { ...record(buildings.workshop), woodIncome: 0 },

--- a/lib/game/save/settlement.test.ts
+++ b/lib/game/save/settlement.test.ts
@@ -14,7 +14,7 @@ function buyAnything(world: ReturnType<typeof generateMap>) {
   const monks = generateMonks(world.seed!), relic = generateRelic(world.seed!)
   let settlement = createSettlement(balance)
   const hovel = world.buildings.find(b => b.id === world.site?.hovelId)!
-  const def = [...BUILD_CATALOG].sort((a, b) => a.requiredRenown - b.requiredRenown)[0]
+  const def = BUILD_CATALOG.filter(b => !b.retired).sort((a, b) => a.requiredRenown - b.requiredRenown || a.cost.gold - b.cost.gold)[0]
   for (let r = 2; r < 14; r++) for (let dz = -r; dz <= r; dz++) for (let dx = -r; dx <= r; dx++) {
     const result = purchaseStructure(settlement, world, monks, [relic], def.id, { x: hovel.x + dx, z: hovel.z + dz }, balance, 0, 0)
     if (!result.error) { settlement = result.settlement; if (settlement.structures.length === 2) return settlement }

--- a/lib/game/settlement.test.ts
+++ b/lib/game/settlement.test.ts
@@ -59,7 +59,7 @@ function testMap(): GameMap {
 }
 const monks = generateMonks(12345)
 const relic = generateRelic(12345)
-const shelter = BUILD_CATALOG.find((item) => item.id === "shelter")!
+const house = BUILD_CATALOG.find((item) => item.id === "house")!
 const cross = BUILD_CATALOG.find((item) => item.id === "cross")!
 
 /** A shrine off a through road, as the generator lays one out: road, track, door. */
@@ -94,6 +94,17 @@ function wearPath(map: GameMap, from: TilePos, to: TilePos, passes = 20) {
 const garden = BUILD_CATALOG.find((item) => item.id === "garden")!
 
 describe("build and buy", () => {
+  it.each(["shelter", "wood-shelter", "lumberCamp", "watering-hole"])("retires %s without deleting existing structures or charging for new ones", type => {
+    const def = BUILD_CATALOG.find(b => b.id === type)!
+    expect(def.retired).toBe(true)
+    const existing = { ...def, id: "legacy", buildType: type, x: 10, z: 14 }
+    const before = { ...createSettlement(), structures: [existing] }
+    const result = purchaseStructure(before, testMap(), monks, [relic], type, { x: 18, z: 14 }, undefined, 10000)
+    expect(result.error).toBe("This structure is no longer available to build.")
+    expect(result.settlement).toBe(before)
+    expect(result.settlement.structures[0]).toBe(existing)
+    expect(structureParts(existing).length).toBeGreaterThan(0)
+  })
   it("activates evangelism only after construction and never stacks extra crosses", () => {
     const map = testMap()
     expect(settlementEvangelism(map)).toBe(0)
@@ -154,9 +165,9 @@ describe("build and buy", () => {
     expect(placementError(map, def, at, undefined, 1)).toBeNull()
   })
 
-  it("offers the whole building kit except the relic enclosure", () => {
-    expect(BUILD_CATALOG.filter(b => b.category === "buildings").map(b => b.id))
-      .toEqual(["shelter", "workshop", "hall", "storehouse", "monk-shelter", "house", "wood-shelter", "lumberCamp", "market", "guard-post", "tavern", "inn", "sheep-pen"])
+  it("offers the active building kit", () => {
+    expect(BUILD_CATALOG.filter(b => b.category === "buildings" && !b.retired).map(b => b.id))
+      .toEqual(["workshop", "hall", "storehouse", "monk-shelter", "house", "market", "guard-post", "tavern", "inn", "sheep-pen"])
     for (const type of ["enclosure", "gable", "hovel"])
       expect(purchaseStructure(createSettlement(), testMap(), monks, [relic], type, { x: 10, z: 14 }).error).toBe("Unknown structure.")
   })
@@ -194,22 +205,22 @@ describe("build and buy", () => {
     const original = structuredClone(map.elevation)
     const before = { ...createSettlement(), resources: { gold: 1000, wood: 1000 } }
     const at = { x: 11, z: 14 }
-    const previewHeight = groundHeight(map, at.x + (shelter.w - 1) / 2, at.z + (shelter.d - 1) / 2)
-    const first = purchaseStructure(before, map, monks, [relic], shelter.id, at)
+    const previewHeight = groundHeight(map, at.x + (house.w - 1) / 2, at.z + (house.d - 1) / 2)
+    const first = purchaseStructure(before, map, monks, [relic], house.id, at)
     expect(first.error).toBeNull()
     const firstElevation = structuredClone(first.settlement.elevation!)
-    const second = purchaseStructure(first.settlement, map, monks, [relic], shelter.id, { x: 9, z: 14 })
+    const second = purchaseStructure(first.settlement, map, monks, [relic], house.id, { x: 9, z: 14 })
     expect(second.error).toBeNull()
     expect(second.settlement.elevation).not.toBe(first.settlement.elevation)
     for (const settlement of [first.settlement, second.settlement]) {
       const placedMap = { ...map, elevation: settlement.elevation }
-      for (let z = at.z; z < at.z + shelter.d; z++) for (let x = at.x; x < at.x + shelter.w; x++) {
+      for (let z = at.z; z < at.z + house.d; z++) for (let x = at.x; x < at.x + house.w; x++) {
         for (const dx of [-0.49, 0.49]) for (const dz of [-0.49, 0.49]) {
           expect(groundHeight(placedMap, x + dx, z + dz)).toBeCloseTo(previewHeight)
         }
       }
     }
-    const rejected = purchaseStructure(second.settlement, map, monks, [relic], shelter.id, at)
+    const rejected = purchaseStructure(second.settlement, map, monks, [relic], house.id, at)
     expect(rejected.error).toMatch(/occupies/)
     expect(rejected.settlement).toBe(second.settlement)
     expect(map.elevation).toEqual(original)
@@ -224,28 +235,28 @@ describe("build and buy", () => {
     expect(buildTileError(map, 11, 14, influence)).toBeNull()
     map.elevation.cliffs[i] = 1
     expect(buildTileError(map, 11, 14, influence)).toMatch(/cliffs/)
-    expect(placementError(map, shelter, { x: 11, z: 14 })).toMatch(/cliffs/)
+    expect(placementError(map, house, { x: 11, z: 14 })).toMatch(/cliffs/)
     map.elevation.cliffs[i] = 0
     map.elevation.corners.fill(0.4, (i + 1) * 4, (i + 2) * 4)
-    expect(placementError(map, shelter, { x: 11, z: 14 })).toMatch(/level ground/)
+    expect(placementError(map, house, { x: 11, z: 14 })).toMatch(/level ground/)
   })
 
   it("pays once on successful placement, retaining the base map and founding supplies", () => {
     const before = createSettlement()
     const map = testMap()
-    const result = purchaseStructure(before, map, monks, [relic], "shelter", { x: 11, z: 14 })
+    const result = purchaseStructure(before, map, monks, [relic], "house", { x: 11, z: 14 })
     expect(result.error).toBeNull()
     expect(result.settlement.resources).toEqual({
-      gold: STARTING_RESOURCES.gold - 45,
-      wood: STARTING_RESOURCES.wood - 35,
+      gold: STARTING_RESOURCES.gold - 40,
+      wood: STARTING_RESOURCES.wood - 30,
     })
     expect(result.settlement.structures[0]).toMatchObject({
-      buildType: "shelter",
+      buildType: "house",
       x: 11,
       z: 14,
       w: 2,
       d: 2,
-      construction: { work: 0, required: 96, cost: { gold: 45, wood: 35 } },
+      construction: { work: 0, required: 96, cost: { gold: 40, wood: 30 } },
     })
     expect(before.resources).toEqual(STARTING_RESOURCES)
     expect(before.structures).toHaveLength(0)
@@ -253,20 +264,20 @@ describe("build and buy", () => {
   })
 
   it.each([
-    { gold: 44, wood: 100 },
-    { gold: 100, wood: 34 },
+    { gold: 39, wood: 100 },
+    { gold: 100, wood: 29 },
   ])("requires enough of each currency: %j", (resources) => {
     const before = { ...createSettlement(), resources }
-    const result = purchaseStructure(before, testMap(), monks, [relic], "shelter", { x: 11, z: 14 })
+    const result = purchaseStructure(before, testMap(), monks, [relic], "house", { x: 11, z: 14 })
     expect(result.error).toMatch(/Not enough/)
     expect(result.settlement).toBe(before)
   })
 
   it("allows exact funds, then refuses a second purchase without going negative", () => {
-    const before = { ...createSettlement(), resources: { ...shelter.cost } }
-    const result = purchaseStructure(before, testMap(), monks, [relic], "shelter", { x: 11, z: 14 })
+    const before = { ...createSettlement(), resources: { ...house.cost } }
+    const result = purchaseStructure(before, testMap(), monks, [relic], "house", { x: 11, z: 14 })
     expect(result.settlement.resources).toEqual({ gold: 0, wood: 0 })
-    const second = purchaseStructure(result.settlement, testMap(), monks, [relic], "shelter", {
+    const second = purchaseStructure(result.settlement, testMap(), monks, [relic], "house", {
       x: 18,
       z: 14,
     })
@@ -277,9 +288,9 @@ describe("build and buy", () => {
   it("rejects overlap with both the founding hovel and player additions without charging", () => {
     const before = createSettlement()
     expect(
-      purchaseStructure(before, testMap(), monks, [relic], "shelter", { x: 13, z: 13 }).settlement,
+      purchaseStructure(before, testMap(), monks, [relic], "house", { x: 13, z: 13 }).settlement,
     ).toBe(before)
-    const first = purchaseStructure(before, testMap(), monks, [relic], "shelter", {
+    const first = purchaseStructure(before, testMap(), monks, [relic], "house", {
       x: 11,
       z: 14,
     }).settlement
@@ -294,7 +305,7 @@ describe("build and buy", () => {
       const map = testMap()
       map.tiles[15 * map.width + 12] = terrain
       const before = createSettlement()
-      const result = purchaseStructure(before, map, monks, [relic], "shelter", { x: 11, z: 14 })
+      const result = purchaseStructure(before, map, monks, [relic], "house", { x: 11, z: 14 })
       expect(result.error).toBeTruthy()
       expect(result.settlement).toBe(before)
     },
@@ -305,7 +316,7 @@ describe("build and buy", () => {
     const road = Array.from({ length: 30 }, (_, z) => ({ x: 11, z }))
     for (const p of road) map.tiles[p.z * map.width + p.x] = "path"
     map.road = road
-    expect(placementError(map, shelter, { x: 10, z: 12 })).toBeNull()
+    expect(placementError(map, house, { x: 10, z: 12 })).toBeNull()
   })
 
   it("refuses a footprint that pens the road in with nowhere to go around", () => {
@@ -316,14 +327,14 @@ describe("build and buy", () => {
       map.tiles[z * map.width + 11] = "path"
       for (const x of [10, 12]) map.tiles[z * map.width + x] = "water"
     }
-    const across = { ...shelter, id: "dam", buildType: "shelter", label: "Dam", w: 1, d: 2, x: 11, z: 12, rotation: 0 as const }
+    const across = { ...house, id: "dam", buildType: "house", label: "Dam", w: 1, d: 2, x: 11, z: 12, rotation: 0 as const }
     expect(roadBlockError(map, [...map.buildings, across])).toMatch(/way around the road/)
   })
 
   it("keeps the road's map edges clear for arrivals and departures", () => {
     const map = testMap()
     map.road = Array.from({ length: 30 }, (_, z) => ({ x: 11, z }))
-    const across = { ...shelter, id: "gate", buildType: "shelter", label: "Gate", x: 10, z: 0, rotation: 0 as const }
+    const across = { ...house, id: "gate", buildType: "house", label: "Gate", x: 10, z: 0, rotation: 0 as const }
     expect(roadBlockError(map, [...map.buildings, across])).toMatch(/leaves the map/)
     expect(roadBlockError(map, [...map.buildings, { ...across, z: 12 }])).toBeNull()
   })
@@ -357,13 +368,13 @@ describe("build and buy", () => {
   })
 
   it("keeps the approach clear even if its terrain is open", () => {
-    expect(placementError(testMap(), shelter, { x: 13, z: 16 })).toMatch(/approach/)
+    expect(placementError(testMap(), house, { x: 13, z: 16 })).toMatch(/approach/)
   })
 
   it("rejects distant sites, partial off-map footprints and fractional coordinates", () => {
-    expect(placementError(testMap(), shelter, { x: 0, z: 0 })).toBeTruthy()
-    expect(placementError(testMap(), shelter, { x: 29, z: 14 })).toBeTruthy()
-    expect(placementError(testMap(), shelter, { x: 11.5, z: 14 })).toBeTruthy()
+    expect(placementError(testMap(), house, { x: 0, z: 0 })).toBeTruthy()
+    expect(placementError(testMap(), house, { x: 29, z: 14 })).toBeTruthy()
+    expect(placementError(testMap(), house, { x: 11.5, z: 14 })).toBeTruthy()
   })
 
   it("housing does not unlock the hall; completed visits can earn the required renown", () => {
@@ -379,7 +390,7 @@ describe("build and buy", () => {
       { x: 15, z: 10 },
       { x: 17, z: 10 },
     ]) {
-      const purchase = purchaseStructure(settlement, map, [], [], "shelter", at)
+      const purchase = purchaseStructure(settlement, map, [], [], "house", at)
       expect(purchase.error).toBeNull()
       settlement = purchase.settlement
     }
@@ -396,7 +407,7 @@ describe("build and buy", () => {
       let available = false
       for (let z = hovel.z - 12; z <= hovel.z + 12 && !available; z++) {
         for (let x = hovel.x - 12; x <= hovel.x + 12; x++) {
-          if (!placementError(map, shelter, { x, z })) {
+          if (!placementError(map, house, { x, z })) {
             available = true
             break
           }
@@ -410,7 +421,7 @@ describe("build and buy", () => {
 describe("shrine renown and income", () => {
   it("adds all four sources and counts each resident and relic separately", () => {
     const map = testMap()
-    const first = purchaseStructure(createSettlement(), map, monks, [relic], "shelter", {
+    const first = purchaseStructure(createSettlement(), map, monks, [relic], "house", {
       x: 11,
       z: 14,
     }).settlement
@@ -425,7 +436,7 @@ describe("shrine renown and income", () => {
       monks,
       relics,
     )
-    expect(total.buildings).toBe(5 + shelter.renown)
+    expect(total.buildings).toBe(5 + house.renown)
     expect(total.scenery).toBe(garden.renown)
     expect(total.individuals).toBe(monks.reduce((sum, monk) => sum + individualRenown(monk), 0))
     expect(total.relics).toBe(relics.reduce((sum, item) => sum + relicRenown(item), 0))

--- a/lib/game/settlement.ts
+++ b/lib/game/settlement.ts
@@ -374,6 +374,7 @@ export function purchaseStructure(
 ): { settlement: Settlement; error: string | null } {
   const def = buildCatalog(balance).find((item) => item.id === type)
   if (!def) return { settlement, error: "Unknown structure." }
+  if (def.retired) return { settlement, error: "This structure is no longer available to build." }
   const map = settlementMap(baseMap, settlement)
   if (settlementRenown(map, residents, relics, balance, completedVisits).total < def.requiredRenown)
     return { settlement, error: `Requires ${def.requiredRenown} shrine renown.` }


### PR DESCRIPTION
Removes the wood shelter, timber yard, pilgrim shelter, and watering hole from the build menu, placement previews, purchases, and active game specifications while retaining existing structures and artwork.
Guard posts now unlock at 80 renown instead of 15, and older balance presets adopt the new default while preserving custom unlock values.
Validation: 81 tests passed across balance, settlement, save, and balance-store suites; `npm run typecheck` and `git diff --check` passed.

Existing [build controls design](https://app.paper.design/file/01M1QTYBYHXP4H1BXFQ79N18AP/2-0/1SK-0).
