### PR TITLE
Level uneven ground under new buildings, within a tunable limit

### DIFF
--- a/app/assets/placement/page.tsx
+++ b/app/assets/placement/page.tsx
@@ -1,0 +1,9 @@
+import type { Metadata } from "next"
+import { PlacementLab } from "@/components/placement-lab/placement-lab"
+
+export const metadata: Metadata = {
+  title: "Pilgrimage — Placement playground",
+  description: "Place buildings on hillsides and watch the ground level under them, within the tuned limit.",
+}
+
+export default function PlacementPage() { return <PlacementLab /> }

--- a/components/game/build-influence-overlay.tsx
+++ b/components/game/build-influence-overlay.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo } from "react"
 import * as THREE from "three"
 import { getBuildInfluence } from "@/lib/game/build-influence"
 import { useBalanceStore } from "@/lib/game/balance-store"
+import type { GameBalance } from "@/lib/game/balance"
 import { groundHeight } from "@/lib/game/map/elevation"
 import { surfaceHeight, bridgeLayout, ropeHeightAt } from "@/lib/game/map/bridges"
 import { tileToWorldX, tileToWorldZ, type GameMap } from "@/lib/game/map/types"
@@ -15,8 +16,9 @@ import { buildTileError } from "@/lib/game/settlement"
  * The cursor separately validates the selected footprint, supplies and camp access.
  * @see https://app.paper.design/file/01M1QTYBYHXP4H1BXFQ79N18AP/2-0
  */
