### PR TITLE
Move New map to the header, switch visibility toggles, split landing resume from new

### DIFF
--- a/components/game/game-hud.css
+++ b/components/game/game-hud.css
@@ -122,6 +122,12 @@
 .hud-world { position: absolute; top: calc(var(--hud-space) * 2 + var(--hud-bar-height)); right: var(--hud-space); width: var(--hud-dock-width); max-height: calc(100% - var(--hud-map-height) - var(--hud-bar-height) - var(--hud-space) * 4); padding: var(--hud-space); overflow-y: auto; overscroll-behavior: contain; pointer-events: auto; z-index: 20; }
 .hud-world-heading { display: flex; align-items: center; justify-content: space-between; padding: 0 0 var(--hud-space); font-family: var(--font-cinzel), serif; font-size: 14px; }
 .hud-world-heading button { cursor: pointer; }
+/* The shared switch in the HUD's dark parchment: gold when on, a rule-coloured rim when off. */
+.hud-switch { pointer-events: auto; border-color: #8c784c; background: #423725; box-shadow: none; }
+.hud-switch[data-state="checked"] { border-color: #f0d598; background: #d4b57a; }
+.hud-switch:focus-visible { border-color: #f0d598; box-shadow: 0 0 0 2px rgba(212, 181, 122, .4); }
+.hud-switch [data-slot="switch-thumb"] { background: #f2e8d5; box-shadow: 0 1px 2px #000; }
+.hud-switch[data-state="checked"] [data-slot="switch-thumb"] { background: #30210c; }
 .hud-inspector { min-height: 0; overflow-y: auto; overscroll-behavior: contain; border-bottom: 1px solid #8c784c; }
 .hud-inspector, .hud-world, .hud-menu, .hud-report, .hud-landing-setup {
   --parchment: #211e16;
@@ -216,7 +222,8 @@
   .hud-world-heading { min-height: 44px; }
   .hud-world-heading button, .hud-inspector button { min-width: 44px; min-height: 44px; }
   .hud-choice-track { min-height: 44px; }
-  .hud-world :is(button, select), .hud-report button { min-height: 44px; }
+  .hud-world :is(button, select):not(.hud-switch), .hud-report button { min-height: 44px; }
+  .hud-switch-row { min-height: 44px; }
   .hud-world :is(input, select), .hud-report :is(input, select, textarea) { font-size: 16px; }
   .hud-inspector summary { min-height: 44px; padding-block: 12px; }
 }
@@ -248,7 +255,9 @@
   padding: 20px;
   pointer-events: auto;
 }
-.hud-landing-setup > label { margin-bottom: -8px; }
+/* The saved world's Continue sits apart from the new-world inputs beneath it. */
+.hud-landing-divider { display: flex; align-items: center; gap: 10px; margin: 2px 0; font-family: var(--font-cinzel), serif; font-size: 11px; letter-spacing: .1em; text-transform: uppercase; color: #d4c297; }
+.hud-landing-divider::before, .hud-landing-divider::after { content: ""; flex: 1; height: 1px; background: #5c4e32; }
 .hud-landing-play { height: 42px; margin-top: 4px; font-size: 14px; }
 @media (max-width: 1024px) {
   .game-hud[data-landing="true"] .hud-header { display: flex; }

--- a/components/game/game-hud.tsx
+++ b/components/game/game-hud.tsx
@@ -9,9 +9,9 @@ import { ELEVATION_CONTROLS, type ElevationSettings } from "@/lib/game/map/eleva
 
 import Link from "next/link"
 import * as Tooltip from "@radix-ui/react-tooltip"
-import { Menu, RefreshCw, Settings, X } from "lucide-react"
+import { Menu, Settings, X } from "lucide-react"
 import "./game-hud.css"
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useId, useMemo, useState } from "react"
 import { useBuildStore } from "@/lib/game/build-store"
 import { useCameraStore } from "@/lib/game/camera-store"
 import {
@@ -24,7 +24,6 @@ import { clampRoadTier, ROAD_TIERS } from "@/lib/game/map/road"
 import { TERRAIN } from "@/lib/game/map/terrain"
 import { tileAt, type BuildingDef, type GameMap } from "@/lib/game/map/types"
 import { nerve } from "@/lib/game/route-choice"
-import { parseSeed, randomSeed } from "@/lib/game/rng"
 import { CHANGELOG, CURRENT_VERSION } from "@/lib/changelog"
 import { SITE_MENU } from "@/lib/site-menu"
 import { ACTIVITY_LABELS, BEGGAR_RECOVERY_GOLD, simRegistry, type SimTraveler } from "@/lib/game/sim"
@@ -50,7 +49,10 @@ import { MusicPlayer } from "./music-player"
 import { HudButton } from "./hud-button"
 import { BugReportDialog } from "./bug-report-dialog"
 import { MapSizeControl } from "./map-size-control"
-import { NewMapDialog } from "./new-map-dialog"
+import { NewMapDialog, type NewWorld } from "./new-map-dialog"
+import { NewWorldFields } from "./new-world-fields"
+import { SeedField } from "./seed-field"
+import { Switch } from "@/components/ui/switch"
 import { browserDiagnostics, diagnosticsSchema, type BugReportDiagnostics } from "@/lib/bug-report"
 import { useBugReportRuntime } from "@/hooks/use-bug-report-runtime"
 import { useSimulationStore } from "@/lib/game/simulation-store"
@@ -154,6 +156,27 @@ function Chooser({
   )
 }
 
+/** An on/off preference as the shared switch, recoloured for the HUD's dark parchment. */
+function ToggleRow({
+  label,
+  checked,
+  disabled = false,
+  onChange,
+}: {
+  label: string
+  checked: boolean
+  disabled?: boolean
+  onChange: (checked: boolean) => void
+}) {
+  const id = useId()
+  return (
+    <div className="hud-switch-row flex items-center justify-between gap-3 py-0.5">
+      <label htmlFor={id} className={`text-[13px] font-medium text-ink-light ${disabled ? "opacity-50" : ""}`}>{label}</label>
+      <Switch id={id} className="hud-switch" checked={checked} disabled={disabled} onCheckedChange={onChange} />
+    </div>
+  )
+}
+
 /** Top-level navigation, folded into the play view. Controls live in here too. */
 function MenuPanel({ onClose, playing }: { onClose: () => void; playing: boolean }) {
   const [showControls, setShowControls] = useState(false)
@@ -206,83 +229,6 @@ function MenuPanel({ onClose, playing }: { onClose: () => void; playing: boolean
           </dl>
         )}
       </nav>
-    </div>
-  )
-}
-
-/**
- * The seed as an editable field: paste a value or refresh for a random world.
- * The shell owns the seed; this only reports.
- */
-function SeedField({
-  seed,
-  onSeedChange,
-  onValidityChange,
-}: {
-  onValidityChange?: (valid: boolean) => void
-  seed: number | null
-  onSeedChange: (seed: number) => void
-}) {
-  const [input, setInput] = useState(seed === null ? "" : String(seed))
-  const [invalid, setInvalid] = useState(false)
-
-  // Follow the shell when the seed changes elsewhere (reroll, URL load).
-  useEffect(() => {
-    if (seed !== null) setInput(String(seed))
-  }, [seed])
-
-  const apply = () => {
-    const parsed = parseSeed(input)
-    if (parsed === null) {
-      setInvalid(true)
-      return
-    }
-    setInvalid(false)
-    onSeedChange(parsed)
-  }
-
-  const refresh = () => {
-    const rolled = randomSeed()
-    const next = rolled === seed ? (rolled + 1) % 2 ** 31 : rolled
-    setInput(String(next))
-    setInvalid(false)
-    onValidityChange?.(true)
-    onSeedChange(next)
-  }
-
-  return (
-    <div className="flex flex-col gap-1.5">
-      <div className="flex items-stretch gap-1.5">
-        <input
-        id={onValidityChange ? "landing-seed" : undefined}
-        value={input}
-        onChange={(event) => {
-          const value = event.target.value
-          setInput(value)
-          const parsed = parseSeed(value)
-          setInvalid(onValidityChange ? parsed === null : false)
-          if (onValidityChange) {
-            onValidityChange(parsed !== null)
-            if (parsed !== null) onSeedChange(parsed)
-          }
-        }}
-        onKeyDown={(event) => {
-          if (event.key === "Enter" && !onValidityChange) apply()
-        }}
-        inputMode="numeric"
-        spellCheck={false}
-        aria-label="World seed"
-        aria-invalid={invalid}
-        className={`pointer-events-auto min-w-0 flex-1 border bg-parchment px-2 py-1 text-[13px] text-ink outline-none ${
-          invalid ? "border-red" : "border-rule focus:border-gold"
-        }`}
-        />
-        <HudButton onClick={refresh} aria-label="Randomize world seed" title="Randomize world seed">
-          <RefreshCw size={14} aria-hidden="true" />
-        </HudButton>
-        {!onValidityChange && <HudButton onClick={apply}>Apply</HudButton>}
-      </div>
-      {invalid && <div className="text-[11px] italic text-red">Digits only</div>}
     </div>
   )
 }
@@ -680,9 +626,6 @@ export function GameHud({
   economy,
   pixelation,
   onPixelationChange,
-  defaultMapSize,
-  mapSizeSaved,
-  onDefaultMapSizeChange,
   onNewMap,
   onSeedChange,
   cheats,
@@ -707,10 +650,8 @@ export function GameHud({
   onSettingsChange: (settings: MapSettings) => void
   pixelation: Required<PixelationProps>
   onPixelationChange: (patch: PixelationProps) => void
-  defaultMapSize: number
-  mapSizeSaved: boolean
-  onDefaultMapSizeChange: (size: number) => void
-  onNewMap: (size: number) => void
+  /** Replace the current map with a fresh world of this size and seed. */
+  onNewMap: (world: NewWorld) => void
   onSeedChange: (seed: number) => void
 }) {
   const [seedValid, setSeedValid] = useState(true)
@@ -861,6 +802,7 @@ export function GameHud({
         </div>
         <div className="hud-header-right">
         <div className="hud-header-actions">
+          {playing && <NewMapDialog defaultSize={settings.size} onCreate={onNewMap} />}
           <MusicPlayer className="hud-header-button" compact />
           {playing && <button type="button" className="hud-header-button" aria-label="World settings" title="World settings"
             aria-expanded={panel === "world"} aria-controls="world-settings" onClick={() => {
@@ -897,10 +839,12 @@ export function GameHud({
         event.preventDefault()
         if (canStart && seedValid) onPlay()
       }}>
-        <MapSizeControl value={settings.size} onChange={size => set({ size })} />
-        <label className="text-[13px] text-ink-light" htmlFor="landing-seed">World seed</label>
-        <SeedField seed={seed} onSeedChange={onSeedChange} onValidityChange={setSeedValid} />
-        {continueHref && <Link href={continueHref} className="hud-action hud-action-primary hud-landing-play">Continue</Link>}
+        {continueHref && <>
+          <Link href={continueHref} className="hud-action hud-action-primary hud-landing-play">Continue</Link>
+          <div className="hud-landing-divider" role="separator">or</div>
+        </>}
+        <NewWorldFields seedId="landing-seed" size={settings.size} seed={seed}
+          onSizeChange={size => set({ size })} onSeedChange={onSeedChange} onSeedValidityChange={setSeedValid} />
         <button type="submit" className={`hud-action hud-landing-play${continueHref ? "" : " hud-action-primary"}`} disabled={!canStart || !seedValid}>
           {continueHref ? "New world" : "Play"}
         </button>
@@ -915,24 +859,18 @@ export function GameHud({
       {playing && panel === "world" && <aside id="world-settings" className="hud-world hud-well" aria-label="World settings">
         <div className="hud-world-heading"><span>World</span><button type="button" aria-label="Close world settings" onClick={() => setPanel(null)}><X size={16} /></button></div>
         <div className="mb-4 flex flex-wrap gap-2">
-          <NewMapDialog defaultSize={defaultMapSize} onCreate={onNewMap} />
           <HudButton id="bug-report-button" onClick={openBugReport}>Report a bug</HudButton>
         </div>
         {reportError && <p role="alert" className="mb-4 text-sm text-red">{reportError}</p>}
-        <div className="mb-4 space-y-1">
-          <MapSizeControl label="Default size" value={defaultMapSize} onChange={onDefaultMapSizeChange} />
-          <p className="text-[11px] italic text-ink-light">Used for new maps and visits without a map size in the link. Your current map stays the same.</p>
-          {!mapSizeSaved && <p role="status" className="text-[11px] text-red">Could not save this preference. It will apply for this session only.</p>}
-        </div>
         <Section {...section("Visibility")}>
           {VISIBILITY_TOGGLES.map(([key, label]) => (
-            <Chooser key={key} label={label} labelClassName="w-24" value={settings[key] ? 1 : 0}
-              options={["Hidden", "Shown"]} onChange={(index) => set({ [key]: index === 1 })} />
+            <ToggleRow key={key} label={label} checked={settings[key]} onChange={(shown) => set({ [key]: shown })} />
           ))}
-          <Chooser label="Buildings" labelClassName="w-24" value={["auto", "interiors", "hidden"].indexOf(settings.buildingVisibility)}
-            options={["Automatic interiors", "Show all interiors", "Hidden"]}
-            onChange={(index) => set({ buildingVisibility: (["auto", "interiors", "hidden"] as const)[index] })} />
-          <p className="py-1 text-[11px] italic text-ink-light">Automatic interiors open when you select a building or someone inside. Scenery includes rocks, plants and the signpost. Hidden objects keep working.</p>
+          <ToggleRow label="Buildings" checked={settings.buildingVisibility !== "hidden"}
+            onChange={(shown) => set({ buildingVisibility: shown ? "auto" : "hidden" })} />
+          <ToggleRow label="All interiors" checked={settings.buildingVisibility === "interiors"} disabled={settings.buildingVisibility === "hidden"}
+            onChange={(all) => set({ buildingVisibility: all ? "interiors" : "auto" })} />
+          <p className="py-1 text-[11px] italic text-ink-light">Interiors open on their own when you select a building or someone inside; All interiors keeps every roof off. Scenery includes rocks, plants and the signpost. Hidden objects keep working.</p>
           <HudButton onClick={() => set(DEFAULT_SCENE_VISIBILITY)}>Reset visibility</HudButton>
         </Section>
         {SHOW_PROPERTY_PANELS && <>

--- a/components/game/game-shell.tsx
+++ b/components/game/game-shell.tsx
@@ -35,7 +35,7 @@ import { tileToWorldX, tileToWorldZ } from "@/lib/game/map/types"
 import { generateRelic, visitChance } from "@/lib/game/relic"
 import { roadsideEvangelism } from "@/lib/game/monk-evangelism"
 import { generateTravelers, travelerCountForMap } from "@/lib/game/travelers"
-import { DEFAULT_MAP_WIDTH, generateMap } from "@/lib/game/map/generate-map"
+import { generateMap } from "@/lib/game/map/generate-map"
 
 import { useAutosave } from "@/hooks/use-autosave"
 import { useSettlement } from "@/hooks/use-settlement"
@@ -113,8 +113,6 @@ export function GameShell({
   const loadingOverlay = useRef<HTMLDivElement>(null)
   const [blasterPastor, setBlasterPastor] = useState(false)
   const [lastMarch, setLastMarch] = useState(false)
-  const [defaultMapSize, setDefaultMapSize] = useState(DEFAULT_MAP_WIDTH)
-  const [mapSizeSaved, setMapSizeSaved] = useState(true)
   const [settings, setSettings] = useState<MapSettings>({
     ...DEFAULT_SETTINGS,
     ...initialDisplay,
@@ -155,7 +153,6 @@ export function GameShell({
     // Resolve the browser's preferences and save before generating terrain or
     // writing the URL. A link that names a different world wins over the save.
     const size = loadDefaultMapSize()
-    setDefaultMapSize(size)
     const { save } = loadGameSave()
     // The landing page keeps the save only to offer "Continue"; its own seed is a fresh roll.
     const resuming = playing && save && !benchmarkCity && saveResumesQuery(save, initialSeed, initialWorld) ? save : null
@@ -398,7 +395,12 @@ export function GameShell({
         playing={revealPhase === "complete"}
         starting={starting}
         canStart={seed !== null && booted}
-        onPlay={() => { if (seed !== null) router.push(`/play?${playQuery(seed, settings)}`) }}
+        onPlay={() => {
+          if (seed === null) return
+          // The last size chosen becomes the default for links that name none.
+          saveDefaultMapSize(settings.size)
+          router.push(`/play?${playQuery(seed, settings)}`)
+        }}
         continueHref={!playing && booted && restore ? "/play" : null}
         cheats={{ blasterPastor, lastMarch }}
         map={map}
@@ -412,15 +414,10 @@ export function GameShell({
         onSettingsChange={setSettings}
         pixelation={pixelationSettings}
         onPixelationChange={(patch) => setPixelationOverrides((current) => ({ ...current, ...patch }))}
-        defaultMapSize={defaultMapSize}
-        mapSizeSaved={mapSizeSaved}
-        onDefaultMapSizeChange={size => {
-          setDefaultMapSize(size)
-          setMapSizeSaved(saveDefaultMapSize(size))
-        }}
-        onNewMap={size => {
+        onNewMap={({ size, seed }) => {
+          saveDefaultMapSize(size)
           setSettings(current => ({ ...current, size }))
-          setSeed(randomSeed())
+          setSeed(seed)
         }}
         onSeedChange={setSeed}
       />

--- a/components/game/new-map-dialog.tsx
+++ b/components/game/new-map-dialog.tsx
@@ -1,23 +1,40 @@
 "use client"
 
+import { MapPlus } from "lucide-react"
 import { useState } from "react"
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog"
+import { randomSeed } from "@/lib/game/rng"
 import { HudButton } from "./hud-button"
-import { MapSizeControl } from "./map-size-control"
+import { NewWorldFields } from "./new-world-fields"
 
-/** Draft dimensions stay local until the player confirms a fresh world. */
+/** What names a fresh world; the shell regenerates once these are confirmed. */
+export interface NewWorld {
+  size: number
+  seed: number
+}
+
+/**
+ * A header button that opens the same size-and-seed form as the landing page.
+ * The draft stays local until the player confirms a fresh world.
+ */
 export function NewMapDialog({ defaultSize, onCreate }: {
+  /** The size the dialog opens on: the current map's, so a reroll keeps its scale. */
   defaultSize: number
-  onCreate: (size: number) => void
+  onCreate: (world: NewWorld) => void
 }) {
   const [open, setOpen] = useState(false)
   const [size, setSize] = useState(defaultSize)
+  const [seed, setSeed] = useState<number | null>(null)
+  const [seedValid, setSeedValid] = useState(true)
 
   return <Dialog open={open} onOpenChange={setOpen}>
-    <HudButton id="new-map-button" aria-haspopup="dialog" onClick={() => {
-      setSize(defaultSize)
-      setOpen(true)
-    }}>✦ New Map</HudButton>
+    <button type="button" id="new-map-button" className="hud-header-button" aria-label="New map" title="New map"
+      aria-haspopup="dialog" aria-expanded={open} onClick={() => {
+        setSize(defaultSize)
+        setSeed(randomSeed())
+        setSeedValid(true)
+        setOpen(true)
+      }}><MapPlus size={16} /></button>
     <DialogContent className="hud-report max-h-[85dvh] overflow-y-auto rounded-none border-rule bg-parchment text-ink sm:max-w-md"
       onKeyDown={event => event.stopPropagation()}
       onCloseAutoFocus={event => {
@@ -26,18 +43,20 @@ export function NewMapDialog({ defaultSize, onCreate }: {
       }}>
       <DialogTitle className="font-display text-lg">New map</DialogTitle>
       <DialogDescription className="text-sm text-ink-light">
-        Choose the size of your new land. Creating a map replaces the current map and starts a fresh settlement.
+        Choose the size and seed of your new land. Creating a map replaces the current map and starts a fresh settlement.
       </DialogDescription>
       <form className="grid gap-4" onSubmit={event => {
         event.preventDefault()
+        if (seed === null || !seedValid) return
         setOpen(false)
-        onCreate(size)
+        onCreate({ size, seed })
       }}>
-        <MapSizeControl value={size} onChange={setSize} />
+        <NewWorldFields seedId="new-map-seed" size={size} seed={seed}
+          onSizeChange={setSize} onSeedChange={setSeed} onSeedValidityChange={setSeedValid} />
         <p className="text-xs text-ink-light">Dimensions are in tiles. Larger maps take longer to generate.</p>
         <div className="flex justify-end gap-3">
           <HudButton onClick={() => setOpen(false)}>Cancel</HudButton>
-          <HudButton type="submit">Create map</HudButton>
+          <HudButton type="submit" disabled={seed === null || !seedValid}>Create map</HudButton>
         </div>
       </form>
     </DialogContent>

--- a/components/game/new-world-fields.tsx
+++ b/components/game/new-world-fields.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import { MapSizeControl } from "./map-size-control"
+import { SeedField } from "./seed-field"
+
+/**
+ * The inputs that name a fresh world: its size and seed. The landing page and
+ * the in-game New map dialog share these so creating a world looks the same
+ * everywhere. The owner keeps the draft; valid edits are reported live.
+ */
+export function NewWorldFields({
+  seedId,
+  size,
+  seed,
+  onSizeChange,
+  onSeedChange,
+  onSeedValidityChange,
+}: {
+  /** Names the seed input for its label; unique per mounted form. */
+  seedId: string
+  size: number
+  seed: number | null
+  onSizeChange: (size: number) => void
+  onSeedChange: (seed: number) => void
+  onSeedValidityChange: (valid: boolean) => void
+}) {
+  return <>
+    <MapSizeControl value={size} onChange={onSizeChange} />
+    <div className="grid gap-1">
+      <label className="text-[13px] text-ink-light" htmlFor={seedId}>World seed</label>
+      <SeedField id={seedId} seed={seed} onSeedChange={onSeedChange} onValidityChange={onSeedValidityChange} />
+    </div>
+  </>
+}

--- a/components/game/seed-field.tsx
+++ b/components/game/seed-field.tsx
@@ -1,0 +1,87 @@
+"use client"
+
+import { RefreshCw } from "lucide-react"
+import { useEffect, useState } from "react"
+import { parseSeed, randomSeed } from "@/lib/game/rng"
+import { HudButton } from "./hud-button"
+
+/**
+ * The seed as an editable field: paste a value or refresh for a random world.
+ * The owner keeps the seed; this only reports. With `onValidityChange` every
+ * valid keystroke is reported live; without it an Apply button commits.
+ */
+export function SeedField({
+  id,
+  seed,
+  onSeedChange,
+  onValidityChange,
+}: {
+  /** Names the input for a label; only set when reporting live. */
+  id?: string
+  onValidityChange?: (valid: boolean) => void
+  seed: number | null
+  onSeedChange: (seed: number) => void
+}) {
+  const [input, setInput] = useState(seed === null ? "" : String(seed))
+  const [invalid, setInvalid] = useState(false)
+
+  // Follow the owner when the seed changes elsewhere (reroll, URL load).
+  useEffect(() => {
+    if (seed !== null) setInput(String(seed))
+  }, [seed])
+
+  const apply = () => {
+    const parsed = parseSeed(input)
+    if (parsed === null) {
+      setInvalid(true)
+      return
+    }
+    setInvalid(false)
+    onSeedChange(parsed)
+  }
+
+  const refresh = () => {
+    const rolled = randomSeed()
+    const next = rolled === seed ? (rolled + 1) % 2 ** 31 : rolled
+    setInput(String(next))
+    setInvalid(false)
+    onValidityChange?.(true)
+    onSeedChange(next)
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-stretch gap-1.5">
+        <input
+        id={onValidityChange ? id : undefined}
+        value={input}
+        onChange={(event) => {
+          const value = event.target.value
+          setInput(value)
+          const parsed = parseSeed(value)
+          setInvalid(onValidityChange ? parsed === null : false)
+          if (onValidityChange) {
+            onValidityChange(parsed !== null)
+            if (parsed !== null) onSeedChange(parsed)
+          }
+        }}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" && !onValidityChange) apply()
+        }}
+        inputMode="numeric"
+        spellCheck={false}
+        aria-label="World seed"
+        aria-invalid={invalid}
+        className={`pointer-events-auto min-w-0 flex-1 border bg-parchment px-2 py-1 text-[13px] text-ink outline-none ${
+          invalid ? "border-red" : "border-rule focus:border-gold"
+        }`}
+        />
+        <HudButton onClick={refresh} aria-label="Randomize world seed" title="Randomize world seed">
+          <RefreshCw size={14} aria-hidden="true" />
+        </HudButton>
+        {!onValidityChange && <HudButton onClick={apply}>Apply</HudButton>}
+      </div>
+      {invalid && <div className="text-[11px] italic text-red">Digits only</div>}
+    </div>
+  )
+}


### PR DESCRIPTION
The New map button moves out of the World panel into the header, directly left of the music button, and opens the same size-and-seed form the landing page uses (extracted into `SeedField` and `NewWorldFields`). The World panel loses its New map button and Default size slider; the last size played or created is saved as the default instead. Visibility options are now the shared switch component recoloured for the HUD, with the three-way buildings choice split into Buildings and All interiors switches. On the landing page, Continue is separated from the new-world inputs by an "or" divider so resuming and starting fresh read as distinct actions. Verified headlessly on desktop and phone viewports; typecheck and the storage and save tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)