### PR TITLE
Gather waiting companions on the grass by the enclave entrance

### DIFF
--- a/docs/travel-party-performance.md
+++ b/docs/travel-party-performance.md
@@ -48,6 +48,15 @@ expansion limit, camp pitches come from one cluster, admissions are asked for
 a few companions at a time, and stalled attempts retry on a timer. The shrine
 planner now checks for a free place before planning any route.
 
+While a company visits, whoever is not at the relic waits in one group on the
+grass at the corner where the branch leaves the road, on the side the company
+came from. The standing places are listed once per attempt from the corner
+outward, each companion takes the nearest free one with a bounded route, and
+companions still on the road ask again on a timer. Someone called up from the
+grass starts their approach where they stand and walks back to the same place;
+once the visit is over everyone walks to the nearest road tile before the
+company regroups.
+
 Formations and the company pace are cached and refreshed a few times per game
 second; the eased company speed hides the steps. Party transport figures stay
 mounted until they are well outside the view instead of remounting at the

--- a/lib/game/roadside-reservations.ts
+++ b/lib/game/roadside-reservations.ts
@@ -2,7 +2,7 @@ import type { SimTraveler } from "./sim"
 import { SpatialPoints } from "./spatial-points"
 
 type Point = { x: number; z: number }
-type Kind = "spot" | "music" | "alms" | "stall"
+type Kind = "spot" | "music" | "alms" | "stall" | "gather"
 interface Reservation extends Point { owner: SimTraveler; source: Point; kind: Kind; radius: number }
 
 /** One local occupancy index per simulation tick. Live source checks release
@@ -10,15 +10,16 @@ interface Reservation extends Point { owner: SimTraveler; source: Point; kind: K
  * same seat. Movement of the person does not move their reserved destination. */
 export class RoadsideReservations {
   private points = new SpatialPoints<Reservation>([])
-  private previous = new Map<number, { spot: Point | null; music?: Point; alms?: Point; stall?: readonly Point[] }>()
+  private previous = new Map<number, { spot: Point | null; music?: Point; alms?: Point; stall?: readonly Point[]; gather?: Point }>()
 
   constructor(people: Iterable<SimTraveler>) { for (const person of people) this.update(person) }
 
   update(owner: SimTraveler) {
     const spot = owner.spot, music = owner.musicVisit?.spot, alms = owner.almsVisit?.spot, stall = owner.stallRoute?.obstacles
-    if (!spot && !music && !alms && !stall?.length) return
+    const gather = owner.partyGathering?.spot
+    if (!spot && !music && !alms && !stall?.length && !gather) return
     const before = this.previous.get(owner.id)
-    if (before && before.spot === spot && before.music === music && before.alms === alms && before.stall === stall) return
+    if (before && before.spot === spot && before.music === music && before.alms === alms && before.stall === stall && before.gather === gather) return
     const add = (source: Point | undefined | null, kind: Kind, radius: number) => {
       if (source) this.points.add({ x: source.x, z: source.z, source, owner, kind, radius })
     }
@@ -26,7 +27,8 @@ export class RoadsideReservations {
     if (music !== before?.music) add(music, "music", .9)
     if (alms !== before?.alms) add(alms, "alms", .9)
     if (stall !== before?.stall) for (const point of stall ?? []) add(point, "stall", 2)
-    this.previous.set(owner.id, { spot, music, alms, stall })
+    if (gather !== before?.gather) add(gather, "gather", .9)
+    this.previous.set(owner.id, { spot, music, alms, stall, gather })
   }
 
   occupied(point: Point, ownerId: number): boolean {
@@ -34,7 +36,8 @@ export class RoadsideReservations {
       const { owner, source, kind, radius } = reservation
       if (owner.id === ownerId || (source.x - point.x) ** 2 + (source.z - point.z) ** 2 >= radius ** 2) return false
       return kind === "spot" ? owner.spot === source : kind === "music" ? owner.musicVisit?.spot === source :
-        kind === "alms" ? owner.almsVisit?.spot === source : !!owner.stallRoute?.obstacles.some(obstacle => obstacle === source)
+        kind === "alms" ? owner.almsVisit?.spot === source : kind === "gather" ? owner.partyGathering?.spot === source
+          : !!owner.stallRoute?.obstacles.some(obstacle => obstacle === source)
     })
   }
 }