-export function BuildInfluenceOverlay({ map, buildMode }: { map: GameMap; buildMode: boolean }) {
-  const balance = useBalanceStore((s) => s.balance)
+export function BuildInfluenceOverlay({ map, buildMode, balance: labBalance }: { map: GameMap; buildMode: boolean; balance?: GameBalance }) {
+  const savedBalance = useBalanceStore((s) => s.balance)
+  const balance = labBalance ?? savedBalance
   const geometry = useMemo(() => {
     const field = getBuildInfluence(map, balance)
     const positions: number[] = [], colors: number[] = [], edges: number[] = []

--- a/components/game/camera-rig.tsx
+++ b/components/game/camera-rig.tsx
@@ -4,8 +4,7 @@ import { useEffect, useMemo, useRef } from "react"
 import { useFrame, useThree } from "@react-three/fiber"
 import * as THREE from "three"
 
-import { groundHeight } from "@/lib/game/map/elevation"
-import { surfaceHeight, ropeHeightAt } from "@/lib/game/map/bridges"
+import { marchToGround } from "@/lib/game/map/ground-pick"
 import { CameraGesture } from "@/lib/game/camera-gesture"
 import { cameraEdgePan } from "@/lib/game/camera-edge-pan"
 import { useBuildStore } from "@/lib/game/build-store"
@@ -73,30 +72,8 @@ export function CameraRig({ map, onPlace }: { map: GameMap; onPlace?: (at: TileP
       const ray = raycaster.current.ray
       const hit = ray.intersectPlane(pickPlane.current, hitPoint.current)
       if (!hit) { setHovered(null); return }
-      const start = hit.clone()
-      const minY = minPickY
-      const clearance = (p: THREE.Vector3) => {
-        const x = p.x + map.width / 2 - 0.5, z = p.z + map.depth / 2 - 0.5
-        const tx = Math.floor(x + 0.5), tz = Math.floor(z + 0.5)
-        if (tx < 0 || tz < 0 || tx >= map.width || tz >= map.depth) return Infinity
-        const y = ropeHeightAt(map, x, z) ?? surfaceHeight(map, tx, tz)
-        const ground = groundHeight(map, tx, tz)
-        return p.y - (Math.abs(y - ground) > 0.001 ? y : groundHeight(map, x, z))
-      }
-      for (let distance = 0; start.y + ray.direction.y * distance >= minY; distance += 0.15) {
-        hit.copy(start).addScaledVector(ray.direction, distance)
-        if (clearance(hit) > 0) continue
-        let lo = Math.max(0, distance - 0.15), hi = distance
-        for (let k = 0; k < 10; k++) {
-          const mid = (lo + hi) / 2
-          hit.copy(start).addScaledVector(ray.direction, mid)
-          if (clearance(hit) > 0) lo = mid; else hi = mid
-        }
-        hit.copy(start).addScaledVector(ray.direction, hi)
-        setHovered({ x: worldToTileX(map, hit.x), z: worldToTileZ(map, hit.z) })
-        return
-      }
-      setHovered(null)
+      const ground = marchToGround(map, hit.clone(), ray.direction, minPickY, hit)
+      setHovered(ground ? { x: worldToTileX(map, ground.x), z: worldToTileZ(map, ground.z) } : null)
     }
     refreshHover.current = updateHover
 

--- a/components/game/tile-cursor.tsx
+++ b/components/game/tile-cursor.tsx
@@ -12,7 +12,7 @@ import { groundHeight } from "@/lib/game/map/elevation"
 
 import { canAfford, placementError, type Resources } from "@/lib/game/settlement"
 import { useBalanceStore } from "@/lib/game/balance-store"
-import { buildCatalog } from "@/lib/game/balance"
+import { buildCatalog, type GameBalance } from "@/lib/game/balance"
 import { useCameraStore } from "@/lib/game/camera-store"
 import { surfaceHeight, ropeHeightAt } from "@/lib/game/map/bridges"
 import { tileAt, tileToWorldX, tileToWorldZ, type GameMap } from "@/lib/game/map/types"
@@ -29,13 +29,17 @@ export function TileCursor({
   buildType,
   resources,
   shrineRenown = 0,
+  balance: labBalance,
 }: {
   map: GameMap
   buildType?: string | null
   resources?: Resources
   shrineRenown?: number
+  /** Playgrounds validate against their own rules instead of the saved tuning. */
+  balance?: GameBalance
 }) {
-  const balance = useBalanceStore((s) => s.balance)
+  const savedBalance = useBalanceStore((s) => s.balance)
+  const balance = labBalance ?? savedBalance
   const requestedRotation = useBuildStore((s) => s.rotation)
   const hovered = useCameraStore((s) => s.hovered)
   const highlight = useMemo(() => {

--- a/components/placement-lab/placement-lab.tsx
+++ b/components/placement-lab/placement-lab.tsx
@@ -1,0 +1,137 @@
+"use client"
+
+import Link from "next/link"
+import dynamic from "next/dynamic"
+import { useEffect, useMemo, useState } from "react"
+import { LabSelect, LabSlider, labButton, labInput } from "@/components/lab-controls"
+import { buildCatalog, DEFAULT_BALANCE, RULE_FIELDS } from "@/lib/game/balance"
+import { useBuildStore } from "@/lib/game/build-store"
+import { useCameraStore } from "@/lib/game/camera-store"
+import { placementRoofRotation } from "@/lib/game/building-placement-layout"
+import { rotatedFootprint } from "@/lib/game/building-rotation"
+import { footprintGrading } from "@/lib/game/map/elevation"
+import { parseSeed, randomSeed } from "@/lib/game/rng"
+import { generateRelic } from "@/lib/game/relic"
+import { completeConstruction, createSettlement, placementError, purchaseStructure, settlementMap, type Settlement } from "@/lib/game/settlement"
+import { DEFAULT_PLACEMENT_LAB, PLACEMENT_LAB_LIMITS, normalizePlacementLab, placementLabBalance, placementLabMap, type PlacementLabSettings } from "@/lib/game/placement-lab"
+
+const PlacementScene = dynamic(() => import("./placement-scene").then(m => m.PlacementScene), { ssr: false })
+
+const LIMIT_FIELD = RULE_FIELDS.find(field => field.key === "levellingLimit")!
+const VIEW_NAMES = ["North-east", "North-west", "South-west", "South-east"]
+
+/** Hillside placement study: the real purchase rules with a tunable levelling limit,
+ * on a generated slope, so grading can be watched building by building. */
+export function PlacementLab() {
+  const [settings, setSettings] = useState<PlacementLabSettings>(DEFAULT_PLACEMENT_LAB)
+  const [draft, setDraft] = useState<PlacementLabSettings>(DEFAULT_PLACEMENT_LAB)
+  const [seedDraft, setSeedDraft] = useState(String(DEFAULT_PLACEMENT_LAB.seed))
+  const [limit, setLimit] = useState(DEFAULT_BALANCE.rules.levellingLimit)
+  const [view, setView] = useState(0)
+  const [grid, setGrid] = useState(true)
+  const [status, setStatus] = useState("")
+  const balance = useMemo(() => placementLabBalance(limit), [limit])
+  const baseMap = useMemo(() => placementLabMap(settings), [settings])
+  const relic = useMemo(() => generateRelic(settings.seed), [settings.seed])
+  const [settlement, setSettlement] = useState<Settlement>(() => createSettlement(balance))
+  const map = useMemo(() => settlementMap(baseMap, settlement), [baseMap, settlement])
+  const catalog = useMemo(() => buildCatalog(balance).filter(def => !def.retired), [balance])
+  const tool = useBuildStore(s => s.tool)
+  const rotation = useBuildStore(s => s.rotation)
+  const hovered = useCameraStore(s => s.hovered)
+  const def = catalog.find(item => item.id === tool) ?? null
+  useEffect(() => {
+    useBuildStore.getState().setTool("house")
+    return () => { useBuildStore.getState().setTool(null); useCameraStore.getState().setHovered(null) }
+  }, [])
+  const candidate = useMemo(() => {
+    if (!def || !hovered) return null
+    const snapped = placementRoofRotation(map, def, hovered, rotation)
+    return { grading: footprintGrading(map, { ...hovered, ...rotatedFootprint(def, snapped) }), error: placementError(map, def, hovered, balance, rotation) }
+  }, [map, def, hovered, rotation, balance])
+  const seed = parseSeed(seedDraft)
+  const pending = seed !== settings.seed || draft.relief !== settings.relief || draft.wavelength !== settings.wavelength
+  const apply = (newSeed: number) => {
+    const next = normalizePlacementLab({ ...draft, seed: newSeed })
+    setSettings(next); setDraft(next); setSeedDraft(String(next.seed))
+    setSettlement(createSettlement(balance))
+    setStatus(`Generated hillside ${next.seed}; buildings cleared.`)
+  }
+  const place = (at: { x: number; z: number }) => {
+    if (!def) return
+    const grading = candidate?.grading ?? footprintGrading(map, { ...at, ...rotatedFootprint(def, rotation) })
+    const result = purchaseStructure(settlement, baseMap, [], [relic], def.id, at, balance, 0, rotation)
+    if (result.error) { setStatus(result.error); return }
+    // The study is about the ground, so skip the building work itself.
+    setSettlement(completeConstruction(result.settlement))
+    setStatus(`${def.label} placed at ${at.x}, ${at.z}: cut ${grading.cut.toFixed(2)}, fill ${grading.fill.toFixed(2)}.`)
+  }
+  const undo = () => {
+    // Replay the remaining purchases so the terrain forgets the undone pad.
+    let next = createSettlement(balance)
+    for (const building of settlement.structures.slice(0, -1)) {
+      const result = purchaseStructure(next, baseMap, [], [relic], building.buildType!, building, balance, 0, building.rotation)
+      if (!result.error) next = result.settlement
+    }
+    setSettlement(completeConstruction(next)); setStatus("Last building removed.")
+  }
+  const placed = settlement.structures.length
+  const verdict = !def ? "Choose a structure." : !hovered ? "Hover the hillside to preview a pad." : candidate?.error ?? "Click to build and level the pad."
+  return <main className="min-h-screen bg-[#14100a] px-4 py-8 text-parchment sm:px-8">
+    <div className="mx-auto flex max-w-[1440px] flex-col gap-5">
+      <header>
+        <Link href="/assets" className="font-display text-[10px] uppercase tracking-[3px] text-gold hover:text-gold-light">← Assets</Link>
+        <h1 className="mt-4 font-display text-2xl font-semibold uppercase tracking-[4px] sm:text-3xl">Placement playground</h1>
+        <p className="mt-2 text-parchment-dark">Buildings no longer need perfectly level ground. A purchase cuts and fills its footprint to the height under its centre, as long as no tile or corner moves more than the levelling limit.</p>
+        <p className="mt-2 max-w-4xl text-sm text-parchment-dark">This study founds a hovel on generated hills and applies the game’s own purchase rules with unlimited supplies. The ghost turns red where the pad would move too much earth, break off as a cliff, or leave its entrance tile too far above or below the floor. The levelling limit here is the same rule as in Game tuning; the slider only changes this page.</p>
+      </header>
+      <section aria-label="Placement settings" className="border border-rule bg-parchment p-4 text-ink sm:p-5">
+        <div className="grid grid-cols-2 items-end gap-4 md:grid-cols-4">
+          <label className="flex flex-col gap-1 text-xs text-ink-light">Hillside seed<input className={labInput} value={seedDraft} inputMode="numeric" aria-invalid={seed === null}
+            onChange={e => setSeedDraft(e.target.value)} onKeyDown={e => { if (e.key === "Enter" && seed !== null) apply(seed) }} /></label>
+          <LabSlider label="Hill height" value={draft.relief} {...PLACEMENT_LAB_LIMITS.relief} onChange={relief => setDraft(old => ({ ...old, relief }))} />
+          <LabSlider label="Hill wavelength (tiles)" value={draft.wavelength} {...PLACEMENT_LAB_LIMITS.wavelength} onChange={wavelength => setDraft(old => ({ ...old, wavelength }))} />
+          <div className="flex flex-wrap gap-2">
+            <button type="button" className={labButton} disabled={seed === null} onClick={() => seed !== null && apply(seed)}>Generate</button>
+            <button type="button" className={labButton} onClick={() => apply((settings.seed + 1) >>> 0)}>Next seed</button>
+            <button type="button" className={labButton} onClick={() => apply(randomSeed())}>Random</button>
+          </div>
+          <LabSlider label={LIMIT_FIELD.label} value={limit} min={LIMIT_FIELD.min} max={LIMIT_FIELD.max} step={LIMIT_FIELD.step} onChange={setLimit} />
+          <LabSelect label="Structure" value={tool ?? ""} options={Object.fromEntries(catalog.map(def => [def.id, `${def.label} · ${def.w} × ${def.d}`]))} onChange={value => useBuildStore.getState().setTool(value)} />
+          <div className="flex flex-col gap-1 text-xs text-ink-light">Rotation · {rotation * 90}°
+            <div className="flex gap-2">
+              <button type="button" className={labButton} onClick={() => useBuildStore.getState().rotateBuilding(-1)}>↺ Left</button>
+              <button type="button" className={labButton} onClick={() => useBuildStore.getState().rotateBuilding(1)}>↻ Right</button>
+            </div>
+          </div>
+          <div className="flex flex-col gap-1 text-xs text-ink-light">View · {VIEW_NAMES[view]}
+            <div className="flex gap-2">
+              <button type="button" className={labButton} aria-label="Turn view left" onClick={() => setView(v => (v + 3) % 4)}>↺</button>
+              <button type="button" className={labButton} aria-label="Turn view right" onClick={() => setView(v => (v + 1) % 4)}>↻</button>
+              <button type="button" className={labButton} disabled={!placed} onClick={undo}>Undo</button>
+              <button type="button" className={labButton} disabled={!placed} onClick={() => { setSettlement(createSettlement(balance)); setStatus("Buildings cleared.") }}>Clear</button>
+            </div>
+          </div>
+        </div>
+        <p className="mt-3 text-xs text-ink-light">{pending ? "Terrain changed — generate to rebuild the hillside. This clears placed buildings." : `Showing hillside ${settings.seed} with ${placed} placed ${placed === 1 ? "building" : "buildings"}.`} The default limit is {LIMIT_FIELD.default}; the game rejects placements above it with the same message shown here.</p>
+      </section>
+      <div className="flex flex-wrap items-center gap-4 text-sm">
+        <label className="flex items-center gap-2"><input type="checkbox" className="accent-gold" checked={grid} onChange={e => setGrid(e.target.checked)} />Show tile grid</label>
+        <span className="text-xs text-parchment-dark">Green pad = the purchase would level here. Red = refused for the reason shown below.</span>
+      </div>
+      <p role="status" className="text-sm text-parchment-dark">{status || "Hover to preview, click to place."}</p>
+      <div className="relative h-[560px] w-full border border-rule bg-[#14100a]">
+        <PlacementScene map={map} relic={relic} balance={balance} buildType={tool} resources={settlement.resources} view={view} grid={grid} onPlace={place} />
+      </div>
+      <dl className="grid grid-cols-2 gap-x-3 gap-y-2 border border-rule bg-parchment p-4 text-xs text-ink md:grid-cols-5" aria-label="Pad under the cursor">
+        {[["Tile", hovered ? `${hovered.x}, ${hovered.z}` : "—"],
+          ["Floor height", candidate ? candidate.grading.foundation.toFixed(2) : "—"],
+          ["Deepest cut", candidate ? candidate.grading.cut.toFixed(2) : "—"],
+          ["Tallest fill", candidate ? candidate.grading.fill.toFixed(2) : "—"],
+          ["Verdict", verdict]].map(([label, value]) =>
+          <div key={label}><dt className="text-ink-light">{label}</dt><dd className="mt-1 font-semibold tabular-nums">{value}</dd></div>)}
+      </dl>
+      <p className="text-xs text-parchment-dark">Heights are in tile units relative to the map base. Cut and fill measure the highest and lowest footprint tile or corner against the floor. A pad also needs every neighbouring tile within the cliff cutoff of the floor, or the graded edge would break off as a cliff. Existing pads and water never move.</p>
+    </div>
+  </main>
+}

--- a/components/placement-lab/placement-scene.tsx
+++ b/components/placement-lab/placement-scene.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import { Suspense, useEffect, useMemo, useRef } from "react"
+import { useThree, type ThreeEvent } from "@react-three/fiber"
+import * as THREE from "three"
+import { PixelCanvas } from "@/components/pixel-canvas"
+import { TerrainTiles } from "@/components/game/terrain-tiles"
+import { Buildings } from "@/components/game/buildings"
+import { Shrine } from "@/components/game/shrine"
+import { TileCursor } from "@/components/game/tile-cursor"
+import { BuildInfluenceOverlay } from "@/components/game/build-influence-overlay"
+import { OutlinePass } from "@/components/game/outline-pass"
+import { SURFACE_LIGHT } from "@/lib/game/render/lighting"
+import { CAM_FAR, CAM_NEAR, cameraOffset, lightOffsetForYaw, yawForView } from "@/lib/game/render/iso"
+import { TILE_HEIGHT } from "@/lib/game/map/terrain"
+import { marchToGround } from "@/lib/game/map/ground-pick"
+import { useCameraStore } from "@/lib/game/camera-store"
+import type { GameBalance } from "@/lib/game/balance"
+import type { Resources } from "@/lib/game/settlement"
+import type { Relic } from "@/lib/game/relic"
+import { worldToTileX, worldToTileZ, type GameMap, type TilePos } from "@/lib/game/map/types"
+
+/** The whole study fits the viewport from any of the game's four isometric views. */
+function LabCamera({ view, extent }: { view: number; extent: number }) {
+  const { camera, size, invalidate } = useThree()
+  useEffect(() => {
+    camera.position.set(...cameraOffset(yawForView(view)))
+    camera.position.y += TILE_HEIGHT
+    camera.lookAt(0, TILE_HEIGHT, 0)
+    if (camera instanceof THREE.OrthographicCamera) camera.zoom = Math.min(size.width / (extent * 1.5), size.height / (extent * 0.85))
+    camera.updateProjectionMatrix()
+    camera.updateMatrixWorld()
+    invalidate()
+  }, [camera, size, view, extent, invalidate])
+  return null
+}
+
+/**
+ * Hover and click land on the tile under the true terrain surface, using the
+ * game's own ray march, so slopes and levelled pads pick where they are drawn.
+ */
+function GroundPicker({ map, ceiling, onPlace }: { map: GameMap; ceiling: number; onPlace: (at: TilePos) => void }) {
+  const setHovered = useCameraStore(s => s.setHovered)
+  const hit = useRef(new THREE.Vector3())
+  const pick = (event: ThreeEvent<PointerEvent | MouseEvent>): TilePos | null => {
+    const ground = marchToGround(map, event.point.clone(), event.ray.direction, -1, hit.current)
+    return ground ? { x: worldToTileX(map, ground.x), z: worldToTileZ(map, ground.z) } : null
+  }
+  return <mesh position={[0, ceiling, 0]} rotation={[-Math.PI / 2, 0, 0]}
+    onPointerMove={event => setHovered(pick(event))}
+    onPointerOut={() => setHovered(null)}
+    onClick={event => {
+      if (event.delta > 6) return
+      event.stopPropagation()
+      const tile = pick(event)
+      if (tile) onPlace(tile)
+    }}>
+    <planeGeometry args={[map.width + 80, map.depth + 80]} />
+    <meshBasicMaterial transparent opacity={0} depthWrite={false} colorWrite={false} />
+  </mesh>
+}
+
+/** The playground's live world: game terrain, the founded hovel, purchases so far and the placement ghost. */
+export function PlacementScene({ map, relic, balance, buildType, resources, view, grid, onPlace }: {
+  map: GameMap; relic: Relic; balance: GameBalance; buildType: string | null; resources: Resources
+  view: number; grid: boolean; onPlace: (at: TilePos) => void
+}) {
+  const ceiling = useMemo(() => TILE_HEIGHT + (map.elevation?.height.reduce((a, b) => Math.max(a, b), 0) ?? 0) + 1, [map.elevation])
+  return <PixelCanvas frameloop="demand" orthographic camera={{ near: CAM_NEAR, far: CAM_FAR }} outputDpr={1} fallback={<p>This playground needs WebGL.</p>}>
+    <color attach="background" args={["#14100a"]} />
+    <LabCamera view={view} extent={Math.max(map.width, map.depth)} />
+    <ambientLight intensity={SURFACE_LIGHT.ambient} />
+    <hemisphereLight args={[SURFACE_LIGHT.sky, SURFACE_LIGHT.ground, SURFACE_LIGHT.hemisphere]} />
+    <directionalLight position={lightOffsetForYaw(yawForView(view))} intensity={SURFACE_LIGHT.sun} />
+    <Suspense fallback={null}>
+      <TerrainTiles map={map} showGrid={grid} />
+      <Shrine map={map} relic={relic} />
+      <Buildings map={map} />
+      <TileCursor map={map} buildType={buildType} resources={resources} shrineRenown={1000} balance={balance} />
+      <BuildInfluenceOverlay map={map} buildMode={!!buildType} balance={balance} />
+      <GroundPicker map={map} ceiling={ceiling} onPlace={onPlace} />
+    </Suspense>
+    <OutlinePass objects={{ buildings: map.buildings, travelers: [], monks: [] }} />
+  </PixelCanvas>
+}

--- a/lib/game/balance.ts
+++ b/lib/game/balance.ts
@@ -254,6 +254,17 @@ export const RULE_FIELDS = [
     step: 1,
   },
   {
+    key: "levellingLimit",
+    group: "Treasury & construction",
+    label: "Ground levelling limit (height units)",
+    description:
+      "Placing a building cuts and fills its footprint to the ground height under its centre, where the placement ghost sits. Construction is refused where any footprint tile or corner would move more than this, where the graded pad would break off as a cliff, or where an entrance tile differs from the floor by more than this.",
+    default: 0.4,
+    min: 0,
+    max: 1,
+    step: 0.05,
+  },
+  {
     key: "residentGold",
     group: "Resident income",
     label: "Gold per resident",
@@ -662,6 +673,7 @@ export function importBalance(json: string): ReturnType<typeof validateBalance> 
         staminaDecay: DEFAULT_BALANCE.rules.staminaDecay,
         hospitalityNeedThreshold: DEFAULT_BALANCE.rules.hospitalityNeedThreshold,
         hospitalityRenownBonus: DEFAULT_BALANCE.rules.hospitalityRenownBonus,
+        levellingLimit: DEFAULT_BALANCE.rules.levellingLimit,
         ...rules,
         // Adopt slower defaults in old saves without overwriting custom rates.
         ...((version < 4 && rules.hungerDecay === 12.5 || version < 5 && rules.hungerDecay === 3 || version < 7 && rules.hungerDecay === 1.5) ? { hungerDecay: DEFAULT_BALANCE.rules.hungerDecay } : {}),

--- a/lib/game/map/elevation.test.ts
+++ b/lib/game/map/elevation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { DEFAULT_ELEVATION, elevationSettings, elevationStep, finishElevation, generateElevation, groundHeight, levelBuildingGround } from "./elevation"
+import { DEFAULT_ELEVATION, elevationSettings, elevationStep, finishElevation, footprintGrading, generateElevation, groundHeight, levelBuildingGround } from "./elevation"
 import { drainWater } from "./hydrology"
 import { generateMap } from "./generate-map"
 import { routeBlind } from "./route"
@@ -71,6 +71,29 @@ describe("topography", () => {
       expect(graded.elevation.slope[building.z * width + building.x]).not.toBe(elevation.slope[building.z * width + building.x])
     },
   )
+
+  it("previews the cut, fill and cliff risk of grading a footprint, matching what levelling then does", () => {
+    const width = 8, depth = 8, water = new Uint8Array(width * depth)
+    const flat: GameMap = { width, depth, tiles: Array(64).fill("grass"), buildings: [] }
+    expect(footprintGrading(flat, { x: 2, z: 2, w: 2, d: 2 })).toEqual({ foundation: 0, cut: 0, fill: 0, cliff: false })
+    const elevation = generateElevation(1, width, depth, water)
+    elevation.height = elevation.height.map((_, i) => (i % width) * 0.1)
+    finishElevation(elevation, width, depth, water, [])
+    const map: GameMap = { width, depth, tiles: Array(64).fill("grass"), buildings: [], elevation }
+    const plot = { x: 2, z: 2, w: 3, d: 2 }
+    const grading = footprintGrading(map, plot)
+    expect(grading.foundation).toBeCloseTo(0.3)
+    // Corners reach half a tile beyond the outer tile centres: 0.1 to the tile, 0.05 more to its corner.
+    expect(grading.cut).toBeCloseTo(0.15); expect(grading.fill).toBeCloseTo(0.15); expect(grading.cliff).toBe(false)
+    const graded = { ...map, elevation: levelBuildingGround(map, plot)! }
+    expect(footprintGrading(graded, plot)).toMatchObject({ foundation: 0.3, cut: 0, fill: 0, cliff: false })
+    expect(footprintGrading(graded, plot).cut).toBe(0)
+    // The neighbouring column to the east stands 0.7 above the pad once graded: a cliff.
+    elevation.height = elevation.height.map((_, i) => (i % width) >= 5 ? 1 : 0.3)
+    finishElevation(elevation, width, depth, water, [])
+    expect(footprintGrading(map, plot).cliff).toBe(true)
+    expect(footprintGrading(map, { ...plot, x: 1 }).cliff).toBe(false)
+  })
 
   it("preserves water, distant terrain, and an existing foundation beside a later purchase", () => {
     const width = 8, depth = 8, water = new Uint8Array(64)

--- a/lib/game/map/elevation.ts
+++ b/lib/game/map/elevation.ts
@@ -190,10 +190,7 @@ export function levelBuildingGround(map: GameMap, building: Pick<BuildingDef, "x
   const original = map.elevation
   if (!original) return undefined
   const { x, z, w, d } = building
-  let foundation = groundHeight(map, x + (w - 1) / 2, z + (d - 1) / 2) - TILE_HEIGHT
-  const corner = original.corners[(z * map.width + x) * 4]
-  // Adding/subtracting TILE_HEIGHT can round an already flat foundation.
-  if (Math.abs(foundation - corner) < 1e-12) foundation = corner
+  const foundation = padFoundation(map, building)
   // Most shrine plots are already level. Keep their buffers (and all readers'
   // caches) intact; copy only the arrays that grading actually changes.
   const elevation = { ...original }
@@ -245,6 +242,55 @@ export function levelBuildingGround(map: GameMap, building: Pick<BuildingDef, "x
     }
   }
   return elevation
+}
+
+/** The pad height a footprint grades to: the ground under its centre, where the placement ghost floats. */
+function padFoundation(map: GameMap, { x, z, w, d }: Pick<BuildingDef, "x" | "z" | "w" | "d">): number {
+  const foundation = groundHeight(map, x + (w - 1) / 2, z + (d - 1) / 2) - TILE_HEIGHT
+  const corner = map.elevation!.corners[(z * map.width + x) * 4]
+  // Adding/subtracting TILE_HEIGHT can round an already flat foundation.
+  return Math.abs(foundation - corner) < 1e-12 ? corner : foundation
+}
+
+export interface FootprintGrading {
+  /** Pad height relative to base, as `levelBuildingGround` would set it. */
+  foundation: number
+  /** Deepest cut: how far the highest tile or corner stands above the pad. */
+  cut: number
+  /** Tallest fill: how far the lowest tile or corner lies below the pad. */
+  fill: number
+  /** The graded pad would meet a neighbouring tile at a cliff step. */
+  cliff: boolean
+}
+
+/**
+ * What levelling a footprint would do before it is done: the earth to move
+ * and whether the pad edge would break off as a cliff. Level ground reports
+ * no cut or fill, and a map without elevation is level everywhere.
+ */
+export function footprintGrading(map: GameMap, building: Pick<BuildingDef, "x" | "z" | "w" | "d">): FootprintGrading {
+  const e = map.elevation
+  if (!e) return { foundation: 0, cut: 0, fill: 0, cliff: false }
+  const { x, z, w, d } = building
+  const foundation = padFoundation(map, building)
+  const wet = (i: number) => map.water ? map.water.depth[i] > 0 : isWaterTerrain(map.tiles[i])
+  const surface = (i: number) => wet(i) ? (map.water?.surface ?? e.height)[i] : e.height[i]
+  let cut = 0, fill = 0, cliff = false
+  for (let tz = z; tz < z + d; tz++) for (let tx = x; tx < x + w; tx++) {
+    if (tx < 0 || tz < 0 || tx >= map.width || tz >= map.depth) continue
+    const i = tz * map.width + tx
+    for (let k = 0; k < 5; k++) {
+      const h = k === 0 ? e.height[i] : e.corners[i * 4 + k - 1]
+      cut = Math.max(cut, h - foundation); fill = Math.max(fill, foundation - h)
+    }
+    for (const [dx, dz] of ROUTE_DIRS) {
+      const nx = tx + dx, nz = tz + dz
+      if (nx < 0 || nz < 0 || nx >= map.width || nz >= map.depth) continue
+      if (nx >= x && nx < x + w && nz >= z && nz < z + d) continue
+      if (Math.abs(surface(nz * map.width + nx) - foundation) >= e.settings.cliffThreshold) cliff = true
+    }
+  }
+  return { foundation, cut, fill, cliff }
 }
 
 export function elevationStep(e: ElevationInfo | undefined, a: number, b: number): number {

--- a/lib/game/map/ground-pick.ts
+++ b/lib/game/map/ground-pick.ts
@@ -1,0 +1,36 @@
+import type * as THREE from "three"
+import { groundHeight } from "./elevation"
+import { ropeHeightAt, surfaceHeight } from "./bridges"
+import type { GameMap } from "./types"
+
+/** Ray-march step in world units; the binary refinement below lands within a texel. */
+const STEP = 0.15
+
+/**
+ * Walk a pick ray down onto the terrain, or onto a bridge deck riding above
+ * it, from `start` along `direction`. Returns the surface point, or null once
+ * the ray drops below `minY` without touching the map. Terrain heights vary
+ * across every tile, so a flat picking plane would misplace slopes and decks.
+ */
+export function marchToGround(map: GameMap, start: THREE.Vector3, direction: THREE.Vector3, minY: number, hit: THREE.Vector3): THREE.Vector3 | null {
+  const clearance = (p: THREE.Vector3) => {
+    const x = p.x + map.width / 2 - 0.5, z = p.z + map.depth / 2 - 0.5
+    const tx = Math.floor(x + 0.5), tz = Math.floor(z + 0.5)
+    if (tx < 0 || tz < 0 || tx >= map.width || tz >= map.depth) return Infinity
+    const y = ropeHeightAt(map, x, z) ?? surfaceHeight(map, tx, tz)
+    const ground = groundHeight(map, tx, tz)
+    return p.y - (Math.abs(y - ground) > 0.001 ? y : groundHeight(map, x, z))
+  }
+  for (let distance = 0; start.y + direction.y * distance >= minY; distance += STEP) {
+    hit.copy(start).addScaledVector(direction, distance)
+    if (clearance(hit) > 0) continue
+    let lo = Math.max(0, distance - STEP), hi = distance
+    for (let k = 0; k < 10; k++) {
+      const mid = (lo + hi) / 2
+      hit.copy(start).addScaledVector(direction, mid)
+      if (clearance(hit) > 0) lo = mid; else hi = mid
+    }
+    return hit.copy(start).addScaledVector(direction, hi)
+  }
+  return null
+}

--- a/lib/game/placement-lab.test.ts
+++ b/lib/game/placement-lab.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+import { DEFAULT_BALANCE } from "./balance"
+import { footprintGrading, groundHeight } from "./map/elevation"
+import { generateRelic } from "./relic"
+import { createSettlement, placementError, purchaseStructure, settlementMap } from "./settlement"
+import { buildCatalog } from "./balance"
+import { DEFAULT_PLACEMENT_LAB, normalizePlacementLab, placementLabBalance, placementLabMap } from "./placement-lab"
+
+describe("placement playground", () => {
+  it("founds a hillside study where the real purchase rules can grade ground", () => {
+    const map = placementLabMap(DEFAULT_PLACEMENT_LAB)
+    const balance = placementLabBalance(DEFAULT_BALANCE.rules.levellingLimit)
+    const hovel = map.buildings[0]
+    expect(map.site?.hovelId).toBe(hovel.id)
+    expect(map.tiles[map.site!.door.z * map.width + map.site!.door.x]).toBe("track")
+    expect(map.road?.every(tile => map.tiles[tile.z * map.width + tile.x] === "path")).toBe(true)
+    expect(footprintGrading(map, hovel)).toMatchObject({ cut: 0, fill: 0, cliff: false })
+    expect(map.elevation!.height.some(h => h > 0.5)).toBe(true)
+    const house = buildCatalog(balance).find(def => def.id === "house")!
+    const relic = generateRelic(map.seed!)
+    let settlement = createSettlement(balance), graded = 0, refused = 0
+    for (let z = 2; z < map.depth - 6; z += 3) for (let x = 2; x < map.width - 3; x += 3) {
+      const live = settlementMap(map, settlement)
+      const grading = footprintGrading(live, { x, z, ...house })
+      const error = placementError(live, house, { x, z }, balance)
+      if (error) { refused++; continue }
+      const result = purchaseStructure(settlement, map, [], [relic], house.id, { x, z }, balance)
+      expect(result.error).toBeNull()
+      settlement = result.settlement
+      if (Math.max(grading.cut, grading.fill) > 0.01) graded++
+      const placed = settlementMap(map, settlement)
+      for (let dz = 0; dz < house.d; dz++) for (let dx = 0; dx < house.w; dx++)
+        expect(groundHeight(placed, x + dx, z + dz)).toBeCloseTo(grading.foundation + 0.2)
+    }
+    expect(graded).toBeGreaterThan(0)
+    expect(refused).toBeGreaterThan(0)
+  })
+
+  it("clamps terrain settings to the study's ranges", () => {
+    expect(normalizePlacementLab({ seed: 4.7, relief: 9, wavelength: 1 })).toEqual({ seed: 4, relief: 2.4, wavelength: 8 })
+    expect(normalizePlacementLab({})).toEqual(DEFAULT_PLACEMENT_LAB)
+  })
+})

--- a/lib/game/placement-lab.ts
+++ b/lib/game/placement-lab.ts
@@ -1,0 +1,76 @@
+import { DEFAULT_BALANCE, type GameBalance } from "./balance"
+import { buildingPreviewBalance } from "./building-preview"
+import { finishElevation, generateElevation } from "./map/elevation"
+import { HOVEL_DEPTH, HOVEL_ID, HOVEL_WIDTH } from "./map/generate-map"
+import type { BuildingDef, GameMap, TilePos } from "./map/types"
+import type { TerrainId } from "./map/terrain"
+
+/** Terrain controls for the placement playground; heights are in tile units. */
+export interface PlacementLabSettings {
+  seed: number
+  /** Maximum hill height, the elevation generator's `maxHeight`. */
+  relief: number
+  /** Hill wavelength in tiles, the elevation generator's `scale`. */
+  wavelength: number
+}
+
+export const PLACEMENT_LAB_SIZE = 36
+export const DEFAULT_PLACEMENT_LAB: PlacementLabSettings = { seed: 7919, relief: 2.4, wavelength: 12 }
+export const PLACEMENT_LAB_LIMITS = {
+  relief: { min: 0, max: 2.4, step: 0.1 },
+  wavelength: { min: 8, max: 40, step: 1 },
+} as const
+
+export function normalizePlacementLab(input: Partial<PlacementLabSettings>): PlacementLabSettings {
+  const clamp = (value: number | undefined, fallback: number, range: { min: number; max: number }) =>
+    value !== undefined && Number.isFinite(value) ? Math.max(range.min, Math.min(range.max, value)) : fallback
+  return {
+    seed: input.seed !== undefined && Number.isFinite(input.seed) ? Math.floor(input.seed) >>> 0 : DEFAULT_PLACEMENT_LAB.seed,
+    relief: clamp(input.relief, DEFAULT_PLACEMENT_LAB.relief, PLACEMENT_LAB_LIMITS.relief),
+    wavelength: clamp(input.wavelength, DEFAULT_PLACEMENT_LAB.wavelength, PLACEMENT_LAB_LIMITS.wavelength),
+  }
+}
+
+/** Free construction anywhere on the study map, with the tuned levelling limit under test. */
+export function placementLabBalance(levellingLimit: number, base: GameBalance = DEFAULT_BALANCE): GameBalance {
+  const balance = buildingPreviewBalance(base)
+  return { ...balance, rules: { ...balance.rules, levellingLimit } }
+}
+
+/**
+ * A founded hillside study: open grass over generated hills, the founding
+ * hovel on a levelled pad, its branch running south to a road along the
+ * bottom edge. Every purchase rule of the real game applies, so the playground
+ * exercises exactly the grading the settlement would do.
+ */
+export function placementLabMap(input: PlacementLabSettings = DEFAULT_PLACEMENT_LAB): GameMap {
+  const { seed, relief, wavelength } = normalizePlacementLab(input)
+  const width = PLACEMENT_LAB_SIZE, depth = PLACEMENT_LAB_SIZE
+  const tiles: TerrainId[] = Array(width * depth).fill("grass")
+  const hovel: BuildingDef = {
+    id: HOVEL_ID, label: "Founding hovel",
+    x: Math.floor(width / 2) - Math.floor(HOVEL_WIDTH / 2), z: 6, w: HOVEL_WIDTH, d: HOVEL_DEPTH,
+    height: 0.6, color: "#b99a72", roofColor: "#855642",
+  }
+  const roadZ = depth - 3
+  const door: TilePos = { x: hovel.x + Math.floor(hovel.w / 2), z: hovel.z + hovel.d }
+  const road = Array.from({ length: width }, (_, x) => ({ x, z: roadZ }))
+  for (const tile of road) tiles[tile.z * width + tile.x] = "path"
+  const branch: TilePos[] = []
+  for (let z = roadZ; z >= door.z; z--) branch.push({ x: door.x, z })
+  for (const tile of branch.slice(1)) tiles[tile.z * width + tile.x] = "track"
+  const water = new Uint8Array(width * depth)
+  // Rolling ground without the world's lowland bias or escarpments: cliffs
+  // are never buildable, so only slopes teach anything here.
+  const elevation = generateElevation(seed, width, depth, water, { maxHeight: relief, scale: wavelength, power: 1, cliffHeight: 0 })
+  // Found the hovel on a level pad with a grass margin, as world generation does.
+  const foundation = elevation.height[hovel.z * width + hovel.x]
+  for (let z = hovel.z - 1; z <= hovel.z + hovel.d; z++) for (let x = hovel.x - 1; x <= hovel.x + hovel.w; x++) {
+    elevation.height[z * width + x] = foundation
+  }
+  finishElevation(elevation, width, depth, water, [])
+  return {
+    width, depth, tiles, seed, buildings: [hovel], road, elevation,
+    site: { hovelId: HOVEL_ID, junction: door.x, door, branch },
+  }
+}

--- a/lib/game/settlement.test.ts
+++ b/lib/game/settlement.test.ts
@@ -2,9 +2,10 @@ import { placementBuildingLayout } from "./building-placement-layout"
 import { settlementRoute } from "./settlement-route"
 import { buildingApproaches, buildingEntry, rotatedFootprint, type BuildingRotation } from "./building-rotation"
 import { getBuildInfluence } from "./build-influence"
-import { DEFAULT_ELEVATION, finishElevation, generateElevation, groundHeight } from "./map/elevation"
+import { DEFAULT_ELEVATION, finishElevation, footprintGrading, generateElevation, groundHeight } from "./map/elevation"
 import { describe, expect, it } from "vitest"
 import { generateMap } from "./map/generate-map"
+import { DEFAULT_BALANCE } from "./balance"
 import { tileToWorldX, tileToWorldZ, type GameMap, type TilePos } from "./map/types"
 import { createFootpaths, recordWalkingPath } from "./footpaths"
 import { generateMonks } from "./monks"
@@ -241,7 +242,37 @@ describe("build and buy", () => {
     expect(placementError(map, house, { x: 11, z: 14 })).toMatch(/cliffs/)
     map.elevation.cliffs[i] = 0
     map.elevation.corners.fill(0.4, (i + 1) * 4, (i + 2) * 4)
-    expect(placementError(map, house, { x: 11, z: 14 })).toMatch(/level ground/)
+    expect(placementError(map, house, { x: 11, z: 14 })).toBeNull()
+    map.elevation.corners.fill(0.9, (i + 1) * 4, (i + 2) * 4)
+    expect(placementError(map, house, { x: 11, z: 14 })).toMatch(/earth to move/)
+  })
+
+  it("levels sloping ground within the tuned limit and refuses steeper pads or cliff edges", () => {
+    const map = testMap(), water = new Uint8Array(map.tiles.length)
+    map.elevation = generateElevation(1, map.width, map.depth, water)
+    // A steady grade across the map: a 2 × 2 home's outer corners sit 0.12 above and below its centre.
+    map.elevation.height = map.elevation.height.map((_, i) => (i % map.width) * 0.12)
+    finishElevation(map.elevation, map.width, map.depth, water, [])
+    const at = { x: 8, z: 14 }
+    const grading = footprintGrading(map, { ...at, ...house })
+    expect(grading.cut).toBeCloseTo(0.12); expect(grading.fill).toBeCloseTo(0.12); expect(grading.cliff).toBe(false)
+    const tuned = (levellingLimit: number) => ({ ...DEFAULT_BALANCE, rules: { ...DEFAULT_BALANCE.rules, levellingLimit } })
+    expect(placementError(map, house, at, tuned(0.15))).toBeNull()
+    expect(placementError(map, house, at, tuned(0.1))).toMatch(/earth to move/)
+    const bought = purchaseStructure({ ...createSettlement(), resources: { gold: 1000, wood: 1000 } }, map, monks, [relic], house.id, at, tuned(0.15))
+    expect(bought.error).toBeNull()
+    const placedMap = { ...map, elevation: bought.settlement.elevation }
+    for (let z = at.z; z < at.z + house.d; z++) for (let x = at.x; x < at.x + house.w; x++)
+      expect(groundHeight(placedMap, x, z)).toBeCloseTo(grading.foundation + 0.2)
+    expect(footprintGrading(placedMap, { ...at, ...house })).toMatchObject({ cut: 0, fill: 0 })
+    // Terraces just under the cliff cutoff: cutting the pad down to its centre
+    // height would leave the upper terrace standing over it as a cliff.
+    const steep = testMap(), steepWater = new Uint8Array(steep.tiles.length)
+    steep.elevation = generateElevation(1, steep.width, steep.depth, steepWater)
+    steep.elevation.height = steep.elevation.height.map((_, i) => (i % steep.width) >= 13 ? 0.95 : (i % steep.width) === 12 ? 0.35 : 0)
+    finishElevation(steep.elevation, steep.width, steep.depth, steepWater, [])
+    expect(footprintGrading(steep, { x: 11, z: 14, ...house }).cliff).toBe(true)
+    expect(placementError(steep, house, { x: 11, z: 14 }, tuned(1))).toMatch(/cliff at the edge/)
   })
 
   it("pays once on successful placement, retaining the base map and founding supplies", () => {

--- a/lib/game/settlement.ts
+++ b/lib/game/settlement.ts
@@ -2,13 +2,13 @@ import { innPlacementError } from "./inn"
 import { buildingEntrance, constructionWork, isComplete } from "./construction"
 import { placementBuildingLayout, placementRoofRotation } from "./building-placement-layout"
 import { rotatedFootprint, buildingEntry, buildingApproaches, type BuildingRotation } from "./building-rotation"
-import { groundHeight, levelBuildingGround } from "./map/elevation"
+import { footprintGrading, groundHeight, levelBuildingGround } from "./map/elevation"
 import { buildingKind, placementProblem, PLACEMENT_PROBLEM_LABELS, type PlacedBuilding } from "./buildings"
 import { settlementRoute, shrineRoadHead } from "./settlement-route"
 import { buildInfluence, getBuildInfluence, type BuildInfluence } from "./build-influence"
 import type { SimState } from "./sim"
 import { DEFAULT_ADMISSION_FEE } from "./shrine-visit"
-import { TERRAIN } from "./map/terrain"
+import { TERRAIN, TILE_HEIGHT } from "./map/terrain"
 import { establishedFootpath } from "./footpaths"
 import { tileAt, type BuildingDef, type GameMap, type TilePos } from "./map/types"
 import type { Monk } from "./monks"
@@ -291,7 +291,7 @@ export function placementError(
   const known = verdicts.get(key), revision = map.footpaths?.revision ?? 0
   if (known && known.buildings === map.buildings && known.count === map.buildings.length && known.revision === revision) return known.verdict
   if (verdicts.size >= 512) verdicts.clear()
-  const verdict = validateAccess(map, def, at, rotation)
+  const verdict = validateAccess(map, def, at, balance, rotation)
   verdicts.set(key, { buildings: map.buildings, count: map.buildings.length, revision, verdict })
   return verdict
 }
@@ -308,9 +308,12 @@ function validateFootprint(map: GameMap, def: BuildDefinition, at: TilePos, bala
     for (let x = at.x; x < at.x + footprint.w; x++) {
       const error = buildTileError(map, x, z, influence)
       if (error) return error
-      if (map.elevation && Math.abs(groundHeight(map, x, z) - groundHeight(map, at.x, at.z)) > 0.2) return "Choose level ground away from cliffs."
     }
   }
+  // Uneven ground is cut and filled on purchase, up to the tuned limit.
+  const grading = footprintGrading(map, { ...at, ...footprint })
+  if (grading.cliff) return "Levelling here would leave a cliff at the edge; choose gentler ground."
+  if (Math.max(grading.cut, grading.fill) > balance.rules.levellingLimit + 1e-9) return "Too much earth to move; choose gentler ground."
   if (def.id === "workshop") {
     const problem = placementProblem(map, map.buildings, "workshop", at.x, at.z, rotation)
     if (problem) return PLACEMENT_PROBLEM_LABELS[problem]
@@ -319,9 +322,11 @@ function validateFootprint(map: GameMap, def: BuildDefinition, at: TilePos, bala
 }
 
 /** Reserve construction frontage and preserve access to every existing building. */
-function validateAccess(map: GameMap, def: BuildDefinition, at: TilePos, rotation: BuildingRotation): string | null {
+function validateAccess(map: GameMap, def: BuildDefinition, at: TilePos, balance: GameBalance, rotation: BuildingRotation): string | null {
   const footprint = rotatedFootprint(def, rotation)
   if (map.site) {
+    // The threshold is measured against the graded floor, not today's ground.
+    const floor = footprintGrading(map, { ...at, ...footprint }).foundation + TILE_HEIGHT
     const candidate = { buildType: def.id, ...def, ...footprint, rotation, ...at, ...placementBuildingLayout(map,{...def,...footprint,rotation,...at,buildType:def.id,id:"construction-preview"}), id: "construction-preview", construction: { work: 0, required: 1 } }
     const approaches=buildingApproaches(map,candidate)
     for(const approach of approaches) {
@@ -329,7 +334,7 @@ function validateAccess(map: GameMap, def: BuildDefinition, at: TilePos, rotatio
       if(!terrain || !TERRAIN[terrain].passable || buildingAt(map,approach.x,approach.z)
         || (map.water?.depth[approach.z*map.width+approach.x] ?? 0)>0)
         return "Keep access clear with a path tile outside the entrance."
-      if(Math.abs(groundHeight(map,approach.x,approach.z)-groundHeight(map,at.x,at.z))>.2)
+      if(Math.abs(groundHeight(map,approach.x,approach.z)-floor)>balance.rules.levellingLimit+1e-9)
         return "The entrance path needs level ground."
     }
     const occupied = [...map.buildings, candidate]

--- a/lib/site-menu.ts
+++ b/lib/site-menu.ts
@@ -20,6 +20,7 @@ export const SITE_MENU: SiteMenuItem[] = [
       { label: "Playground", description: "Characters, animals & buildings", href: "/assets/characters" },
       { label: "Path playgrounds", description: "Traffic, regrowth & settlement paths", href: "/assets/paths" },
       { label: "Map playground", description: "Compare meadows, groves & connected clearings", href: "/assets/maps" },
+      { label: "Placement playground", description: "Level hillsides under new buildings", href: "/assets/placement" },
       { label: "Pixel workshop", description: "Compare rendering methods in motion", href: "/assets/rendering" },
     ],
   },


### PR DESCRIPTION
## Summary

Buildings no longer need perfectly level ground. A purchase now cuts and fills its footprint to the ground height under its centre (where the placement ghost already floats), as long as no tile or corner moves more than the new **Ground levelling limit** balance rule (default 0.4 height units, range 0–1). Placement is refused where the graded pad would break off as a cliff, or where an entrance tile differs from the floor by more than the limit.

- `footprintGrading` (lib/game/map/elevation.ts) previews the pad height, deepest cut, tallest fill and cliff risk, sharing its foundation maths with `levelBuildingGround` so preview and grade always agree.
- `validateFootprint` / `validateAccess` (lib/game/settlement.ts) use the grading and the tuned limit instead of the old fixed 0.2 spread.
- The new rule shows on the tuning page and the game-specs rule table automatically; old saved presets get the default merged in.
- The hover ray march moved from `camera-rig.tsx` into `lib/game/map/ground-pick.ts`; `TileCursor` and `BuildInfluenceOverlay` accept a balance override for playgrounds.

## Placement playground

`/assets/placement` (listed under Assets) founds a hovel on a generated hillside and runs the real purchase path with unlimited supplies. Controls: seed, hill height, wavelength, levelling limit, structure, rotation, view, undo, clear. A panel under the canvas shows the hovered tile, floor height, deepest cut, tallest fill and the exact verdict the game would give.

## Test plan

- [x] `tsc --noEmit` clean
- [x] 149 tests across the placement, elevation, balance, save and terrain-block suites, including new tests for grading, limit and cliff refusals, and the lab map
- [x] Headless Playwright run on `/assets/placement`: placed four houses on slopes needing up to 0.29 of cut and fill, no console errors
- Lint not run: eslint is not in the lockfile and there is no config

🤖 Generated with [Claude Code](https://claude.com/claude-code)
