### PR TITLE
Add a Stop button while a map generates

### DIFF
--- a/components/game/game-hud.css
+++ b/components/game/game-hud.css
@@ -1,6 +1,6 @@
 /* Contextual game chrome, adapted from Paper with left actions and a right details dock.
    @see https://app.paper.design/file/01M1QTYBYHXP4H1BXFQ79N18AP/2-0/1GB-0 */
-.game-hud, .game-hud-tooltip {
+.game-hud, .game-hud-tooltip, .loading-church {
   --hud-space: 12px;
   --hud-control-gap: 4px;
 }
@@ -11,15 +11,18 @@
   --hud-map-height: 182px;
   --hud-left: var(--hud-space);
   --hud-right: calc(var(--hud-space) * 2 + var(--hud-dock-width));
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  color: #f2e8d5;
+}
+/* One button palette for the HUD and the loading overlay's Stop control. */
+.game-hud, .loading-church {
   --hud-button-face: #30291c;
   --hud-button-edge: #726242;
   --hud-button-hover: #423725;
   --hud-button-selected: #594b31;
   --hud-button-highlight: #bea067;
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  color: #f2e8d5;
 }
 .game-hud button:focus-visible, .game-hud a:focus-visible {
   outline: 2px solid #f4d991;

--- a/components/game/game-shell.tsx
+++ b/components/game/game-shell.tsx
@@ -351,7 +351,8 @@ export function GameShell({
         phase={revealPhase} overlayRef={loadingOverlay} view={openingView} resuming={resuming}
         viewSize={resumeWorld ? resumeWorld.camera.viewSize : !booted && expectResume && resumeViewSize ? resumeViewSize : openingViewSize}
         groundOffset={resuming ? 0 : undefined}
-        focus={resuming && resumeWorld ? { camera: resumeWorld.camera, size: resumeWorld.world.size } : null} />
+        focus={resuming && resumeWorld ? { camera: resumeWorld.camera, size: resumeWorld.world.size } : null}
+        onStop={() => router.push("/")} />
       {map && relic ? (
         <GameCanvas
           {...pixelationSettings}

--- a/components/game/loading-church.css
+++ b/components/game/loading-church.css
@@ -1,6 +1,8 @@
 .loading-church {
   /* The loading UI keeps a fixed pixel size independently of the world zoom. */
   --loading-pixel: 1px;
+  /* The caption's line box, so the Stop button can mirror the indicators' extent. */
+  --loading-caption-line: 14px;
   /* Clear the clipped preview, including saved tree canopies, while keeping
      the caption on screen when a close zoom fills the viewport. */
   --loading-indicator-top: max(48px, min(20%, calc(50% + var(--ground-offset) + var(--resume-view-y, 0dvh) - var(--resume-view-height, 50dvh) / 2 - 16px)));
@@ -103,6 +105,7 @@
   color: #d4c297;
   font-family: var(--font-cinzel), serif;
   font-size: 11px;
+  line-height: var(--loading-caption-line);
   letter-spacing: .12em;
   white-space: nowrap;
 }
@@ -149,6 +152,19 @@
 }
 .loading-church-progress-fill { animation: loading-church-progress 1.2s steps(32) infinite alternate; }
 @keyframes loading-church-progress { to { transform: translateX(32px); } }
+/* Stop sits as far from the bottom edge as the caption's top sits from the top edge. */
+.loading-church-stop {
+  position: absolute;
+  z-index: 5;
+  left: 50%;
+  bottom: calc(var(--loading-indicator-top) - 10 * var(--loading-pixel) - var(--loading-caption-line));
+  transform: translateX(-50%);
+  pointer-events: auto;
+}
+.loading-church-stop:focus-visible {
+  outline: 2px solid #f4d991;
+  outline-offset: 3px;
+}
 @media (max-width: 640px) {
   .loading-church[data-idle="true"] { transform: translateY(-19dvh) scale(.78); transform-origin: 50% 50%; }
 }

--- a/components/game/loading-church.tsx
+++ b/components/game/loading-church.tsx
@@ -70,10 +70,12 @@ const GRID_LINES = LOADING_TILES.map(tile => `M${tile.points}Z`).join(" ")
  * resume script before hydration and by the shell once the save is read.
  */
 export function LoadingChurch({ showChurch, phase, overlayRef, idle = false, generating = false, resuming = false, view = 0, viewSize = DEFAULT_VIEW_SIZE,
-  groundOffset = GROUND_OFFSET, focus = null }: {
+  groundOffset = GROUND_OFFSET, focus = null, onStop }: {
   idle?: boolean; generating?: boolean
   /** A saved world is coming back: no church, no pulse, and its last view where the land will appear. */
   resuming?: boolean
+  /** Abandon the map being generated. Offers a Stop button beneath the indicators while a new world generates. */
+  onStop?: () => void
   showChurch: boolean; phase: MapRevealPhase; overlayRef: RefObject<HTMLDivElement | null>; view?: number; viewSize?: number
   /** Screen-down offset of the ground plane from centre, world units. Zero when the camera targets open ground. */
   groundOffset?: number
@@ -159,6 +161,7 @@ export function LoadingChurch({ showChurch, phase, overlayRef, idle = false, gen
         <rect x={1} y={1} width={46} height={4} fill="#5b4d2f" />
         <rect className="loading-church-progress-fill" x={2} y={2} width={12} height={2} fill="#dab767" />
       </svg>
+      {!resuming && onStop && <button type="button" className="hud-action loading-church-stop" onClick={onStop}>Stop</button>}
     </>}
   </div>
 }


### PR DESCRIPTION
Shows a **Stop** button beneath the church while a new world generates, placed as far from the bottom edge as the "generating map" caption sits from the top (the caption's line height is now explicit so the distance is exact). It reuses the HUD action style by sharing the HUD spacing and button palette variables with the loading overlay, and is hidden while a saved settlement restores. Clicking it returns to the landing page; generation itself is synchronous, so Stop abandons the world during the asset loading and reveal that follow, and since autosave only runs after the reveal any previously saved settlement stays available via Continue. Verified headlessly at 1440×900 and 390×844: caption top and button bottom offsets match, the click lands on `/`, and the typecheck passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)