### PR TITLE
Park knights' horses and merchants' wagons in the field beside the shrine

### DIFF
--- a/assets/TRANSPORT.md
+++ b/assets/TRANSPORT.md
@@ -116,11 +116,20 @@ with a backrest. Knees stay below the hips and boots hang over the front; both
 hands hold reins that follow the animated bridle through turns. Driver and cart
 share one sprite anchor, scale and turning frame; there is no separate seated
 body depth plane. Rein sockets use that same displayed cart heading.
-Hand carts retain the shared walking/pulling rig. Shrine visitors first pull
-off onto a grass clearing near the road junction, leave the hitched convoy
-parked, and walk through a shrine gate alone. They return before rejoining
-the road. Arrival and departure check the complete convoy against terrain,
-buildings and elevation; unavailable parking means continuing along the road.
+Hand carts retain the shared walking/pulling rig. Shrine visitors plan their
+stop a few tiles before the fork, turn up the branch, ride the track to the
+enclave and pull off onto open grass in the field beside the shrine
+(`transport/enclave-parking.ts`), standing parallel to the track or nose-in
+where the field is a narrow pocket. They leave the hitched convoy or the
+knight's horse standing there and walk through a shrine gate alone. A tree
+within reach gets a tether, but none is required.
+Leaving is a forward loop back onto the track and down to the road just past
+the fork; a wagon never reverses. The turn into the field and back checks the
+complete convoy against terrain, buildings, trunks and other stops; the track
+itself is checked for buildings only, like the road. When the field is full
+or the fork is covered, riders fall back to the roadside verge stop at the
+fork (`shrineParking`), which still needs a tether tree; with no stop at all
+they continue along the road.
 `transport/route.ts` rounds cart turns independently of the painted paths and
 pedestrian lanes. The radius is 1.5 tiles where the verge permits it; tight
 spaces and bridge decks constrain the curve. Supported bridge elbows add a

--- a/lib/game/knights.test.ts
+++ b/lib/game/knights.test.ts
@@ -8,6 +8,7 @@ import { travelerAppearance } from "./base-person/population"
 import { TRAVELER_TYPES, type Traveler } from "./travelers"
 import { animalWalkSpeed } from "./transport/assets"
 import { tileAt, worldToTileX, worldToTileZ, tileToWorldX, tileToWorldZ } from "./map/types"
