### PR TITLE
Select a cart by clicking its draught animal

### DIFF
--- a/components/game/character-selection.tsx
+++ b/components/game/character-selection.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useLayoutEffect, useMemo, useRef } from "react"
 import { useFrame, useThree } from "@react-three/fiber"
 import * as THREE from "three"
-import { prioritizePeople, SELECTION_OUTLINE_COLOR, SELECTION_OUTLINE_OPACITY } from "@/lib/game/selection"
+import { CHARACTER_HIT_TARGET, prioritizePeople, SELECTION_OUTLINE_COLOR, SELECTION_OUTLINE_OPACITY } from "@/lib/game/selection"
 import { useCameraStore } from "@/lib/game/camera-store"
 import { BASE_CHARACTER_SCALE } from "@/lib/game/base-person/gait"
 import { walkingSurface } from "@/lib/game/map/walking-surface"
@@ -32,9 +32,10 @@ export function PersonPicking() {
   return null
 }
 
-/** A generous click volume shared by monks and travelers, without visible geometry. */
+/** A generous click volume shared by monks and travelers, without visible geometry.
+ * It yields to any figure's drawn texels behind it (see `prioritizePeople`). */
 export function CharacterHitTarget({ onClick }: { onClick: FigureClickHandler }) {
-  return <mesh name="character-hit-target" position={[0, 0.4, 0]} onClick={onClick}>
+  return <mesh name={CHARACTER_HIT_TARGET} position={[0, 0.4, 0]} onClick={onClick}>
     <boxGeometry args={[0.8, 1, 0.8]} />
     <meshBasicMaterial visible={false} />
   </mesh>
@@ -155,7 +156,7 @@ export function CharacterSelectionOutline({ flying = false }: { flying?: boolean
     // Sprites manage their own layer so selection also works after async loading.
     // The click volume and flat ID copies must never enlarge its silhouette.
     anchor.current?.parent?.traverse((object) => {
-      if ((object instanceof THREE.Mesh || object instanceof THREE.Sprite) && object.layers.isEnabled(0) && object.name !== "character-hit-target") include(object)
+      if ((object instanceof THREE.Mesh || object instanceof THREE.Sprite) && object.layers.isEnabled(0) && object.name !== CHARACTER_HIT_TARGET) include(object)
     })
     scene.traverse((object) => {
       if (object instanceof THREE.Light) include(object)

--- a/components/game/character-sprite.tsx
+++ b/components/game/character-sprite.tsx
@@ -33,6 +33,7 @@ import { strikeTree } from "@/lib/game/trees/impact"
 import { useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react"
 import { useLoader, type RootState } from "@react-three/fiber"
 import * as THREE from "three"
+import { prepareSpritePicking, spriteTexelRaycast } from "@/lib/game/render/sprite-picking"
 import { usePixelWorldTexel } from "@/components/pixel-canvas"
 import { characterVisual, spriteRow, type SpriteClip, type CharacterModel } from "@/lib/game/character-assets"
 import { usePopulationStore } from "@/lib/game/base-person/population-store"
@@ -117,6 +118,7 @@ export function CharacterSprite({ map: suppliedMap, type, onClick, outlineColor,
   const depthTextures = useMemo(() => new Map(depthEntries.map((entry, index) =>
     [entry.index, configureSpriteDepthTexture(sources[textureEntries.length + index])])), [sources, textureEntries])
   const poseDepth = useMemo<SpritePoseDepth>(() => ({ map: { value: null }, enabled: { value: false } }), [])
+  useEffect(() => prepareSpritePicking(sources.slice(0, textureEntries.length)), [sources, textureEntries])
   // Each traveler owns UV state only for clips they have actually played.
   // Eager views for every possible job/prayer/sleep animation left hundreds of
   // thousands of unused Texture objects in the heap at large populations.
@@ -408,7 +410,7 @@ export function CharacterSprite({ map: suppliedMap, type, onClick, outlineColor,
         walk: crowdWalk, pose: poseRoot, entry: batchEntry, control: characterBatchControl, publish: batchEntries.publish,
       } : undefined} />
       {(type === "minstrel" || type === "beggar") && !visualOverride && <RoadsideSignals type={type} size={size} pixelSize={size / 64} />}
-      <sprite renderOrder={renderOrder} ref={sprite} layers-mask={selected ? 1 | (1 << SELECTED_CHARACTER_LAYER) : 1} name={name} material={material} onClick={onClick} scale={[size, size, 1]} center={center} userData={{ characterModel, calling: type, variant: varied ? appearance.variant : null, appearanceScale: varied ? appearance.scale : 1, bodyType: visual.design?.bodyType, design: visual.design, fps, sync: walkTuning?.sync !== false }} />
+      <sprite renderOrder={renderOrder} ref={sprite} layers-mask={selected ? 1 | (1 << SELECTED_CHARACTER_LAYER) : 1} name={name} material={material} onClick={onClick} raycast={spriteTexelRaycast} scale={[size, size, 1]} center={center} userData={{ characterModel, calling: type, variant: varied ? appearance.variant : null, appearanceScale: varied ? appearance.scale : 1, bodyType: visual.design?.bodyType, design: visual.design, fps, sync: walkTuning?.sync !== false }} />
       {attachment && <group ref={attachmentRoot} visible={false}>{attachment.content}</group>}
       {outlineMaterial && <sprite ref={idSprite} renderOrder={renderOrder} layers-mask={OUTLINE_ID_LAYER_MASK} material={outlineMaterial}
         scale={[size, size, 1]} center={center} />}

--- a/components/game/debug-handle.tsx
+++ b/components/game/debug-handle.tsx
@@ -44,7 +44,8 @@ import { BENCHMARK_SIMULATION_SPEEDS, useSimulationStore } from "@/lib/game/simu
  * Development only, unless a local benchmark build explicitly enables it.
  */
 export function DebugHandle({ map, trees, travelers, speed, movement, speedScales, beggarSpeedScales, characterScale }: { map: GameMap; trees?: readonly TreePlacement[]; travelers: Traveler[]; speed: number; movement: MovementTuning; speedScales?: ReadonlyMap<number, number>; beggarSpeedScales?: ReadonlyMap<number, number>; characterScale?: number }) {
-  const { gl, camera, scene, setDpr } = useThree()
+  const { gl, camera, scene, setDpr, raycaster } = useThree()
+  const getState = useThree(state => state.get)
 
   useEffect(() => {
     if (process.env.NODE_ENV === "production" && process.env.NEXT_PUBLIC_GAME_BENCHMARK !== "1") return
@@ -157,6 +158,22 @@ export function DebugHandle({ map, trees, travelers, speed, movement, speedScale
       },
       playback: () => useSimulationStore.getState(),
       selectObject: (selection: Selection | null) => useCameraStore.getState().select(selection),
+      /** Fiber's pointer picking under a client point: interactive-object hits before and after the shared filter. */
+      pickAt: (clientX: number, clientY: number) => {
+        const state = getState(), rect = gl.domElement.getBoundingClientRect()
+        raycaster.setFromCamera(new THREE.Vector2((clientX - rect.left) / rect.width * 2 - 1, 1 - (clientY - rect.top) / rect.height * 2), camera)
+        const describe = (hit: THREE.Intersection) => {
+          let travelerId: unknown, visible = true
+          for (let node: THREE.Object3D | null = hit.object; node; node = node.parent) {
+            travelerId ??= node.userData.travelerId
+            visible &&= node.visible
+          }
+          return { name: hit.object.name, type: hit.object.type, distance: +hit.distance.toFixed(3), travelerId, visible, uv: hit.uv?.toArray().map(v => +v.toFixed(3)) }
+        }
+        const raw = raycaster.intersectObjects(state.internal.interaction, true)
+        const filtered = state.events.filter ? state.events.filter(raw, state) : raw
+        return { raw: raw.slice(0, 12).map(describe), filtered: filtered.slice(0, 8).map(describe) }
+      },
       selectTraveler: (id: number) => useCameraStore.getState().select({ kind: "traveler", id }),
       selectionVisuals: () => {
         let shadows = 0, sprites = 0, reducedWalking = 0

--- a/components/game/transport-sprite.tsx
+++ b/components/game/transport-sprite.tsx
@@ -9,6 +9,7 @@ import { markPerson } from "@/lib/game/selection"
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
 import { useFrame, useLoader } from "@react-three/fiber"
 import * as THREE from "three"
+import { prepareSpritePicking, spriteTexelRaycast } from "@/lib/game/render/sprite-picking"
 import type { GameMap } from "@/lib/game/map/types"
 import { walkingSurface } from "@/lib/game/map/walking-surface"
 import { usePixelWorldTexel } from "@/components/pixel-canvas"
@@ -82,6 +83,7 @@ export function TransportSprite({ passengerCart, seat = 0, calling = "peasant", 
   }), [map, maps, kind, passengerCart, driverFrame, driverVisible, viewport, worldTexel, groundPlane, poseDepth, depths, outlineColor?.[0], outlineColor?.[1], outlineColor?.[2]])
   useEffect(() => () => { materials.forEach(m => m.dispose()) }, [materials])
   useEffect(() => () => maps.forEach(map => map.dispose()), [maps])
+  useEffect(() => prepareSpritePicking(maps), [maps])
   const body = useRef<THREE.Sprite>(null), ids = useRef<THREE.Sprite>(null)
   const batchEntries = useCharacterBatches()
   useLayoutEffect(() => {
@@ -186,9 +188,9 @@ export function TransportSprite({ passengerCart, seat = 0, calling = "peasant", 
   const size = manifest.scale * characterScale
   const center = useMemo(() => new THREE.Vector2(manifest.anchor[0] / manifest.cellSize, 1 - manifest.anchor[1] / manifest.cellSize), [])
   return <group ref={group => { root.current = group; markPerson(group) }} position={position}>
-    {/* Batching hides this source sprite only for drawing. Keep its full click
-        area active, including for passenger carts without a walker hit target. */}
-    <sprite ref={body} name={kind} renderOrder={renderOrder} material={materials[0]} center={center} scale={[size, size, 1]} onClick={onClick}
+    {/* Batching hides this source sprite only for drawing. Its drawn texels stay
+        clickable, including for passenger carts without a walker hit target. */}
+    <sprite ref={body} name={kind} renderOrder={renderOrder} material={materials[0]} center={center} scale={[size, size, 1]} onClick={onClick} raycast={spriteTexelRaycast}
       userData-batchedPickTarget={true}
       layers-mask={selected ? 1 | (1 << SELECTED_CHARACTER_LAYER) : 1} />
     {outlineColor && <sprite ref={ids} renderOrder={renderOrder} material={materials[1]} center={center} scale={[size, size, 1]} layers-mask={OUTLINE_ID_LAYER_MASK} />}

--- a/lib/game/render/sprite-picking.test.ts
+++ b/lib/game/render/sprite-picking.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest"
+import * as THREE from "three"
+import { registerCharacterBatchEntry } from "./character-batch"
+import { spriteTexelOpaque, spriteTexelRaycast } from "./sprite-picking"
+
+/** A 4 × 2 atlas of two 2 × 2 frames: frame 0 is opaque only at its top-left
+ * texel, frame 1 only at its bottom-right one. Row 0 is the top of the image. */
+function atlas(): THREE.Texture {
+  const data = new Uint8ClampedArray(4 * 2 * 4)
+  data[(0 * 4 + 0) * 4 + 3] = 255
+  data[(1 * 4 + 3) * 4 + 3] = 255
+  data[(1 * 4 + 1) * 4 + 3] = 100
+  const texture = new THREE.Texture({ width: 4, height: 2, data } as unknown as HTMLImageElement)
+  texture.repeat.set(.5, 1)
+  return texture
+}
+
+function figure(map: THREE.Texture): THREE.Sprite {
+  const sprite = new THREE.Sprite(new THREE.SpriteMaterial({ map, alphaTest: .5 }))
+  sprite.scale.set(2, 2, 1)
+  sprite.updateMatrixWorld(true)
+  return sprite
+}
+
+describe("figure sprite picking", () => {
+  it("reads the current atlas frame through the texture's repeat and offset", () => {
+    const map = atlas(), sprite = figure(map)
+    expect(spriteTexelOpaque(sprite, { x: .25, y: .75 })).toBe(true)
+    expect(spriteTexelOpaque(sprite, { x: .75, y: .25 })).toBe(false)
+    map.offset.set(.5, 0)
+    expect(spriteTexelOpaque(sprite, { x: .25, y: .75 })).toBe(false)
+    expect(spriteTexelOpaque(sprite, { x: .75, y: .25 })).toBe(true)
+  })
+
+  it("honours the material's alpha test", () => {
+    const sprite = figure(atlas())
+    expect(spriteTexelOpaque(sprite, { x: .75, y: .25 })).toBe(false)
+    sprite.material.alphaTest = 0
+    expect(spriteTexelOpaque(sprite, { x: .75, y: .25 })).toBe(true)
+  })
+
+  it("uses a batched figure's published frame over its own texture view", () => {
+    const shared = atlas(), sprite = figure(atlas())
+    registerCharacterBatchEntry({ sprite, ids: new THREE.Sprite(), color: shared, uv: new THREE.Vector4(.5, 1, .5, 0),
+      ground: { value: new THREE.Vector4() }, depth: { map: { value: null }, enabled: { value: true } }, id: new THREE.Vector3() })
+    expect(spriteTexelOpaque(sprite, { x: .25, y: .75 })).toBe(false)
+    expect(spriteTexelOpaque(sprite, { x: .75, y: .25 })).toBe(true)
+  })
+
+  it("keeps sprites without a readable image fully clickable", () => {
+    const sprite = figure(new THREE.Texture())
+    expect(spriteTexelOpaque(sprite, { x: .9, y: .9 })).toBe(true)
+  })
+
+  it("drops quad hits on transparent texels during raycasting", () => {
+    const sprite = figure(atlas())
+    sprite.raycast = spriteTexelRaycast
+    const camera = new THREE.OrthographicCamera(-2, 2, 2, -2, .1, 20)
+    camera.position.z = 10
+    camera.updateMatrixWorld(true)
+    const raycaster = new THREE.Raycaster()
+    const hitsAt = (x: number, y: number) => { raycaster.setFromCamera(new THREE.Vector2(x, y), camera); return raycaster.intersectObject(sprite) }
+    // Quad uv (.25, .75) sits at world (-.5, .5): the opaque top-left texel.
+    expect(hitsAt(-.25, .25)).toHaveLength(1)
+    expect(hitsAt(.25, -.25)).toHaveLength(0)
+    expect(hitsAt(.75, .75)).toHaveLength(0)
+  })
+})

--- a/lib/game/render/sprite-picking.ts
+++ b/lib/game/render/sprite-picking.ts
@@ -1,0 +1,116 @@
+import * as THREE from "three"
+import { characterBatchEntry } from "./character-batch"
+
+/**
+ * Figure sprites are square billboards much larger than the person, animal or
+ * cart drawn on them. Three's sprite picking accepts the whole quad, so the
+ * transparent margin of a nearer figure swallowed clicks meant for a cart, its
+ * draught animal or a walker drawn behind it. Match the renderer instead: a
+ * hit only counts where the current atlas frame is opaque at the material's
+ * alpha test, the same approach tree foliage picking uses.
+ */
+
+interface OpaqueMask { threshold: number; width: number; height: number; bits: Uint8Array }
+interface MaskImage { width: number; height: number; data?: ArrayLike<number> }
+interface LiveCanvas extends MaskImage { getContext(kind: "2d"): CanvasRenderingContext2D | null }
+
+const masks = new WeakMap<object, OpaqueMask | null>()
+const readers = new WeakMap<object, CanvasRenderingContext2D | null>()
+const pending = new WeakSet<object>()
+
+function buildMask(width: number, height: number, data: ArrayLike<number>, threshold: number): OpaqueMask {
+  const bits = new Uint8Array(Math.ceil(width * height / 8))
+  for (let texel = 0, count = width * height; texel < count; texel++) {
+    if (data[texel * 4 + 3] >= threshold) bits[texel >> 3] |= 1 << (texel & 7)
+  }
+  return { threshold, width, height, bits }
+}
+
+function decodeImage(image: MaskImage, threshold: number): OpaqueMask | null {
+  const canvas = document.createElement("canvas")
+  canvas.width = image.width; canvas.height = image.height
+  const context = canvas.getContext("2d", { willReadFrequently: true })
+  if (!context) return null
+  try {
+    context.drawImage(image as unknown as CanvasImageSource, 0, 0)
+    return buildMask(image.width, image.height, context.getImageData(0, 0, image.width, image.height).data, threshold)
+  } catch { return null }
+}
+
+/** Reading a full cart atlas back takes long enough to drop frames, so image
+ * decodes wait for idle time; the pointer usually crosses a figure well before
+ * it clicks one. Until then the sprite stays fully clickable, as before. */
+function scheduleDecode(image: MaskImage, threshold: number) {
+  if (pending.has(image)) return
+  pending.add(image)
+  const run = () => { pending.delete(image); masks.set(image, decodeImage(image, threshold)) }
+  if (typeof requestIdleCallback === "function") requestIdleCallback(run, { timeout: 250 })
+  else setTimeout(run, 0)
+}
+
+/** One bit per texel per shared atlas image. Unreadable images stay fully clickable. */
+function opaqueMask(image: MaskImage, threshold: number): OpaqueMask | null {
+  const cached = masks.get(image)
+  if (cached !== undefined && (cached === null || cached.threshold === threshold)) return cached
+  if (image.data) {
+    const mask = buildMask(image.width, image.height, image.data, threshold)
+    masks.set(image, mask)
+    return mask
+  }
+  if (typeof document === "undefined") { masks.set(image, null); return null }
+  scheduleDecode(image, threshold)
+  return cached ?? null
+}
+
+/** Start decoding a figure's atlases as soon as they load, so masks are ready
+ * before its first click rather than after its first hover. */
+export function prepareSpritePicking(textures: Iterable<THREE.Texture>, alphaTest = .5): void {
+  if (typeof document === "undefined") return
+  for (const texture of textures) {
+    const image = texture.image as MaskImage | undefined
+    if (image && image.width > 0 && image.height > 0 && !image.data && !isLiveCanvas(image) && masks.get(image) === undefined) {
+      scheduleDecode(image, Math.max(1, Math.ceil(alphaTest * 255)))
+    }
+  }
+}
+
+const isLiveCanvas = (image: MaskImage): image is LiveCanvas => typeof (image as LiveCanvas).getContext === "function"
+
+/** Edited rig frames redraw a canvas every frame; read the texel as it is now. */
+function liveAlpha(canvas: LiveCanvas, x: number, y: number): number | null {
+  let context = readers.get(canvas)
+  if (context === undefined) { context = canvas.getContext("2d"); readers.set(canvas, context) }
+  if (!context) return null
+  return context.getImageData(x, y, 1, 1).data[3]
+}
+
+/** Whether the sprite draws an opaque texel at quad coordinates `uv` (0,0 bottom-left). */
+export function spriteTexelOpaque(sprite: THREE.Sprite, uv: { x: number; y: number }): boolean {
+  const material = sprite.material, entry = characterBatchEntry(sprite)
+  const texture = entry?.color ?? material.map
+  const image = texture?.image as MaskImage | undefined
+  if (!texture || !image || !(image.width > 0) || !(image.height > 0)) return true
+  // Batched figures publish their frame beside the shared atlas; every other
+  // sprite advances the frame through its own texture view's repeat and offset.
+  const frame = entry?.uv
+  const u = frame ? frame.z + uv.x * frame.x : texture.offset.x + uv.x * texture.repeat.x
+  const v = frame ? frame.w + uv.y * frame.y : texture.offset.y + uv.y * texture.repeat.y
+  const x = Math.min(image.width - 1, Math.max(0, Math.floor(u * image.width)))
+  const y = Math.min(image.height - 1, Math.max(0, Math.floor((texture.flipY ? 1 - v : v) * image.height)))
+  const threshold = Math.max(1, Math.ceil(material.alphaTest * 255))
+  if (isLiveCanvas(image)) {
+    const alpha = liveAlpha(image, x, y)
+    return alpha === null || alpha >= threshold
+  }
+  const mask = opaqueMask(image, threshold)
+  if (!mask) return true
+  const texel = y * mask.width + x
+  return (mask.bits[texel >> 3] & (1 << (texel & 7))) !== 0
+}
+
+/** Drop-in `raycast` for figure sprites: three's quad test, then the drawn-texel test. */
+export function spriteTexelRaycast(this: THREE.Sprite, raycaster: THREE.Raycaster, intersections: THREE.Intersection[]): void {
+  const quad: THREE.Intersection[] = []
+  THREE.Sprite.prototype.raycast.call(this, raycaster, quad)
+  for (const hit of quad) if (!hit.uv || spriteTexelOpaque(this, hit.uv)) intersections.push(hit)
+}

--- a/lib/game/selection.test.ts
+++ b/lib/game/selection.test.ts
@@ -170,4 +170,19 @@ describe("shared selection", () => {
     layer.visible = true
     expect(prioritizePeople(hits)).toEqual(hits)
   })
+
+  it("lets a figure's drawn texels beat another figure's click volume in front", () => {
+    const figure = (name: string) => { const root = { userData: {} }; markPerson(root); return { name, userData: {}, parent: root } }
+    const volumeA = { object: figure("character-hit-target"), distance: 1 }
+    const spriteB = { object: figure("traveler"), distance: 2 }
+    const wall = { object: { userData: {} }, distance: 1.5 }
+    const volumeC = { object: figure("character-hit-target"), distance: 3 }
+    const cart = { object: figure("cart"), distance: 4 }
+    expect(prioritizePeople([volumeA, spriteB])).toEqual([spriteB, volumeA])
+    expect(prioritizePeople([volumeA, spriteB, volumeC, cart])).toEqual([spriteB, cart, volumeA, volumeC])
+    // Surfaces between them still occlude, and volumes alone keep their order.
+    expect(prioritizePeople([volumeA, wall, spriteB])).toEqual([volumeA, wall, spriteB])
+    expect(prioritizePeople([volumeA, volumeC])).toEqual([volumeA, volumeC])
+    expect(prioritizePeople([spriteB, volumeC])).toEqual([spriteB, volumeC])
+  })
 })

--- a/lib/game/selection.ts
+++ b/lib/game/selection.ts
@@ -44,11 +44,15 @@ export function selectionObjectId(selection: Selection | null, objects: {
       : selection.kind === "monk" ? residentObjectId(index) : pileObjectId(index)
 }
 
+/** The invisible click volume every walking figure shares. */
+export const CHARACTER_HIT_TARGET = "character-hit-target"
+
 /** Marks a rendered subtree as a person, for `prioritizePeople`. */
 const PERSON_PICK = "person"
 const SCENERY_PICK = "selectionScenery"
 
 interface PickObject {
+  name?: string
   visible?: boolean
   userData?: Record<string, unknown>
   parent?: PickObject | null
@@ -89,5 +93,28 @@ export function prioritizePeople<T extends { object: PickObject }>(hits: readonl
     const passThrough = hasPickTag(hit.object, SCENERY_PICK) && !hasPickTag(hit.object, PERSON_PICK)
     ;(passThrough ? scenery : solid).push(hit)
   }
-  return scenery.length ? [...solid, ...scenery] : hits as T[]
+  return preferDrawnFigures(scenery.length ? [...solid, ...scenery] : hits as T[])
+}
+
+/**
+ * Figure sprites only report their drawn texels, so one figure's opaque pixel
+ * beats another figure's invisible click volume in front of it: a crowd's
+ * boxes never swallow the cart, animal or walker seen behind them. Only
+ * neighbouring person hits reorder; any surface between them keeps its place.
+ */
+function preferDrawnFigures<T extends { object: PickObject }>(hits: T[]): T[] {
+  let result: T[] | null = null
+  for (let start = 0; start < hits.length;) {
+    if (!hasPickTag(hits[start].object, PERSON_PICK)) { start++; continue }
+    let end = start + 1
+    while (end < hits.length && hasPickTag(hits[end].object, PERSON_PICK)) end++
+    const run = hits.slice(start, end)
+    const volumes = run.filter(hit => hit.object.name === CHARACTER_HIT_TARGET)
+    if (volumes.length && volumes.length < run.length) {
+      result ??= [...hits]
+      result.splice(start, run.length, ...run.filter(hit => hit.object.name !== CHARACTER_HIT_TARGET), ...volumes)
+    }
+    start = end
+  }
+  return result ?? hits
 }


### PR DESCRIPTION
Clicking a vendor's horse or donkey often selected an unrelated traveler: figure sprites are square billboards far larger than the figure, and three's sprite picking accepted the whole quad, so the transparent margin of a nearer horse or passenger cart swallowed the click. Character and transport sprites now pick only their drawn texels, using a one-bit mask per atlas decoded in idle time (edited rig frames are sampled live), the same approach foliage picking already uses. The shared selection filter also lets a figure's drawn texels beat another figure's invisible click volume in front of it, so a crowd's boxes no longer hide the animal behind them, while surfaces between them still occlude. The dev debug handle gains `pickAt(x, y)` to inspect fiber's raw and filtered hits under a screen point. Verified headlessly at dense traffic: every click on a vendor's donkey now selects that vendor, with unit tests covering frame lookup, batched frames, the alpha threshold and the reorder rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)