### PR TITLE
Spread walkers across diagonal roads and keep cliffs clear of road edges

### DIFF
--- a/lib/game/map/generate-map.ts
+++ b/lib/game/map/generate-map.ts
@@ -9,6 +9,7 @@ import { addRoadsideTowns } from "./roadside-towns"
 import { addFoundingWell, addPathSprings } from "./seeded-water"
 import { beachAccess } from "./beaches"
 import { taperRiverBanks, gradeBridgeApproaches } from "./river-banks"
+import { cliffVergeCost, clearCliffsBesideRoads } from "./road-cliffs"
 import { bridgeLayout } from "./bridges"
 import { seedFords } from "./fords"
 import { generateElevation, finishElevation, levelBuildingGround, elevationStep, type ElevationInfo, type ElevationSettings } from "./elevation"
@@ -231,6 +232,8 @@ export function generateMap(options: GenerateMapOptions): GameMap {
   const elevation = generateElevation(seed, width, depth, kind, options.elevation, water.flow)
   const waterInfo = drainWater(kind, water.depth, width, depth, elevation)
   taperRiverBanks(elevation, width, depth, kind, waterInfo, water.flow, seed)
+  // Roads and tracks keep a cliff-free verge; routing pays to hug a cliff face.
+  const cliffVerge = cliffVergeCost(elevation, width, depth, kind)
   for (let i = 0; i < kind.length; i++) {
     if (kind[i] !== 0) tiles[i] = "water"
   }
@@ -502,7 +505,7 @@ export function generateMap(options: GenerateMapOptions): GameMap {
     return surface + vergeShade[i] * ROAD_CLEARING_COST
   }
   const groundWander = new Float64Array(roadWander)
-  for (let i = 0; i < groundWander.length; i++) groundWander[i] += groundCost(i)
+  for (let i = 0; i < groundWander.length; i++) groundWander[i] += groundCost(i) + cliffVerge[i]
 
 
   // Keep the road outside old growth and prefer open land beyond its canopy.
@@ -514,8 +517,8 @@ export function generateMap(options: GenerateMapOptions): GameMap {
   const roadCost = new Float64Array(width * depth)
   for (let i = 0; i < roadCost.length; i++) {
     // Prefer economical lines through open ground.
-    roadCost[i] = roadWander[i] * .175 + groundCost(i) + darkPenalty(i)
-    trailWander[i] += darkPenalty(i)
+    roadCost[i] = roadWander[i] * .175 + groundCost(i) + darkPenalty(i) + cliffVerge[i]
+    trailWander[i] += darkPenalty(i) + cliffVerge[i]
     // Trails, unlike the road, never enter old growth at all.
     if (tiles[i] === "darkwood") walkable[i] = WATER_KIND_LAKE
   }
@@ -780,6 +783,8 @@ export function generateMap(options: GenerateMapOptions): GameMap {
     site,
     water: waterInfo,
   }
+  // Whatever the routing could not avoid, cut back: no cliff face within the clearance of a road edge.
+  clearCliffsBesideRoads(elevation, width, depth, kind, tiles, map.buildings, waterInfo.surface)
   finishElevation(elevation, width, depth, kind, waterInfo.surface!)
   // Corner averaging can pull surrounding slopes back through founding floors.
   // Pin every footprint with the same cut-and-fill used for player purchases.
@@ -792,6 +797,11 @@ export function generateMap(options: GenerateMapOptions): GameMap {
   addRoadsideTowns(map)
   createCrossroads(map)
   clearMainRoadVerge(map)
+  // Wells, springs and towns lay their own tracks; keep those clear of cliffs too.
+  for (let round = 0; round < 3 && clearCliffsBesideRoads(map.elevation!, width, depth, kind, map.tiles, map.buildings, waterInfo.surface) > 0; round++) {
+    finishElevation(map.elevation!, width, depth, kind, waterInfo.surface!)
+    for (const building of map.buildings) map.elevation = levelBuildingGround(map, building)
+  }
   return map
 }
 

--- a/lib/game/map/road-cliffs.test.ts
+++ b/lib/game/map/road-cliffs.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest"
+import { generateElevation, elevationStep } from "./elevation"
+import { generateMap } from "./generate-map"
+import { isRoadTerrain } from "./road"
+import { CLIFF_CLEARANCE, cliffVergeCost, clearCliffsBesideRoads } from "./road-cliffs"
+import { ROUTE_DIRS } from "./route"
+import type { GameMap } from "./types"
+import type { TerrainId } from "./terrain"
+
+/** Dry cliff faces within `clearance` land tiles of any road or track tile. */
+function cliffsBesideRoads(map: GameMap, clearance = CLIFF_CLEARANCE): string[] {
+  const { width, depth, tiles, elevation } = map, e = elevation!
+  const water = (i: number) => tiles[i] === "water" || tiles[i] === "bridge"
+  const distance = new Int32Array(tiles.length).fill(-1), queue: number[] = []
+  for (let i = 0; i < tiles.length; i++) if (isRoadTerrain(tiles[i])) { distance[i] = 0; queue.push(i) }
+  for (let q = 0; q < queue.length; q++) {
+    const i = queue[q], x = i % width, z = Math.floor(i / width)
+    if (distance[i] >= clearance) continue
+    for (const [dx, dz] of ROUTE_DIRS) {
+      const nx = x + dx, nz = z + dz, n = nz * width + nx
+      if (nx < 0 || nz < 0 || nx >= width || nz >= depth || water(n) || distance[n] !== -1) continue
+      distance[n] = distance[i] + 1; queue.push(n)
+    }
+  }
+  const found: string[] = []
+  for (let i = 0; i < tiles.length; i++) {
+    if (distance[i] < 0) continue
+    const x = i % width, z = Math.floor(i / width)
+    for (const [dx, dz] of ROUTE_DIRS) {
+      const nx = x + dx, nz = z + dz, n = nz * width + nx
+      if (nx < 0 || nz < 0 || nx >= width || nz >= depth || water(n)) continue
+      if (Math.abs(e.height[i] - e.height[n]) >= e.settings.cliffThreshold) found.push(`${x},${z}→${nx},${nz}`)
+    }
+  }
+  return found
+}
+
+describe("cliff clearance beside roads", () => {
+  it("cuts a ridge back from a road, feathers the cut, and leaves distant cliffs alone", () => {
+    const width = 12, depth = 9, kind = new Uint8Array(width * depth)
+    const e = generateElevation(1, width, depth, kind)
+    e.height.fill(0)
+    // A road along z = 1, a ridge top two tiles below it, and a far ridge at the bottom edge.
+    for (let x = 0; x < width; x++) for (let z = 3; z <= 4; z++) e.height[z * width + x] = 1
+    for (let x = 0; x < width; x++) e.height[8 * width + x] = 1
+    const tiles: TerrainId[] = Array(width * depth).fill("grass")
+    for (let x = 0; x < width; x++) tiles[1 * width + x] = "path"
+    const before = [...e.height]
+    expect(clearCliffsBesideRoads(e, width, depth, kind, tiles)).toBeGreaterThan(0)
+    const map: GameMap = { width, depth, tiles, buildings: [], elevation: e }
+    expect(cliffsBesideRoads(map)).toEqual([])
+    for (let x = 0; x < width; x++) {
+      expect(e.height[1 * width + x]).toBe(0)
+      // The far ridge is untouched, and so is the flat ground beside it.
+      expect(e.height[8 * width + x]).toBe(before[8 * width + x])
+      expect(e.height[7 * width + x]).toBe(before[7 * width + x])
+      // Within the clearance every step is walkable; the ridge's far face lies beyond it.
+      for (let z = 0; z < 4; z++) expect(Number.isFinite(elevationStep(e, z * width + x, (z + 1) * width + x))).toBe(true)
+    }
+  })
+
+  it("charges routes for hugging a cliff face, out to the clearance", () => {
+    const width = 9, depth = 1, kind = new Uint8Array(width)
+    const e = generateElevation(1, width, depth, kind)
+    e.height.fill(0); e.height[0] = 1
+    expect([...cliffVergeCost(e, width, depth, kind)].map(c => c > 0)).toEqual([true, true, true, true, false, false, false, false, false])
+  })
+
+  it.each([
+    { seed: 1 }, { seed: 42 }, { seed: 7919 }, { seed: 158381 },
+    { seed: 1, elevation: { maxHeight: 4, cliffHeight: 2, cliffThreshold: 0.25, scale: 8, detail: 0.5, riverCut: 1, cutFrequency: 1 } },
+    { seed: 42, elevation: { maxHeight: 4, cliffHeight: 2, cliffThreshold: 0.25, scale: 8, detail: 0.5, riverCut: 1, cutFrequency: 1 } },
+  ])("keeps every generated road and track edge clear of cliff faces (%o)", options => {
+    const map = generateMap(options)
+    expect(map.elevation!.cliffs.some(Boolean)).toBe(true)
+    expect(cliffsBesideRoads(map)).toEqual([])
+  }, 120000)
+})

--- a/lib/game/map/road-cliffs.ts
+++ b/lib/game/map/road-cliffs.ts
@@ -1,0 +1,119 @@
+import type { ElevationInfo } from "./elevation"
+import { isRoadTerrain } from "./road"
+import { ROUTE_DIRS } from "./route"
+import type { TerrainId } from "./terrain"
+import type { BuildingDef } from "./types"
+
+/** Tiles of cliff-free ground kept on either side of every road and track. */
+export const CLIFF_CLEARANCE = 2
+/** Route cost per tile within the clearance of a cliff; comparable to solid forest. */
+export const CLIFF_VERGE_COST = 4
+/** Lowest a cut bank may sit above its water, in tile heights. */
+const BANK_LIP = 0.15
+
+/** Land tiles whose dry neighbours drop or rise a full cliff step. Bank cliffs to water are bank shaping, not cliffs. */
+function dryCliffTiles(e: ElevationInfo, width: number, depth: number, kind: Uint8Array): Uint8Array {
+  const cliff = new Uint8Array(kind.length)
+  for (let z = 0; z < depth; z++) for (let x = 0; x < width; x++) {
+    const i = z * width + x
+    if (kind[i]) continue
+    for (const [dx, dz] of ROUTE_DIRS) {
+      const nx = x + dx, nz = z + dz, n = nz * width + nx
+      if (nx < 0 || nz < 0 || nx >= width || nz >= depth || kind[n]) continue
+      if (Math.abs(e.height[i] - e.height[n]) >= e.settings.cliffThreshold) { cliff[i] = 1; break }
+    }
+  }
+  return cliff
+}
+
+/** Breadth-first land distance from the seed tiles, up to `limit`; -1 beyond. */
+function landDistance(seeds: Uint8Array, width: number, depth: number, kind: Uint8Array, limit: number): Int32Array {
+  const distance = new Int32Array(kind.length).fill(-1), queue: number[] = []
+  for (let i = 0; i < seeds.length; i++) if (seeds[i] && !kind[i]) { distance[i] = 0; queue.push(i) }
+  for (let q = 0; q < queue.length; q++) {
+    const i = queue[q], x = i % width, z = Math.floor(i / width)
+    if (distance[i] >= limit) continue
+    for (const [dx, dz] of ROUTE_DIRS) {
+      const nx = x + dx, nz = z + dz, n = nz * width + nx
+      if (nx < 0 || nz < 0 || nx >= width || nz >= depth || kind[n] || distance[n] !== -1) continue
+      distance[n] = distance[i] + 1; queue.push(n)
+    }
+  }
+  return distance
+}
+
+/** Extra routing cost that steers roads and tracks a clearance away from cliff faces. */
+export function cliffVergeCost(e: ElevationInfo, width: number, depth: number, kind: Uint8Array, clearance = CLIFF_CLEARANCE): Float64Array {
+  const cost = new Float64Array(kind.length)
+  const distance = landDistance(dryCliffTiles(e, width, depth, kind), width, depth, kind, clearance)
+  for (let i = 0; i < cost.length; i++) if (distance[i] >= 0) cost[i] = CLIFF_VERGE_COST
+  return cost
+}
+
+/**
+ * Regrade the ground so no dry cliff face remains within the clearance of any
+ * road or track tile. Cliffs are cut back from the high side, so the road keeps
+ * its level, and each cut feathers outward below the cliff threshold until it
+ * meets the untouched hillside. Bridge and ford footings and building pads keep
+ * their graded heights, and a bank never sinks below its water; a cliff against
+ * one of those is filled from below instead.
+ * Cliffs beyond the clearance are left alone.
+ */
+export function clearCliffsBesideRoads(e: ElevationInfo, width: number, depth: number, kind: Uint8Array, tiles: readonly TerrainId[],
+  buildings: readonly Pick<BuildingDef, "x" | "z" | "w" | "d">[] = [], surface?: readonly number[], clearance = CLIFF_CLEARANCE): number {
+  const threshold = e.settings.cliffThreshold, grade = threshold * 0.8
+  const road = new Uint8Array(kind.length)
+  for (let i = 0; i < road.length; i++) if (isRoadTerrain(tiles[i])) road[i] = 1
+  const near = landDistance(road, width, depth, kind, clearance)
+  // Footings are graded to their deck and pads to their floor. A bank can be
+  // cut down to a low shelf, but never below its water.
+  const frozen = new Uint8Array(kind.length), floor = new Float64Array(kind.length).fill(-Infinity)
+  // A pad's ring meets its floor when the footprint is re-levelled, so it is part of the pad here.
+  for (const b of buildings) for (let z = b.z - 1; z <= b.z + b.d; z++) for (let x = b.x - 1; x <= b.x + b.w; x++)
+    if (x >= 0 && z >= 0 && x < width && z < depth) frozen[z * width + x] = 1
+  for (let z = 0; z < depth; z++) for (let x = 0; x < width; x++) {
+    const i = z * width + x
+    if (kind[i]) continue
+    for (const [dx, dz] of ROUTE_DIRS) {
+      const nx = x + dx, nz = z + dz, n = nz * width + nx
+      if (nx < 0 || nz < 0 || nx >= width || nz >= depth || !kind[n]) continue
+      floor[i] = Math.max(floor[i], (surface?.[n] ?? e.height[n]) + BANK_LIP)
+      if (tiles[n] === "bridge" || tiles[n] === "ford") frozen[i] = 1
+    }
+  }
+  const dirty = new Uint8Array(kind.length)
+  let changed = 0
+  // Cut first, then fill: each phase only ever moves ground one way, so it
+  // converges instead of trading a fill against the road for a cut against the
+  // hillside behind it.
+  for (const phase of ["cut", "fill"] as const) for (let pass = 0; pass < 512; pass++) {
+    let moved = false
+    for (let z = 0; z < depth; z++) for (let x = 0; x < width; x++) {
+      const i = z * width + x
+      if (kind[i]) continue
+      for (const [dx, dz] of [[1, 0], [0, 1]] as const) {
+        const nx = x + dx, nz = z + dz, n = nz * width + nx
+        if (nx >= width || nz >= depth || kind[n]) continue
+        if (near[i] < 0 && near[n] < 0 && !dirty[i] && !dirty[n]) continue
+        const high = e.height[i] >= e.height[n] ? i : n, low = high === i ? n : i
+        if (e.height[high] - e.height[low] < threshold) continue
+        if (phase === "cut") {
+          // Cut the high side unless it is a footing or a pad. The road itself
+          // keeps its level, except that it descends to meet a pad.
+          if (frozen[high] || (road[high] && !frozen[low])) continue
+          const target = Math.max(e.height[low] + grade, floor[high])
+          if (target >= e.height[high]) continue
+          e.height[high] = target
+          dirty[high] = 1
+        } else {
+          if (frozen[low]) continue
+          e.height[low] = e.height[high] - grade
+          dirty[low] = 1
+        }
+        moved = true; changed++
+      }
+    }
+    if (!moved) break
+  }
+  return changed
+}

--- a/lib/game/map/road-width.test.ts
+++ b/lib/game/map/road-width.test.ts
@@ -112,6 +112,23 @@ describe("two-tile main road", () => {
     }
   })
 
+  it("spreads walkers across a diagonal ribbon as widely as on a straight", () => {
+    const map = fixture()
+    // Straight run, then a long staircase that renders as one 45-degree line.
+    map.road = [...Array.from({ length: 8 }, (_, x) => ({ x, z: 2 }))]
+    for (let i = 0; i < 12; i++) map.road.push({ x: 8 + Math.floor(i / 2), z: 2 + Math.ceil(i / 2) })
+    map.tiles.fill("grass")
+    for (const p of map.road) map.tiles[p.z * map.width + p.x] = "path"
+    expect(mainRoadWidthAt(map, 3, true)).toBe(2)
+    // The tight transition into the diagonal still pinches, then eases back out.
+    expect(mainRoadWidthAt(map, 8, true)).toBeLessThan(1)
+    expect(mainRoadWidthAt(map, 14, true)).toBe(2)
+    for (const lane of [-.28, .28]) {
+      const centre = roadLanePoint(map, map.road, 14, 0)!, offset = roadLanePoint(map, map.road, 14, lane)!
+      expect(Math.hypot(offset.x - centre.x, offset.z - centre.z)).toBeCloseTo(Math.abs(lane) * 2, 8)
+    }
+  })
+
   it("clears trees beside the route without changing its centreline, water, or bridge tiles", () => {
     const map = fixture(), road = map.road!.map(p => ({ ...p }))
     map.tiles[7 * map.width + 10] = "forest"

--- a/lib/game/map/road-width.ts
+++ b/lib/game/map/road-width.ts
@@ -1,5 +1,6 @@
 import { elevationStep } from "./elevation"
 import { bridgeLayout } from "./bridges"
+import { diagonalRoadBend } from "./road"
 import { tileAt, type GameMap } from "./types"
 
 /** Main roads have two tiles of usable ground; tracks and bridge decks retain one. */
@@ -32,6 +33,10 @@ function profile(map: GameMap) {
   for (let i = 1; i < road.length - 1; i++) {
     const a = road[i - 1], p = road[i], b = road[i + 1]
     if ((p.x - a.x) * (b.z - p.z) === (p.z - a.z) * (b.x - p.x)) continue
+    // Inside a diagonal ribbon the alternating bends render as one 45-degree
+    // line, so walkers spread across it exactly as they do on a straight.
+    // Bridge decks keep their quarter-turn lanes and stay narrow.
+    if (!bridges.rise[p.z * map.width + p.x] && tileAt(map, p.x, p.z) !== "bridge" && diagonalRoadBend(map, p.x, p.z)?.straight) continue
     // The authored Bezier's tightest radius is smaller than half a tile.
     // Narrow through the whole bend, then ease back out on either straight.
     for (let j = i - 1; j <= i + 1; j++) walking[j] = Math.min(walking[j], .7)


### PR DESCRIPTION
Diagonal road ribbons render as one straight 45° line, but the walking-lane profile narrowed every bend tile, so people crowded the centre of every diagonal; straight-diagonal tiles off bridge decks now keep full lane width while the tight end transitions and deck tiles stay narrow. Map generation now keeps dry cliff faces at least two tiles from any road or track edge: routing pays a forest-sized penalty to hug a cliff, and a final regrade pass (new `lib/game/map/road-cliffs.ts`) cuts back whatever was unavoidable, feathering below the cliff threshold, with bridge/ford footings and building pads filled against rather than cut and banks never sinking below their water. The pass repeats after wells, springs and towns lay their own tracks. Covered by new tests for the diagonal lane width and for cliff clearance on synthetic and generated maps, including a harsh cliff configuration; the wider map, road and settlement test files pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)