+import { ENCLAVE_FIELD_RADIUS } from "./transport/enclave-parking"
 import type { GameMap } from "./map/types"
 
 function fixture(direction: 1 | -1) {
@@ -19,7 +20,10 @@ function fixture(direction: 1 | -1) {
   const t: Traveler = { id: 0, type: TRAVELER_TYPES.knight, name: "Knight", pace: 1, direction, offset: (14 - direction * 0.03) / 29,
     attributes: { happiness: 80, gold: 100, piety: 100, hunger: 100, thirst: 100, stamina: 100, status: 100, jobless: false, skills: [], age: 30 } }
   const sim = createSim([t], map); sim.shrineRenown = 10000
-  sim.trees = [1, -1].map(side => ({ x: tileToWorldX(map, 14 + side * 2), y: 0.2, z: tileToWorldZ(map, 17), species: "oak" as const }))
+  // Tether trees on either side of the field beside the shrine, clear of the
+  // track, and a pair on the far verge of the road for stops at the fork.
+  sim.trees = [1, -1].flatMap(side => [{ x: tileToWorldX(map, 14 + side * 4), y: 0.2, z: tileToWorldZ(map, 8), species: "oak" as const },
+    { x: tileToWorldX(map, 14 + side * 2), y: 0.2, z: tileToWorldZ(map, 17), species: "oak" as const }])
   return { map, t, sim, s: sim.travelers.get(0)! }
 }
 
@@ -39,6 +43,9 @@ describe("mounted knight journeys", () => {
     expect(s.branchProgress).toBe(0)
     expect(s.horseRest?.tree).toBeDefined()
     expect(tileAt(map, worldToTileX(map, s.horseRest!.x), worldToTileZ(map, s.horseRest!.z))).toBe("grass")
+    // The horse waits in the field beside the shrine, not on the verge of the road.
+    expect(Math.hypot(s.horseRest!.x - tileToWorldX(map, 14), s.horseRest!.z - tileToWorldZ(map, 10))).toBeLessThanOrEqual(ENCLAVE_FIELD_RADIUS)
+    expect(Math.abs(s.horseRest!.z - tileToWorldZ(map, 14))).toBeGreaterThan(2)
     const horse = { ...s.horseRest! }
     expect(horse.x).toBeCloseTo(s.x); expect(horse.z).toBeCloseTo(s.z)
     let prayed = false, walkedOut = false
@@ -71,13 +78,13 @@ describe("mounted knight journeys", () => {
     expect(knightMounted(s.activity, s.horseRest)).toBe(false)
   })
 
-  it("continues on the road when there is no standing tree to tie to", () => {
+  it("leaves the horse standing loose in the field when no tree is within reach", () => {
     const { map, t, sim, s } = fixture(1)
     sim.trees = []
-    for (let i = 0; i < 200; i++) stepSim(sim, [t], map, DEFAULT_WALK_SPEED, 0.1)
-    expect(s.horseRest).toBeUndefined()
-    expect(s.shrineParking).toBeUndefined()
-    expect(s.visits).toBe(0)
+    for (let i = 0; i < 3000 && !s.horseRest; i++) stepSim(sim, [t], map, DEFAULT_WALK_SPEED, 0.1)
+    expect(s.horseRest).toBeDefined()
+    expect(s.horseRest?.tree).toBeUndefined()
+    expect(s.activity).toBe("toRelic")
   })
 
   it("uses the horse's stride on the road and the knight's own legs after dismounting", () => {

--- a/lib/game/sim.ts
+++ b/lib/game/sim.ts
@@ -39,6 +39,7 @@ import { RoadsideReservations } from "./roadside-reservations"
 import { SpatialPoints } from "./spatial-points"
 import { walkingSurface } from "./map/walking-surface"
 import { convoyPoint, convoyBounds, convoyBuildingsClear, stallParking, shrineParking, type ParkingContext, type ShrineParking } from "./transport/navigation"
+import { enclaveParking } from "./transport/enclave-parking"
 import { alignCart, followCart, type CartPose } from "./transport/follow"
 import { keeperRoutine } from "./transport/keeper"
 import { populationDesign, travelerAppearance } from "./base-person/population"
@@ -724,11 +725,12 @@ function shrineWorldPoint(map: GameMap, s: SimTraveler): WorldPoint {
   return point
 }
 
-/** Nearby live obstacles and reservations are shared by shrine and market parking. */
-function parkingContext(sim: SimState, s: SimTraveler, scale: number, traffic = false): ParkingContext {
-  const nearby = (p: { x: number; z: number }) => Math.hypot(p.x - s.x, p.z - s.z) < 16 + scale * 4
+/** Nearby live obstacles and reservations are shared by shrine and market parking.
+ * The stop can lie well away from the traveler, up the branch by the shrine. */
+function parkingContext(sim: SimState, s: SimTraveler, scale: number, traffic = false, centre: { x: number; z: number } = s): ParkingContext {
+  const nearby = (p: { x: number; z: number }) => Math.hypot(p.x - centre.x, p.z - centre.z) < 16 + scale * 4
   const trees: Array<{ tree: TreePlacement; index: number }> = []
-  treeSpatialIndex(sim.trees).forEachWithin(s.x, s.z, 16 + scale * 4, (tree, index) => {
+  treeSpatialIndex(sim.trees).forEachWithin(centre.x, centre.z, 16 + scale * 4, (tree, index) => {
     if (!sim.felled.has(index) && !tree.walking) trees.push({ tree, index })
   })
   const obstacles: StallRoute["obstacles"] = [], people: SimTraveler[] = []
@@ -1849,8 +1851,13 @@ function tryRoadVisit(sim: SimState, s: SimTraveler, t: Traveler, map: GameMap,
   let parking: ShrineParking | null = null
   if (visitRoute && needsParking) {
     const puller = isVendor ? cartLoadout(s.id).puller : "horse"
-    parking = shrineParking(map, parkingProgress, direction, isVendor ? -cartOffset(puller) * characterScale : 0, puller, characterScale,
-      [...sim.travelers.values()].flatMap(other => other.shrineParking ? [other.shrineParking.parked] : []), parkingContext(sim, s, characterScale))
+    const wheelbase = isVendor ? -cartOffset(puller) * characterScale : 0
+    const occupied = [...sim.travelers.values()].flatMap(other => other.shrineParking ? [other.shrineParking.parked] : [])
+    // Ride up to the shrine and leave the horse in the field beside it. Only
+    // when that field is full does a rider settle for the verge at the fork.
+    const door = { x: tileToWorldX(map, map.site!.door.x), z: tileToWorldZ(map, map.site!.door.z) }
+    parking = enclaveParking(map, parkingProgress, direction, wheelbase, puller, characterScale, occupied, parkingContext(sim, s, characterScale, false, door))
+      ?? shrineParking(map, parkingProgress, direction, wheelbase, puller, characterScale, occupied, parkingContext(sim, s, characterScale))
     const footRoute = parking ? settlementRoute(map, map.buildings,
       { x: worldToTileX(map, parking.parked.hitch.x), z: worldToTileZ(map, parking.parked.hitch.z) }, visitRoute.at(-1)!, false, true, visit!.seat) : null
     visitRoute = footRoute
@@ -2741,8 +2748,9 @@ export function stepSim(
           const crossingTile = Math.floor(s.progress) !== Math.floor(s.progress + direction * worldSpeed * haste * dt)
           const bypassesJunction = diversion !== null && direction * (site.junction - s.progress) >= 0
             && direction * (site.junction - diversion.end) < 0
-          // Convoys seek a parking verge in advance. Pedestrians whose detour
-          // bypasses the turning leave from this clear road tile and return here.
+          // Riders and convoys plan their stop in advance: the field by the shrine
+          // first, else a verge before the fork. Pedestrians whose detour bypasses
+          // the turning leave from this clear road tile and return here.
           if (distance <= worldSpeed * haste * dt || bypassesJunction || (needsParking && distance <= 12 && crossingTile)) {
             const leaveHere = needsParking || bypassesJunction
             const from = leaveHere ? { x: worldToTileX(map, s.x), z: worldToTileZ(map, s.z) } : undefined

--- a/lib/game/transport/enclave-parking.test.ts
+++ b/lib/game/transport/enclave-parking.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest"
+import { enclaveParking, ENCLAVE_FIELD_RADIUS } from "./enclave-parking"
+import { cartOffset } from "./assets"
+import { convoyClear, convoyPoint } from "./navigation"
+import { followCart } from "./follow"
+import { routeLength, routePoint } from "./roadside"
+import { tileToWorldX, tileToWorldZ, type GameMap } from "../map/types"
+
+/** The shrine sits in its own glade a real detour off the road. */
+function fixture(): GameMap {
+  const width = 30, depth = 24
+  const branch = [...Array.from({ length: 14 }, (_, i) => ({ x: 10, z: 4 + i })), { x: 11, z: 17 }]
+  const map: GameMap = { width, depth, tiles: Array.from({ length: width * depth }, () => "grass"),
+    road: Array.from({ length: width }, (_, x) => ({ x, z: 4 })),
+    buildings: [{ id: "shrine", label: "Shrine", x: 12, z: 16, w: 3, d: 3, height: 1, color: "#888", roofColor: "#888" }],
+    site: { hovelId: "shrine", junction: 10, branch, door: { x: 11, z: 17 } } }
+  for (const p of map.road!) map.tiles[p.z * width + p.x] = "path"
+  for (const p of branch.slice(1)) map.tiles[p.z * width + p.x] = "track"
+  return map
+}
+const door = (map: GameMap) => ({ x: tileToWorldX(map, map.site!.door.x), z: tileToWorldZ(map, map.site!.door.z) })
+
+describe("enclave parking", () => {
+  it.each([["knight", "horse", 0], ["wagon", "horse", -cartOffset("horse") * 1.5], ["donkey cart", "donkey", -cartOffset("donkey") * 1.5], ["handcart", "hand", -cartOffset("hand") * 1.5]] as const)(
+    "leaves the %s standing on grass beside the shrine, whichever way it was travelling", (_, puller, wheelbase) => {
+    for (const direction of [1, -1] as const) {
+      const map = fixture(), progress = 10 - direction * 0.5
+      const plan = enclaveParking(map, progress, direction, wheelbase, puller, 1.5, [], { trees: [] })
+      expect(plan).not.toBeNull()
+      const { parked, entry, exit, returnProgress } = plan!
+      expect(Math.hypot(parked.hitch.x - door(map).x, parked.hitch.z - door(map).z)).toBeLessThanOrEqual(ENCLAVE_FIELD_RADIUS)
+      expect(Math.abs(parked.hitch.z - tileToWorldZ(map, 4))).toBeGreaterThan(8)
+      expect(convoyClear(map, parked, puller, 1.5, true)).toBe(true)
+      // The ride starts on the road lane, climbs the track and ends at the stand.
+      const near = (a: { x: number; z: number }, b: { x: number; z: number }) => { expect(a.x).toBeCloseTo(b.x); expect(a.z).toBeCloseTo(b.z) }
+      near(entry[0], convoyPoint(map, progress, 1.5, direction))
+      near(entry.at(-1)!, parked.hitch)
+      expect(entry.some(p => Math.abs(p.x - tileToWorldX(map, 10)) < 1e-6 && Math.abs(p.z - tileToWorldZ(map, 12)) < 1e-6)).toBe(true)
+      // Leaving rejoins the road just past the fork, still travelling the same way.
+      near(exit[0], parked.hitch)
+      near(exit.at(-1)!, convoyPoint(map, returnProgress, 1.5, direction))
+      expect((returnProgress - 10) * direction).toBeGreaterThan(0)
+      // The wagon only ever rolls forward: its heading turns about smoothly, never flipping in one step.
+      let pose = parked, previous = parked.heading
+      const length = routeLength(exit)
+      for (let d = 0.04; d <= length; d += 0.04) {
+        pose = followCart(pose, routePoint(exit, d), wheelbase)
+        const turn = Math.abs(Math.atan2(Math.sin(pose.heading - previous), Math.cos(pose.heading - previous)))
+        expect(turn).toBeLessThan(0.5)
+        previous = pose.heading
+      }
+    }
+  })
+  it("shares the field: a second wagon stands clear of the first", () => {
+    const map = fixture(), wheelbase = -cartOffset("horse") * 1.5
+    const first = enclaveParking(map, 9.5, 1, wheelbase, "horse", 1.5, [], { trees: [] })!
+    const second = enclaveParking(map, 9.5, 1, wheelbase, "horse", 1.5, [first.parked], { trees: [] })
+    expect(second).not.toBeNull()
+    expect(Math.hypot(second!.parked.hitch.x - first.parked.hitch.x, second!.parked.hitch.z - first.parked.hitch.z)).toBeGreaterThan(1)
+  })
+  it("declines a fork covered by a building, leaving the roadside verge as the fallback", () => {
+    const map = fixture()
+    map.buildings.push({ id: "cross", label: "Cross", x: 10, z: 4, w: 1, d: 1, height: 1, color: "", roofColor: "" })
+    expect(enclaveParking(map, 9.5, 1, -cartOffset("horse") * 1.5, "horse", 1.5, [], { trees: [] })).toBeNull()
+  })
+  it("declines when there is no grass to stand on around the shrine", () => {
+    const map = fixture()
+    map.tiles = map.tiles.map(t => t === "grass" ? "water" : t)
+    expect(enclaveParking(map, 9.5, 1, 0, "horse", 1.5, [], { trees: [] })).toBeNull()
+  })
+  it("ties the horse to a tree within reach of the stand, but does not need one", () => {
+    const map = fixture()
+    const loose = enclaveParking(map, 9.5, 1, 0, "horse", 1.5, [], { trees: [] })!
+    expect(loose.tree).toBeUndefined()
+    const tree = { x: loose.parked.hitch.x + 1.5, y: 0.2, z: loose.parked.hitch.z, species: "oak" as const }
+    const tied = enclaveParking(map, 9.5, 1, 0, "horse", 1.5, [], { trees: [tree] })!
+    expect(tied).not.toBeNull()
+    if (tied.tree) expect(Math.hypot(tied.tree.x - tied.parked.hitch.x, tied.tree.z - tied.parked.hitch.z)).toBeLessThanOrEqual(2.5)
+  })
+})

--- a/lib/game/transport/enclave-parking.ts
+++ b/lib/game/transport/enclave-parking.ts
@@ -1,0 +1,125 @@
+import { tileAt, tileToWorldX, tileToWorldZ, worldToTileX, worldToTileZ, type GameMap } from "../map/types"
+import { buildingAt } from "../settlement"
+import type { Puller } from "./assets"
+import { alignCart, cartOnRoute, followCart, type CartPose } from "./follow"
+import { convoyBuildingsClear, convoyPoint, convoyBounds, parkingClear, parkingTree, type ParkingContext, type ShrineParking } from "./navigation"
+import { roundRoute, routeLength, routePoint, type Point } from "./roadside"
+
+/** How far from the shrine door, in tiles, a horse may be left standing. */
+export const ENCLAVE_FIELD_RADIUS = 10
+/** Keep the doorway, the gate walk and the shrine's own walls open. */
+const DOOR_CLEARANCE = 2.5, WALL_CLEARANCE = 1.5
+
+/** Sample the whole rigid convoy along a route, stopping at the first sample
+ * that fails the check. Returns the final pose, or null when blocked. */
+function sampleRoute(pose: CartPose, route: readonly Point[], wheelbase: number, clear: (pose: CartPose) => boolean,
+  visit?: (pose: CartPose) => void) {
+  const length = routeLength(route)
+  for (let d = 0.04; d < length + 0.04; d += 0.04) {
+    pose = followCart(pose, routePoint(route, Math.min(d, length)), wheelbase)
+    if (!clear(pose)) return null
+    visit?.(pose)
+  }
+  return pose
+}
+
+/** Ride up the branch from the junction and leave the horse or wagon standing
+ * in the field beside the shrine, then drive back down to rejoin the road
+ * just past the fork. The pull-off matches the roadside verge stop; leaving
+ * is a forward loop back onto the track, so a wagon never reverses. The track
+ * is as public as the road, so it is checked for structures only, as playback
+ * does; the turn into the field and back must also clear trunks, people and
+ * reserved stops. A covered fork fails every candidate, sending the rider
+ * back to the roadside verge instead. */
+export function enclaveParking(map: GameMap, progress: number, direction: 1 | -1, wheelbase: number, puller: Puller, scale: number,
+  occupied: readonly CartPose[] = [], context: ParkingContext = { trees: [] }): ShrineParking | null {
+  const site = map.site, road = map.road, shrine = map.buildings.find(b => b.id === site?.hovelId)
+  if (!site || !road || !shrine || site.branch.length < 3) return null
+  const returnProgress = site.junction + direction * 1.5
+  if (returnProgress < 0 || returnProgress > road.length - 1) return null
+  const reserved = { ...context, obstacles: [...(context.obstacles ?? []), ...occupied.flatMap(pose => convoyBounds(pose, "horse", scale))] }
+  const track = site.branch.map(p => ({ x: tileToWorldX(map, p.x), z: tileToWorldZ(map, p.z) })), door = track.at(-1)!
+  const initial = cartOnRoute(progress, direction, wheelbase, p => convoyPoint(map, p, scale, direction))
+  const structures = (pose: CartPose) => convoyBuildingsClear(map, pose, puller, scale)
+  // Woods and trunks crowd the track's edges; they only matter once the
+  // convoy has actually left the track for the grass.
+  const field = (pose: CartPose) => ["track", "path", "bridge", "ford"].includes(tileAt(map, worldToTileX(map, pose.hitch.x), worldToTileZ(map, pose.hitch.z)) ?? "")
+    ? structures(pose) : parkingClear(map, pose, puller, scale, reserved)
+  // Along the road to the fork, then up the track tile by tile.
+  const approach: Point[] = []
+  const steps = Math.max(1, Math.ceil(Math.abs(site.junction - progress) / 0.5))
+  for (let i = 0; i < steps; i++) approach.push(convoyPoint(map, progress + (site.junction - progress) * i / steps, scale, direction))
+  const roadExit = [convoyPoint(map, site.junction + direction, scale, direction), convoyPoint(map, returnProgress, scale, direction)]
+  // Turn-offs lie on the last stretch of the track, up to the door tile itself
+  // for a glade whose open ground lies beyond the gate walk. Ride that stretch
+  // once, keeping the convoy's pose as it reaches each tile; a track that
+  // clips a wall further on still serves the tiles before it.
+  const last = track.length - 1
+  let first = last
+  while (first > 1 && Math.hypot(track[first - 1].x - door.x, track[first - 1].z - door.z) <= ENCLAVE_FIELD_RADIUS + 3) first--
+  const reached = new Map<number, { pose: CartPose; gap: number }>()
+  sampleRoute(initial, roundRoute([...approach, ...track.slice(0, last + 1)], 0.45), wheelbase, structures, pose => {
+    for (let k = first; k <= last; k++) {
+      const gap = Math.hypot(pose.hitch.x - track[k].x, pose.hitch.z - track[k].z)
+      if (gap < (reached.get(k)?.gap ?? 0.5)) reached.set(k, { pose, gap })
+    }
+  })
+  const standAllowed = (p: Point) => {
+    const x = worldToTileX(map, p.x), z = worldToTileZ(map, p.z), terrain = tileAt(map, x, z)
+    if ((terrain !== "grass" && terrain !== "clearing") || buildingAt(map, x, z)) return false
+    const fromDoor = Math.hypot(p.x - door.x, p.z - door.z)
+    if (fromDoor < DOOR_CLEARANCE || fromDoor > ENCLAVE_FIELD_RADIUS) return false
+    const dx = Math.max(shrine.x - x, 0, x - (shrine.x + shrine.w - 1)), dz = Math.max(shrine.z - z, 0, z - (shrine.z + shrine.d - 1))
+    return Math.hypot(dx, dz) >= WALL_CLEARANCE
+  }
+  // Closest to the door first.
+  for (let k = last; k >= first; k--) {
+    const arrival = reached.get(k)
+    if (!arrival) continue
+    // Pull off in the direction the convoy is already travelling at this tile.
+    const heading = Math.atan2(track[k].x - track[k - 1].x, track[k].z - track[k - 1].z)
+    const local = (along: number, across: number, side: number) => ({ x: track[k].x + Math.sin(heading) * along + Math.cos(heading) * across * side,
+      z: track[k].z + Math.cos(heading) * along - Math.sin(heading) * across * side })
+    for (const side of [1, -1]) for (const depth of [1.5, 2, 2.5, 3]) for (const shape of ["along", "across"] as const) {
+      // Stand parallel to the track, as on a roadside verge, or nose-in across
+      // it where the field is a narrow pocket. Leaving is a forward loop back
+      // onto the track facing the road either way.
+      if (shape === "across" && depth < 2) continue
+      const park = shape === "along" ? local(2 + wheelbase, depth, side) : local(2, depth, side)
+      const stand = shape === "along" ? heading : Math.atan2(Math.sin(heading + side * Math.PI / 2), Math.cos(heading + side * Math.PI / 2))
+      if (!standAllowed(park) || !parkingClear(map, alignCart(park, stand, wheelbase), puller, scale, reserved, true)) continue
+      const pullOff = shape === "along" ? [local(0.4, 0, side), local(1.4, depth, side), park]
+        : [local(0.4, 0, side), local(1.4, 0.6, side), local(2, 1.4, side), park]
+      const parked = sampleRoute(arrival.pose, roundRoute([arrival.pose.hitch, ...pullOff], 0.45), wheelbase, field)
+      if (!parked || !parkingClear(map, parked, puller, scale, reserved, true)) continue
+      const radius = Math.max(0.75, Math.min(1.25, depth / 2))
+      const loops: Point[][] = []
+      if (shape === "along") for (const turn of [-1, 1]) {
+        // Pull forward and turn about, towards the track or out into the field.
+        const loop: Point[] = []
+        for (let i = 0; i <= 8; i++) {
+          const angle = i / 8 * Math.PI
+          loop.push(local(2.6 + wheelbase + Math.sin(angle) * radius, depth + turn * radius * (1 - Math.cos(angle)), side))
+        }
+        loops.push([park, ...loop, local(0.6, 0, side), track[k - 1]])
+      } else {
+        // Pull further out, swing round towards the road and drop back onto the track.
+        const loop: Point[] = []
+        for (let i = 0; i <= 8; i++) {
+          const angle = i / 8 * Math.PI
+          loop.push(local(2 - radius + Math.cos(angle) * radius, depth + 0.6 + Math.sin(angle) * radius, side))
+        }
+        loops.push([park, ...loop, local(2 - 2 * radius, 0.7, side), local(2 - 2 * radius - 0.7, 0, side), track[k - 1]])
+      }
+      for (const about of loops) {
+        const merged = sampleRoute(parked, roundRoute(about, 0.45), wheelbase, field)
+        if (!merged || !sampleRoute(merged, roundRoute([track[k - 1], ...track.slice(0, k - 1).reverse(), ...roadExit], 0.45), wheelbase, structures)) continue
+        const tree = puller === "hand" ? undefined : parkingTree(map, parked, context.trees)
+        return { tree, entry: roundRoute([...approach, ...track.slice(0, k + 1), ...pullOff], 0.45),
+          exit: roundRoute([...about, ...track.slice(0, k - 1).reverse(), ...roadExit], 0.45),
+          pose: initial, parked, returnProgress, distance: 0, walking: false }
+      }
+    }
+  }
+  return null
+}


### PR DESCRIPTION
Knights and merchants used to pull off onto a roadside verge up to twelve tiles before the fork and walk the whole branch, leaving their animals far outside the enclave. They now ride the track to the shrine and leave the horse or wagon standing on open grass near the door, parallel to the track or nose-in where the glade is only a narrow pocket, and leave by a forward loop back onto the track so a wagon never reverses. A tree within reach still gets a tether but none is required; the roadside verge remains the fallback for a covered fork, a full field or a glade too steep for a wagon. The change adds `lib/game/transport/enclave-parking.ts` with its own tests, wires it into the shrine visit in `sim.ts` ahead of the verge search, updates the knight tests to expect the horse beside the shrine, and documents the behaviour in `assets/TRANSPORT.md`. Verified with the parking test files, a survey of ten generated worlds and headless screenshots on seeds 1 and 63353.

🤖 Generated with [Claude Code](https://claude.com/claude-code)