--- a/lib/game/sim.ts
+++ b/lib/game/sim.ts
@@ -300,6 +300,13 @@ function minstrelWalkSeconds(id: number, cycle: number): number {
 export const BEGGAR_DELAY_SECONDS = GAME_DAY_SECONDS
 export const BEGGAR_RECOVERY_GOLD = 15
 
+/** A waiting companion's place on the gathering ground, and the way back to the road once the visit is over. */
+export interface PartyGathering {
+  spot: WorldPoint
+  arrived: boolean
+  back?: { point: WorldPoint; progress: number }
+}
+
 export interface SimTraveler {
   partyId?: number
   partyWaiting?: boolean
@@ -309,6 +316,10 @@ export interface SimTraveler {
   /** Placed on the road by the company this step; the personal walking update stands aside. */
   partyCarried?: boolean
   partyVisitAborted?: boolean
+  /** Standing room on the grass by the enclave entrance while the company visits, and the walk to and from it. */
+  partyGathering?: PartyGathering
+  /** Where a shrine route began off the road; the first tile of the approach blends from here rather than the road lane. */
+  shrineOrigin?: WorldPoint
   waterVisit?: WaterVisit
   waterRetry?: number
   /** A reversible progression; the original calling and personal attributes stay intact. */
@@ -731,7 +742,7 @@ function shrineWorldPoint(map: GameMap, s: SimTraveler): WorldPoint {
   if (s.branchProgress < 1) {
     const start = routeWorldPoint(map, route, 0, lane)
     const roadLane = s.activity === "toRelic" ? s.branchEntryLane : s.direction * s.laneOffset
-    const road = roadWorldPoint(map, s.progress, roadLane)
+    const road = s.shrineOrigin ?? roadWorldPoint(map, s.progress, roadLane)
     const blend = 1 - s.branchProgress
     point.x += (road.x - start.x) * blend
     point.y += (road.y - start.y) * blend
@@ -1479,6 +1490,120 @@ const FORMATION_TOLERANCE = .05
 const FAR_POSITION_STEPS = 4
 /** Bound each person's camp or seat route; a stranded companion keeps the company on the road. */
 const PARTY_ROUTE_LIMIT = 1500
+/** Waiting companions stand at least this far apart on the grass. */
+const GATHERING_SPACING = .9
+/** Tiles around the entrance corner searched for standing room. */
+const GATHERING_REACH = 3
+/** Seconds between attempts to seat companions still standing on the road. */
+const GATHERING_RETRY = 3
+const GATHERING_GROUND: readonly string[] = ["grass", "dirt", "clearing"]
+
+/** Open ground at the corner where the branch leaves the road, on the side the
+ * company came from: grass within reach of the entrance, never road, track,
+ * footprint, parked wagon or tree, ordered from the corner outward so a company
+ * fills one loose group rather than a ring around the junction. */
+function gatheringGround(sim: SimState, map: GameMap, party: TravelParty, head: SimTraveler, scale: number): WorldPoint[] {
+  const site = map.site, road = map.road
+  if (!site || !road) return []
+  const length = road.length - 1
+  const wrap = (i: number) => ((i % length) + length) % length
+  const junction = road[site.junction]
+  if (!junction) return []
+  const before = road[wrap(site.junction - party.direction)] ?? junction
+  const along = { x: Math.sign(junction.x - before.x), z: Math.sign(junction.z - before.z) }
+  const first = site.branch[1] ?? site.door
+  const aside = { x: Math.sign(first.x - junction.x), z: Math.sign(first.z - junction.z) }
+  const rng = makeRng(deriveSeed(party.id ^ 0x47415448, party.decisions))
+  const anchor = { x: tileToWorldX(map, junction.x) + (aside.x - along.x) * 1.5 + (rng() - .5) * .8,
+    z: tileToWorldZ(map, junction.z) + (aside.z - along.z) * 1.5 + (rng() - .5) * .8 }
+  const key = (x: number, z: number) => z * map.width + x
+  const blocked = new Set<number>()
+  for (const p of site.branch) blocked.add(key(p.x, p.z))
+  for (let i = -GATHERING_REACH * 3; i <= GATHERING_REACH * 3; i++) { const p = road[wrap(site.junction + i)]; if (p) blocked.add(key(p.x, p.z)) }
+  const wagons = parkingContext(sim, head, scale, false, anchor).obstacles ?? []
+  const trees = treeSpatialIndex(sim.trees)
+  const ax = worldToTileX(map, anchor.x), az = worldToTileZ(map, anchor.z)
+  const points: WorldPoint[] = []
+  for (let dz = -GATHERING_REACH; dz <= GATHERING_REACH; dz++) for (let dx = -GATHERING_REACH; dx <= GATHERING_REACH; dx++) {
+    const x = ax + dx, z = az + dz
+    if (blocked.has(key(x, z)) || !GATHERING_GROUND.includes(tileAt(map, x, z) ?? "") || buildingAt(map, x, z)) continue
+    for (const [ox, oz] of [[-.25, -.25], [.25, -.25], [-.25, .25], [.25, .25]]) {
+      const wx = tileToWorldX(map, x) + ox, wz = tileToWorldZ(map, z) + oz
+      if (trees.firstWithin(wx, wz, .8, (_, index) => !sim.felled.has(index))) continue
+      if (wagons.some(box => Math.hypot(box.x - wx, box.z - wz) < Math.max(box.halfWidth, box.halfLength) + .5)) continue
+      points.push({ x: wx, y: walkingSurface(map, wx, wz).height, z: wz })
+    }
+  }
+  const away = (p: WorldPoint) => (p.x - anchor.x) ** 2 + (p.z - anchor.z) ** 2
+  return points.sort((a, b) => away(a) - away(b))
+}
+
+/** Take the nearest free place on the ground that can be walked to, and set out for it. */
+function joinGathering(s: SimTraveler, map: GameMap, ground: readonly WorldPoint[], reservations: RoadsideReservations): boolean {
+  const start = { x: worldToTileX(map, s.x), z: worldToTileZ(map, s.z) }
+  for (const spot of ground) {
+    if (reservations.occupied(spot, s.id)) continue
+    const route = settlementRoute(map, map.buildings, start, { x: worldToTileX(map, spot.x), z: worldToTileZ(map, spot.z) },
+      false, false, undefined, PARTY_ROUTE_LIMIT)
+    if (!route) continue
+    routeWalk(s, map, route, spot)
+    s.partyGathering = { spot, arrived: false }
+    reservations.update(s)
+    return true
+  }
+  return false
+}
+
+/** Walk the rest of the way to the place; someone back from the relic before
+ * reaching it plans the remainder from where they stand. */
+function stepGathering(s: SimTraveler, map: GameMap, speed: number, dt: number): void {
+  const gathering = s.partyGathering!
+  if (gathering.arrived) return
+  if (!s.offRoadRoute?.length) {
+    const route = settlementRoute(map, map.buildings, { x: worldToTileX(map, s.x), z: worldToTileZ(map, s.z) },
+      { x: worldToTileX(map, gathering.spot.x), z: worldToTileZ(map, gathering.spot.z) }, false, false, undefined, PARTY_ROUTE_LIMIT)
+    if (!route) { s.partyGathering = undefined; return }
+    routeWalk(s, map, route, gathering.spot)
+  }
+  if (stepOffRoadWalk(s, gathering.spot, speed, dt, map)) { gathering.arrived = true; s.offRoadRoute = null; s.walkFrom = null }
+}
+
+/** The road position nearest a point, to half a tile, searched around `near`. */
+function nearestRoadProgress(map: GameMap, point: { x: number; z: number }, near: number): number {
+  const length = map.road!.length - 1
+  const wrap = (p: number) => ((p % length) + length) % length
+  let best = near, bestDistance = Infinity
+  for (let i = -GATHERING_REACH * 3; i <= GATHERING_REACH * 3; i++) for (const half of [0, .5]) {
+    const progress = wrap(near + i + half)
+    const at = roadWorldPoint(map, progress, 0)
+    const distance = (at.x - point.x) ** 2 + (at.z - point.z) ** 2
+    if (distance < bestDistance) { bestDistance = distance; best = progress }
+  }
+  return best
+}
+
+/** Leave the gathering for the road beside it, ready to fall into formation.
+ * True once they stand on the road; someone who never left it is there already. */
+function leaveGathering(s: SimTraveler, map: GameMap, speed: number, dt: number): boolean {
+  const gathering = s.partyGathering
+  if (!gathering) return true
+  if (!gathering.back) {
+    const progress = nearestRoadProgress(map, s, map.site?.junction ?? Math.floor(s.progress))
+    const lane = s.direction * s.laneOffset
+    const point = roadWorldPoint(map, progress, lane)
+    const route = settlementRoute(map, map.buildings, { x: worldToTileX(map, s.x), z: worldToTileZ(map, s.z) },
+      { x: worldToTileX(map, point.x), z: worldToTileZ(map, point.z) }, false, false, undefined, PARTY_ROUTE_LIMIT)
+    if (route) routeWalk(s, map, route, point)
+    else s.offRoadRoute = [{ ...point }]
+    gathering.back = { point, progress }
+    gathering.arrived = false
+  }
+  if (!stepOffRoadWalk(s, gathering.back.point, speed, dt, map)) return false
+  s.progress = gathering.back.progress
+  s.lane = s.direction * s.laneOffset
+  s.offRoadRoute = null; s.walkFrom = null; s.partyGathering = undefined
+  return true
+}
 
 // Identities keyed by ID, reused across steps while the cast is unchanged.
 const identityIndexes = new WeakMap<readonly Traveler[], Map<number, Traveler>>()
@@ -1546,6 +1671,8 @@ function stepTravelParties(sim: SimState, travelers: Traveler[], map: GameMap, d
   const hold = (s: SimTraveler) => { s.partyWaiting = true; s.partyCarried = true; s.partySpeed = 0 }
   // Vendors at their stalls, read once and only when a camping company is hungry.
   let vending: SimTraveler[] | undefined
+  // Standing room already taken beside the road, read once and only when a company needs places.
+  let reservations: RoadsideReservations | undefined
   for (const party of sim.parties.values()) {
     const members: SimTraveler[] = []
     for (const id of party.members) { const s = sim.travelers.get(id); if (s) members.push(s) }
@@ -1642,6 +1769,8 @@ function stepTravelParties(sim: SimState, travelers: Traveler[], map: GameMap, d
             party.visitPending = party.visitPending.filter(other => other !== id)
             party.visitStarted.push(id)
             party.elapsed = 0
+            // Their place on the grass stays theirs; anyone still walking to it finishes the walk after the relic.
+            if (s.partyGathering) { s.offRoadRoute = null; s.walkFrom = null }
           }
         }
       }
@@ -1651,8 +1780,26 @@ function stepTravelParties(sim: SimState, travelers: Traveler[], map: GameMap, d
       if (members.some(s => ["toRelic", "visiting", "offering", "fromRelic", "toWater", "drinking", "drinkingLow", "fromWater"].includes(s.activity))) party.elapsed = 0
       // A closed or saturated enclave cannot keep unadmitted companions forever.
       if (party.elapsed > 120) party.visitPending = []
-      for (const s of members) if (s.activity === "walking") hold(s)
-      if (!party.visitPending.length && members.every(s => s.activity === "walking")) {
+      // Whoever is not at the relic waits in one group on the grass beside the
+      // entrance rather than strung along the road. Once the visit is over
+      // everyone walks back to the road before the company regroups.
+      const done = !party.visitPending.length && members.every(s => s.activity === "walking")
+      party.gatherRetry = Math.max(0, (party.gatherRetry ?? 0) - dt)
+      let ground: WorldPoint[] | undefined, returned = true
+      for (const s of members) {
+        if (s.activity !== "walking") continue
+        hold(s)
+        if (done) { if (!leaveGathering(s, map, naturalSpeed(s), dt)) returned = false; continue }
+        if (!s.partyGathering) {
+          if (party.gatherRetry > 0 || !map.site) continue
+          ground ??= gatheringGround(sim, map, party, members[0], characterScale)
+          reservations ??= new RoadsideReservations(sim.travelers.values())
+          if (!joinGathering(s, map, ground, reservations)) continue
+        }
+        stepGathering(s, map, naturalSpeed(s), dt)
+      }
+      if (ground) party.gatherRetry = GATHERING_RETRY
+      if (done && returned) {
         for (const s of members) {
           if (s.home || s.employer || s.partyVisitAborted || !party.visitStarted.includes(s.id)) continue
           const t = identities.get(s.id)!
@@ -1666,7 +1813,10 @@ function stepTravelParties(sim: SimState, travelers: Traveler[], map: GameMap, d
         for (const s of members) { s.visitCooldown = 45; s.partyWaiting = false }
         regroupParty(party, members.filter(s => s.partyId === party.id), length, seconds, characterScale)
         continue
-      } else { party.reason = party.visitPending.length ? "Waiting for room at the enclave" : "Waiting for companions to finish visiting"; continue }
+      } else {
+        party.reason = done ? "Walking back to the road" : party.visitPending.length ? "Waiting for room at the enclave" : "Waiting for companions to finish visiting"
+        continue
+      }
     }
     if (party.waterCarrier !== undefined) {
       const carrier = sim.travelers.get(party.waterCarrier)
@@ -1896,6 +2046,9 @@ function tryRoadVisit(sim: SimState, s: SimTraveler, t: Traveler, map: GameMap,
     s.shrineQueueOrder = ++sim.shrineQueueSequence
     if (parking) s.direction = direction
     s.shrineParking = parking ?? undefined
+    // Someone called up from the grass by the entrance starts where they stand
+    // and comes back to that place; everyone else joins from their road lane.
+    s.shrineOrigin = s.partyGathering ? { x: s.x, y: s.y, z: s.z } : undefined
     s.activity = parking ? "toParking" : "toRelic"
     s.partyVisitAborted = false
     s.targetId = null

--- a/lib/game/travel-parties.test.ts
+++ b/lib/game/travel-parties.test.ts
@@ -9,6 +9,8 @@ import { jobBuildings } from "./settlement"
 import { roadLanePoint } from "./map/road-lane"
 import { tileToWorldX, tileToWorldZ, worldToTileX, worldToTileZ, type GameMap } from "./map/types"
 import { shrineVisitPlan } from "./shrine-visit"
+import { generateMap } from "./map/generate-map"
+import type { TravelParty } from "./travel-parties"
 
 function fixture(count = 6, direction: 1 | -1 = 1) {
   const map: GameMap = { width: 80, depth: 20, seed: 42, tiles: Array(1600).fill("grass"), buildings: [],
@@ -257,6 +259,75 @@ describe("shared stops", () => {
     expect(sim.visits).toBe(5)
     expect(party.stage).toBe("traveling")
   })
+
+  it.each([8, 20])("waits in one group on the grass beside the entrance and walks back to the road afterwards (%i companions)", count => {
+    const { map, travelers, sim } = fixture(count)
+    withShrine(map)
+    const party = sim.parties.get(0)!
+    run(sim, travelers, map, 1)
+    expect(party.stage).toBe("visiting")
+    const members = party.members.map(id => sim.travelers.get(id)!)
+    const onRoad = (s: { z: number }) => worldToTileZ(map, s.z) === 5
+    const onGrass = (s: { x: number; z: number }) => map.tiles[worldToTileZ(map, s.z) * map.width + worldToTileX(map, s.x)] === "grass"
+    const entrance = { x: tileToWorldX(map, 28), z: tileToWorldZ(map, 5) }
+    let gathered = 0, longestStep = 0, calledFromGrass = false
+    let previous = members.map(s => ({ x: s.x, z: s.z }))
+    for (let i = 0; i < 12000 && !(party.stage === "traveling" && sim.visits === count); i++) {
+      stepSim(sim, travelers, map, 1, .1)
+      members.forEach((s, j) => { longestStep = Math.max(longestStep, Math.hypot(s.x - previous[j].x, s.z - previous[j].z)) })
+      previous = members.map(s => ({ x: s.x, z: s.z }))
+      if (members.some(s => s.activity === "toRelic" && s.shrineOrigin)) calledFromGrass = true
+      // Whoever is not at the relic stands off the road on the grass by the entrance, apart from each other.
+      const waiting = members.filter(s => s.activity === "walking" && s.partyGathering?.arrived)
+      for (const s of waiting) {
+        expect(onGrass(s)).toBe(true)
+        expect(onRoad(s)).toBe(false)
+        expect(Math.hypot(s.x - entrance.x, s.z - entrance.z)).toBeLessThan(6)
+      }
+      for (let a = 0; a < waiting.length; a++) for (let b = a + 1; b < waiting.length; b++)
+        expect(Math.hypot(waiting[a].x - waiting[b].x, waiting[a].z - waiting[b].z)).toBeGreaterThan(.8)
+      gathered = Math.max(gathered, waiting.length)
+    }
+    expect(sim.visits).toBe(count)
+    expect(party.stage).toBe("traveling")
+    expect(gathered).toBeGreaterThanOrEqual(3)
+    // A full line means later companions are called up from the grass, not from the road.
+    if (count === 20) expect(calledFromGrass).toBe(true)
+    // Nobody jumped between the road, the grass and the branch: every move was a walking step.
+    expect(longestStep).toBeLessThan(.5)
+    // Everyone is back on the road and the company moves on together.
+    for (const s of members) { expect(s.partyGathering).toBeUndefined(); expect(onRoad(s)).toBe(true) }
+    const before = party.progress
+    run(sim, travelers, map, 30)
+    expect(party.progress).toBeGreaterThan(before)
+    expect(party.formed).toBe(true)
+  })
+
+  it("finds standing room by the entrance of a generated world and brings everyone back to the road", () => {
+    const seed = 42
+    const map = generateMap({ seed })
+    const travelers = withTravelParties(generateTravelers(seed, 40), seed)
+    const sim = createSim(travelers, map, [], { sanctity: 100, spectacle: 100, doubt: 0 })
+    sim.balance = { ...DEFAULT_BALANCE, rules: { ...DEFAULT_BALANCE.rules, hungerDecay: 0, thirstDecay: 0, staminaDecay: 0 } }
+    sim.shrineRenown = 10000
+    const gatheredAt = (s: { x: number; z: number }) => map.tiles[worldToTileZ(map, s.z) * map.width + worldToTileX(map, s.x)]
+    const roadTiles = new Set(map.road!.map(p => p.z * map.width + p.x))
+    const junction = map.road![map.site!.junction]
+    let party: TravelParty | undefined
+    run(sim, travelers, map, 900, () => {
+      for (const s of sim.travelers.values()) if (s.partyGathering?.arrived && s.activity === "walking") { party = sim.parties.get(s.partyId!); return true }
+      return false
+    })
+    expect(party).toBeDefined()
+    const waiting = party!.members.map(id => sim.travelers.get(id)!).filter(s => s.partyGathering?.arrived)
+    for (const s of waiting) {
+      expect(["grass", "dirt", "clearing"]).toContain(gatheredAt(s))
+      expect(roadTiles.has(worldToTileZ(map, s.z) * map.width + worldToTileX(map, s.x))).toBe(false)
+      expect(Math.hypot(worldToTileX(map, s.x) - junction.x, worldToTileZ(map, s.z) - junction.z)).toBeLessThan(7)
+    }
+    run(sim, travelers, map, 900, () => party!.stage === "traveling" || !sim.parties.has(party!.id))
+    for (const id of party!.members) expect(sim.travelers.get(id)?.partyGathering).toBeUndefined()
+  }, 30000)
 
   it("walks a track longer than the waiting timeout to its end instead of turning back", () => {
     const count = 6

--- a/lib/game/travel-parties.ts
+++ b/lib/game/travel-parties.ts
@@ -29,6 +29,8 @@ export interface TravelParty {
   decisions: number
   waterCarrier?: number
   waterRetry?: number
+  /** Seconds before waiting companions still on the road look for standing room again. */
+  gatherRetry?: number
   visitPending: number[]
   visitStarted: number[]
   /** Road progress of the formation's head. Every place in the company derives from it. */
@@ -196,7 +198,7 @@ function createParty(id: number, people: Traveler[], leader: SimTraveler): Trave
 
 function leaveParty(s: SimTraveler) {
   s.partyId = undefined; s.partyWaiting = undefined; s.partySpeed = undefined
-  s.partyRiding = false; s.partyBoarding = false; s.partyCarried = false
+  s.partyRiding = false; s.partyBoarding = false; s.partyCarried = false; s.partyGathering = undefined
 }
 
 /** Full roster rebuild for a new simulation and after companions settle. */


### PR DESCRIPTION
While a company visits the enclave, members who are not at the relic now walk to a loose group on the grass at the corner where the branch leaves the road, on the side the company arrived from, instead of standing strung along the road. Standing spots exclude road, track, footprints, trees and parked wagons, and are reserved through the roadside reservation index so overlapping companies, performers and beggars stay apart. Someone called up from the grass starts their approach where they stand and walks back to the same place, and once the visit is over everyone walks to the nearest road tile before the company regroups. Tests cover companies of 8 and 20 waiting apart on grass and returning without any teleport, plus a generated-world check; the behaviour is noted in docs/travel-party-performance.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)