### PR TITLE
Raise loading indicators and keep the progress bar size fixed

### DIFF
--- a/components/game/loading-church.css
+++ b/components/game/loading-church.css
@@ -1,4 +1,9 @@
 .loading-church {
+  /* The loading UI keeps a fixed pixel size independently of the world zoom. */
+  --loading-pixel: 1px;
+  /* Clear the clipped preview, including saved tree canopies, while keeping
+     the caption on screen when a close zoom fills the viewport. */
+  --loading-indicator-top: max(48px, min(20%, calc(50% + var(--ground-offset) + var(--resume-view-y, 0dvh) - var(--resume-view-height, 50dvh) / 2 - 16px)));
   position: absolute;
   inset: 0;
   z-index: 40;
@@ -92,7 +97,7 @@
 .loading-church-caption {
   position: absolute;
   /* Sits above the progress bar: the bar's own height plus a four-pixel gap. */
-  top: calc(50% - var(--church-roof-offset) - 10 * var(--loading-pixel));
+  top: calc(var(--loading-indicator-top) - 10 * var(--loading-pixel));
   left: 50%;
   transform: translate(-50%, -100%);
   color: #d4c297;
@@ -136,7 +141,7 @@
   position: absolute;
   z-index: 5;
   left: 50%;
-  top: calc(50% - var(--church-roof-offset));
+  top: var(--loading-indicator-top);
   transform: translate(-50%, -100%);
   width: calc(48 * var(--loading-pixel));
   height: calc(6 * var(--loading-pixel));

--- a/components/game/loading-church.tsx
+++ b/components/game/loading-church.tsx
@@ -116,7 +116,7 @@ export function LoadingChurch({ showChurch, phase, overlayRef, idle = false, gen
   if (!showChurch && phase === "complete") return null
   const scale = 100 / viewSize
   return <div ref={overlayRef} className="loading-church" data-loading-church data-phase={phase} data-idle={idle}
-    style={{ "--ground-offset": `${groundOffset * scale}dvh`, "--church-caption-offset": `${3.5 * scale}dvh`, "--church-roof-offset": `${3.6 * scale}dvh`, "--loading-pixel": `${CHARACTER_PIXEL_SIZE * scale}dvh` } as CSSProperties}>
+    style={{ "--ground-offset": `${groundOffset * scale}dvh`, "--church-caption-offset": `${3.5 * scale}dvh` } as CSSProperties}>
     {phase !== "complete" && <div className="loading-church-ground" aria-hidden="true"><div className="loading-church-wipe">
     <svg ref={tilesRef} className="loading-church-tiles" width="100%" height="100%"
       style={{ transform: `translate(${gridShift.x * scale}dvh, ${gridShift.y * scale}dvh)` }}>


### PR DESCRIPTION
Move the loading caption and progress bar higher during map generation and settlement reload, positioning them above the saved preview with a 16px gap where viewport space permits. Keep the bar at 48 × 6 CSS pixels and its caption gap at 4px regardless of world zoom.

Validation: TypeScript passed; Playwright checked desktop and mobile generation/reload layouts and confirmed fixed bar dimensions at minimum, default, and maximum zoom.
