### PR TITLE
Restore the previous medieval background music track

### DIFF
--- a/components/game/music-player.tsx
+++ b/components/game/music-player.tsx
@@ -10,7 +10,7 @@ import { Music2, Slash } from "lucide-react"
  * whole component out.
  */
 
-const VIDEO_ID = "xERuXyDeVqc"
+const VIDEO_ID = "5F5dgg1eeGE"
 /** 0–100. Quiet enough to sit under the game rather than in front of it. */
 const VOLUME = 20
 const MUSIC_STORAGE_KEY = "pilgrimage.music"


### PR DESCRIPTION
Switches the background music YouTube video back to `5F5dgg1eeGE`, the medieval lute recording used before the swap to `xERuXyDeVqc` in e20575b1. Only the `VIDEO_ID` constant in `components/game/music-player.tsx` changes; the file is now byte-identical to its pre-swap state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)