### PR TITLE
Measure the inn's real overhang and snap it onto the tavern

### DIFF
--- a/components/game/hud-controls.tsx
+++ b/components/game/hud-controls.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { placementRoofRotation } from "@/lib/game/building-placement-layout"
+import { placementSite } from "@/lib/game/building-placement-layout"
 
 import Image from "next/image"
 import { useEffect, useMemo, useState, type ReactElement, type ReactNode } from "react"
@@ -91,7 +91,7 @@ export function BuildControls({ economy, open, onToggle, onClose, minimapOpen, o
     return map && hovered ? placementError(map, selected, hovered, balance, rotation) : null
   }, [selected, renown, settlement.resources, map, hovered, balance, rotation])
 
-  const alignedRotation=useMemo(()=>map && selected && hovered ? placementRoofRotation(map,selected,hovered,rotation) : rotation,[map,selected,hovered,rotation])
+  const alignedRotation=useMemo(()=>map && selected && hovered ? placementSite(map,selected,hovered,rotation).rotation : rotation,[map,selected,hovered,rotation])
   const footprint = selected && rotatedFootprint(selected, alignedRotation)
 
   return <div className="hud-bottom-center">

--- a/components/game/tile-cursor.tsx
+++ b/components/game/tile-cursor.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { StructureModel } from "@/components/building-lab/building-model"
-import { placementBuildingLayout, placementRoofRotation } from "@/lib/game/building-placement-layout"
+import { placementBuildingLayout, placementSite } from "@/lib/game/building-placement-layout"
 import { structureParts } from "@/lib/game/building-art/structure"
 
 import { useMemo } from "react"
@@ -50,27 +50,30 @@ export function TileCursor({
       [x, onBridge ? (ropeHeightAt(map, hovered.x + x * 0.999, hovered.z + z * 0.999) ?? centre) - centre : groundHeight(map, hovered.x + x * 0.999, hovered.z + z * 0.999) - centre, z]))
   }, [map, hovered])
   const build = useMemo(() => buildCatalog(balance).find((item) => item.id === buildType && !item.retired), [balance, buildType])
-  const rotation=useMemo(()=>build && hovered ? placementRoofRotation(map,build,hovered,requestedRotation) : requestedRotation,[map,build,hovered,requestedRotation])
-  const {layoutSeed,hearthZ,fireplace,supportId,floorHeight,tavernFlue} = build && hovered ? placementBuildingLayout(map,{...build,...rotatedFootprint(build,rotation),...hovered,rotation,buildType:build.id,id:"construction-preview"}) : {}
+  // An inn hovered over its tavern snaps onto the roof, so the ghost stands
+  // where the click will actually build rather than under the cursor.
+  const site=useMemo(()=>build && hovered ? placementSite(map,build,hovered,requestedRotation) : null,[map,build,hovered,requestedRotation])
+  const rotation=site?.rotation ?? requestedRotation
+  const {layoutSeed,hearthZ,fireplace,supportId,floorHeight,tavernFlue} = build && site ? placementBuildingLayout(map,{...build,...rotatedFootprint(build,rotation),...site,rotation,buildType:build.id,id:"construction-preview"}) : {}
   const parts = useMemo(() => build ? structureParts({ ...build, buildType: build.id, layoutSeed, hearthZ, fireplace, supportId, floorHeight, tavernFlue }) : [], [build, layoutSeed, hearthZ, fireplace, supportId, floorHeight, tavernFlue])
   if (!hovered) return null
 
   if (!tileAt(map, hovered.x, hovered.z)) return null
 
-  if (build) {
+  if (build && site) {
     const footprint = rotatedFootprint(build, rotation)
     const valid =
       shrineRenown >= build.requiredRenown &&
-      !placementError(map, build, hovered, balance, rotation) &&
+      !placementError(map, build, site, balance, rotation) &&
       !!resources &&
       canAfford(resources, build.cost)
     const color = valid ? "#93bc6c" : "#db6656"
     return (
       <group
         position={[
-          tileToWorldX(map, hovered.x) + (footprint.w - 1) / 2,
-          groundHeight(map, hovered.x + (footprint.w - 1) / 2, hovered.z + (footprint.d - 1) / 2) + (floorHeight ?? 0),
-          tileToWorldZ(map, hovered.z) + (footprint.d - 1) / 2,
+          tileToWorldX(map, site.x) + (footprint.w - 1) / 2,
+          groundHeight(map, site.x + (footprint.w - 1) / 2, site.z + (footprint.d - 1) / 2) + (floorHeight ?? 0),
+          tileToWorldZ(map, site.z) + (footprint.d - 1) / 2,
         ]}
       >
         <mesh position={[0, 0.04, 0]} renderOrder={4}>

--- a/components/placement-lab/placement-lab.tsx
+++ b/components/placement-lab/placement-lab.tsx
@@ -7,7 +7,7 @@ import { LabSelect, LabSlider, labButton, labInput } from "@/components/lab-cont
 import { buildCatalog, DEFAULT_BALANCE, RULE_FIELDS } from "@/lib/game/balance"
 import { useBuildStore } from "@/lib/game/build-store"
 import { useCameraStore } from "@/lib/game/camera-store"
-import { placementRoofRotation } from "@/lib/game/building-placement-layout"
+import { placementSite } from "@/lib/game/building-placement-layout"
 import { rotatedFootprint } from "@/lib/game/building-rotation"
 import { footprintGrading } from "@/lib/game/map/elevation"
 import { parseSeed, randomSeed } from "@/lib/game/rng"
@@ -46,8 +46,8 @@ export function PlacementLab() {
   }, [])
   const candidate = useMemo(() => {
     if (!def || !hovered) return null
-    const snapped = placementRoofRotation(map, def, hovered, rotation)
-    return { grading: footprintGrading(map, { ...hovered, ...rotatedFootprint(def, snapped) }), error: placementError(map, def, hovered, balance, rotation) }
+    const site = placementSite(map, def, hovered, rotation)
+    return { grading: footprintGrading(map, { ...site, ...rotatedFootprint(def, site.rotation) }), error: placementError(map, def, hovered, balance, rotation) }
   }, [map, def, hovered, rotation, balance])
   const seed = parseSeed(seedDraft)
   const pending = seed !== settings.seed || draft.relief !== settings.relief || draft.wavelength !== settings.wavelength

--- a/lib/game/building-art/map-preview.ts
+++ b/lib/game/building-art/map-preview.ts
@@ -1,4 +1,4 @@
-import { innPlacementLayout } from "../inn"
+import { innPlacementLayout, innStackSite } from "../inn"
 import type { GameMap, BuildingDef, TilePos } from "../map/types"
 import type { TerrainId } from "../map/terrain"
 import { EARLY_BUILDINGS, earlyBuildingRecipe, type BuildingRecipe } from "./style"
@@ -81,9 +81,12 @@ export function buildingPreviewMap(recipe: BuildingRecipe, neighbor?: BuildingRe
 /** Preview and commit exactly the same orientation, footprint and adopted flue. */
 export function previewPlacement(map: GameMap, recipe: BuildingRecipe, at: TilePos, rotation: BuildingRotation,
   snap: boolean, recipes: ReadonlyMap<string,BuildingRecipe>) {
-  let building=previewBuilding(recipe,at,"placement-ghost",rotation)
+  // An upper floor covers one host exactly, so it snaps onto the tavern under
+  // the cursor instead of demanding that corner tile.
+  const stacked=snap ? innStackSite(map,recipe.variant,at) : undefined
+  let building=previewBuilding(recipe,stacked ?? at,"placement-ghost",stacked?.rotation ?? rotation)
   const riseFor=(b:BuildingDef)=>b.id===building.id ? recipe.roofRise : recipes.get(b.id)!.roofRise
-  const aligned=snap ? roofAlignedRotation(map,building,riseFor) : rotation
+  const aligned=stacked?.rotation ?? (snap ? roofAlignedRotation(map,building,riseFor) : rotation)
   building={...building,...rotatedFootprint({w:recipe.width,d:recipe.depth},aligned),rotation:aligned}
   building={...building,...(building.buildType === "inn" ? innPlacementLayout(map,building) : adoptNeighborChimney(map,building,riseFor))}
   return {building,recipe:{...recipe,layoutSeed:building.layoutSeed,hearthZ:building.hearthZ,fireplace:building.fireplace},

--- a/lib/game/building-art/structure.ts
+++ b/lib/game/building-art/structure.ts
@@ -1,4 +1,3 @@
-import { INN_OVERHANG } from "../inn"
 import { innLadderParts, innParts } from "./inn"
 import { innLayout } from "../inn-layout"
 import { waterSourceParts } from "../water-sources/model"
@@ -8,7 +7,7 @@ import type { BuildingDef } from "../map/types"
 import { buildingParts, type BuildingPart } from "./geometry"
 import { earlyBuildingParts, type SettlementBuildingType } from "./early-geometry"
 import { EARLY_BUILDINGS, earlyBuildingRecipe } from "./style"
-import { singlePlaneRoofRise } from "./dimensions"
+import { INN_OVERHANG, singlePlaneRoofRise } from "./dimensions"
 import type { RoofJoin } from "./roof-joins"
 
 export type StructureAppearance = Pick<BuildingDef, "buildType" | "w" | "d" | "height" | "color" | "roofColor" | "layoutSeed" | "hearthZ" | "fireplace" | "floorHeight" | "supportId" | "tavernFlue">

--- a/lib/game/building-placement-layout.ts
+++ b/lib/game/building-placement-layout.ts
@@ -1,10 +1,10 @@
-import { innPlacementError, innPlacementLayout, innPlacementRotation } from "./inn"
+import { innPlacementError, innPlacementLayout, innPlacementRotation, innStackSite } from "./inn"
 import { layoutHand, placementLayoutSeed } from "./building-layout"
 import { buildingRoofJoins } from "./building-art/roof-joins"
 import { hasDomesticHearth, shelterHearth } from "./building-art/furnishings"
 import { rotateBuildingPoint, rotatedFootprint, buildingApproaches } from "./building-rotation"
 import { singlePlaneRoofRise } from "./building-art/dimensions"
-import type { BuildingDef, GameMap } from "./map/types"
+import type { BuildingDef, GameMap, TilePos } from "./map/types"
 
 /** New neighbours adopt an existing fireplace's position; older homes never move.
  * Persist the result so demolition and later additions cannot reshuffle a layout.
@@ -77,6 +77,17 @@ export function placementClearance(map: GameMap, candidate: BuildingDef): string
   if(map.buildings.some(b=>buildingApproaches(map,b).some(p=>covers(candidate,p)))) return "Keep the neighboring doors clear."
   if(buildingApproaches(map,candidate).some(p=>p.x<0 || p.z<0 || p.x>=map.width || p.z>=map.depth || map.buildings.some(b=>covers(b,p)))) return "Leave a clear tile outside each door."
   return null
+}
+
+/** Resolve the hovered tile into the site that is actually built. An upper
+ * floor only fits one host, so hovering any of that host's tiles snaps the
+ * whole footprint and its rotation onto it; ordinary buildings keep the tile
+ * and merely turn to meet a touching roof. The ghost, the placement error and
+ * the purchase all resolve the cursor through here, so they never disagree.
+ */
+export function placementSite(map: GameMap, def: Pick<BuildingDef,"id"|"label"|"w"|"d"|"height"|"color"|"roofColor">,
+  at: TilePos, rotation: import("./building-rotation").BuildingRotation): TilePos & {rotation: import("./building-rotation").BuildingRotation} {
+  return innStackSite(map,def.id,at) ?? {x:at.x,z:at.z,rotation:placementRoofRotation(map,def,at,rotation)}
 }
 
 /** Resolve a catalogue placement before validating, drawing or buying it. */

--- a/lib/game/inn.test.ts
+++ b/lib/game/inn.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest"
 import { BUILD_CATALOG, DEFAULT_BALANCE } from "./balance"
 import { rotatedFootprint, rotateBuildingPoint, buildingEntry, type BuildingRotation } from "./building-rotation"
 import { innPlacementLayout, innPlacementError } from "./inn"
-import { placementBuildingLayout, placementRoofRotation, placementClearance } from "./building-placement-layout"
+import { placementBuildingLayout, placementRoofRotation, placementClearance, placementSite } from "./building-placement-layout"
 import { structureParts } from "./building-art/structure"
 import { tavernStackParts } from "./building-art/stacked"
 import { buildingHearth } from "./building-art/furnishings"
@@ -100,6 +100,21 @@ describe("inn upper floors",()=> {
       expect(settlementRoute(stacked,stacked.buildings,buildingEntry(host),buildingEntry(host,true),false,true)).toEqual(before)
       expect(innPlacementError(stacked,candidate)).toMatch(/already/)
   })
+  it.each([0,1,2,3] as const)("snaps onto the tavern from any of its tiles at rotation %i",rotation=> {
+    const {map,host}=fixture(rotation)
+    for(let z=host.z;z<host.z+host.d;z++) for(let x=host.x;x<host.x+host.w;x++) {
+      expect(placementSite(map,inn,{x,z},0),`${x},${z}`).toEqual({x:host.x,z:host.z,rotation})
+      expect(placementError(map,inn,{x,z},DEFAULT_BALANCE,0),`${x},${z}`).toBeNull()
+    }
+    const clear={x:host.x+host.w+2,z:host.z}
+    expect(placementSite(map,inn,clear,0)).toMatchObject(clear)
+    const balance={...DEFAULT_BALANCE,buildings:{...DEFAULT_BALANCE.buildings,inn:{...DEFAULT_BALANCE.buildings.inn,requiredRenown:0}}}
+    const settlement={...createSettlement(balance),resources:{gold:1000,wood:1000}}
+    const inside={x:host.x+1,z:host.z+1}
+    const bought=purchaseStructure(settlement,map,[],[],"inn",inside,balance)
+    expect(bought.error).toBeNull()
+    expect(bought.settlement.structures[0]).toMatchObject({x:host.x,z:host.z,rotation,supportId:host.id})
+  })
   it("rejects partial overlaps, unsupported buildings, independent taverns and unfinished hosts",()=> {
     const {map,host,candidate}=fixture()
     expect(innPlacementError(map,{...candidate,x:candidate.x+1})).toMatch(/full footprint/)
@@ -176,9 +191,24 @@ describe("inn upper floors",()=> {
     const ground=structureParts({...inn,buildType:"inn"}).find(p=>p.name==="inn-plaster-x-1-1")!
     expect(ground.size![1]).toBeLessThan(upper.height)
     expect(front.position[2]).toBeGreaterThan(upper.d/2)
+  })
+  it("clears a neighbour's own roofline but not what rises into the upper storey",()=>{
     const {map,candidate,host}=fixture()
-    const neighbor={...host,id:"neighbor",x:host.x+host.w}
-    expect(innPlacementError({...map,buildings:[...map.buildings,neighbor]},candidate)).toMatch(/overhanging/)
+    const beside=(id:string,extra:Partial<BuildingDef>={}):BuildingDef=>{
+      const def=BUILD_CATALOG.find(b=>b.id===id)!
+      return {...def,id:"neighbor",buildType:id,rotation:0,x:host.x+host.w,z:host.z,...extra}
+    }
+    const error=(neighbor:BuildingDef)=>innPlacementError({...map,buildings:[...map.buildings,neighbor]},candidate)
+    // Low eaves, thatch and gable ends pass beneath the jetty on either side,
+    // and so does a party-wall chimney adopted from the tavern's own hearth.
+    for(const id of ["house","market","well","tavern"]) for(const fireplace of [false,undefined])
+      expect(error(beside(id,{fireplace})),`${id} ${fireplace}`).toBeNull()
+    for(const patch of [{rotation:2 as const,fireplace:true},{x:host.x-2,fireplace:true}])
+      expect(error(beside("house",patch)),JSON.stringify(patch)).toBeNull()
+    // A raised store, a gable cross or a second upper floor all reach into it.
+    expect(error(beside("storehouse"))).toMatch(/overhanging/)
+    expect(error(beside("hall"))).toMatch(/overhanging/)
+    expect(error(beside("inn"))).toMatch(/overhanging/)
   })
   it("runs the upper roof perpendicular to the tavern, with its ridge along Z",()=> {
     const {upper}=fixture()

--- a/lib/game/inn.ts
+++ b/lib/game/inn.ts
@@ -1,16 +1,17 @@
-import { rotatedFootprint, type BuildingRotation } from "./building-rotation"
+import { Box3, Euler, Matrix4, Quaternion, Vector3 } from "three"
+import { normalizeBuildingRotation, rotateBuildingPoint, rotatedFootprint, type BuildingRotation } from "./building-rotation"
 import { innLayout } from "./inn-layout"
+import { structureParts } from "./building-art/structure"
 import { buildingHearth, hasDomesticHearth } from "./building-art/furnishings"
-import { INN_OVERHANG, INN_ROOF_OVERHANG, INN_UPPER_ROOF_PITCH, singlePlaneRoofRise } from "./building-art/dimensions"
-import type { BuildingDef, GameMap } from "./map/types"
-
-export { INN_OVERHANG } from "./building-art/dimensions"
+import { INN_OVERHANG, INN_ROOF_OVERHANG, singlePlaneRoofRise } from "./building-art/dimensions"
+import type { BuildingDef, GameMap, TilePos } from "./map/types"
 
 export const footprintsOverlap = (a: Pick<BuildingDef,"x"|"z"|"w"|"d">, b: Pick<BuildingDef,"x"|"z"|"w"|"d">) =>
   a.x < b.x+b.w && a.x+a.w > b.x && a.z < b.z+b.d && a.z+a.d > b.z
 
 /** The upper dormitory covers the tavern’s entire footprint. */
-export function innSupport(map: Pick<GameMap,"buildings">, candidate: BuildingDef): BuildingDef | undefined {
+export function innSupport(map: Pick<GameMap,"buildings">,
+  candidate: Pick<BuildingDef,"buildType"|"x"|"z"|"w"|"d"|"rotation">): BuildingDef | undefined {
   if (candidate.buildType !== "inn") return undefined
   return map.buildings.find(b => {
     if (b.buildType !== "tavern" || b.supportId) return false
@@ -22,13 +23,61 @@ export function innSupport(map: Pick<GameMap,"buildings">, candidate: BuildingDe
   })
 }
 
-export function innPlacementRotation(map: Pick<GameMap,"buildings">, candidate: BuildingDef): BuildingRotation {
-  for (const b of map.buildings) {
-    if (b.buildType !== "tavern") continue
-    const rotation = b.rotation ?? 0
-    if (innSupport({buildings:[b]},{...candidate,...rotatedFootprint({w:3,d:4},rotation),rotation})) return rotation
+/** An upper floor fits one host exactly, so every tile of that host resolves to
+ * the same site: hovering anywhere over the tavern snaps the inn onto its roof.
+ * Ordinary ground placements keep the hovered tile.
+ */
+export function innStackSite(map: Pick<GameMap,"buildings">, buildType: string | undefined, at: TilePos):
+  (TilePos & {rotation: BuildingRotation}) | undefined {
+  if (buildType !== "inn") return undefined
+  for (const host of map.buildings) {
+    if (at.x<host.x || at.x>=host.x+host.w || at.z<host.z || at.z>=host.z+host.d) continue
+    const rotation = normalizeBuildingRotation(host.rotation ?? 0)
+    const site = {x:host.x,z:host.z,rotation}
+    if (innSupport({buildings:[host]},{...site,...rotatedFootprint({w:3,d:4},rotation),buildType})) return site
   }
-  return candidate.rotation ?? 0
+  return undefined
+}
+
+export function innPlacementRotation(map: Pick<GameMap,"buildings">, candidate: BuildingDef): BuildingRotation {
+  return innStackSite(map,candidate.buildType,candidate)?.rotation ?? candidate.rotation ?? 0
+}
+
+/** A hair of daylight between the jettied floor and whatever already stands
+ * beside it, so touching art never reads as one shape pushed through another. */
+const INN_CLEARANCE = .02
+
+/** Shapes repeat across a settlement and across every frame of a drag. */
+const boundsCache = new Map<string,Box3[]>()
+
+/** Every authored box of a placed structure, in map tiles and world height.
+ * Roof pitch, eaves, jetties and chimney stacks all come from the art the game
+ * already draws, so a placement rule never restates the shell's dimensions.
+ */
+function structureBounds(building: BuildingDef): Box3[] {
+  const local = rotatedFootprint(building,building.rotation)
+  const key = [building.buildType,local.w,local.d,building.height,building.rotation ?? 0,building.layoutSeed ?? 0,
+    building.hearthZ,building.fireplace,building.supportId ?? "",building.floorHeight ?? 0,
+    building.tavernFlue?.x,building.tavernFlue?.z].join("/")
+  let boxes = boundsCache.get(key)
+  if (!boxes) {
+    boxes = structureParts({...building,...local}).flatMap(part => {
+      const box = new Box3()
+      const transform = new Matrix4().compose(new Vector3(...part.position),
+        new Quaternion().setFromEuler(new Euler(...part.rotation ?? [0,0,0])), new Vector3(1,1,1))
+      if (part.size) box.setFromCenterAndSize(new Vector3(),new Vector3(...part.size)).applyMatrix4(transform)
+      else for (let i=0;i<(part.vertices?.length ?? 0);i+=3) box.expandByPoint(new Vector3().fromArray(part.vertices!,i).applyMatrix4(transform))
+      if (box.isEmpty()) return []
+      const near = rotateBuildingPoint(box.min.x,box.min.z,building.rotation)
+      const far = rotateBuildingPoint(box.max.x,box.max.z,building.rotation)
+      return [new Box3(new Vector3(Math.min(near.x,far.x),box.min.y,Math.min(near.z,far.z)),
+        new Vector3(Math.max(near.x,far.x),box.max.y,Math.max(near.z,far.z)))]
+    })
+    if (boundsCache.size > 64) boundsCache.clear()
+    boundsCache.set(key,boxes)
+  }
+  const centre = new Vector3(building.x+building.w/2,building.floorHeight ?? 0,building.z+building.d/2)
+  return boxes.map(box => box.clone().translate(centre))
 }
 
 /** Undefined means ordinary ground placement; stacked sites preserve the host's access and ownership. */
@@ -39,18 +88,24 @@ export function innPlacementError(map: Pick<GameMap,"buildings">, candidate: Bui
   if (host.owner === "independent") return "The tavern must belong to your settlement."
   if (host.construction && host.construction.work < host.construction.required) return "Finish the tavern before adding an inn."
   if (map.buildings.some(b=>b.id!==host.id && footprintsOverlap(candidate,b))) return "An upper floor already occupies these tiles."
-  const projection=INN_OVERHANG+INN_ROOF_OVERHANG
+  const projection=INN_OVERHANG+INN_ROOF_OVERHANG+INN_CLEARANCE
   const expanded={...candidate,x:candidate.x-projection,z:candidate.z-projection,w:candidate.w+projection*2,d:candidate.d+projection*2}
-  const floor=host.height+singlePlaneRoofRise(4)+.2
-  if(map.buildings.some(b=> {
-    if(b.id===host.id) return false
-    const margin=b.supportId ? projection : 0
-    const bounds={...b,x:b.x-margin,z:b.z-margin,w:b.w+margin*2,d:b.d+margin*2}
-    const local=rotatedFootprint(b,b.rotation)
-    const rise=b.buildType==="inn" && b.supportId ? (local.w/2+INN_OVERHANG)*INN_UPPER_ROOF_PITCH : singlePlaneRoofRise(local.d)
-    const top=(b.floorHeight ?? 0)+b.height+rise+.2
-    return top>floor-.32 && footprintsOverlap(expanded,bounds)
-  })) return "Leave room beside the tavern for the inn’s overhanging upper walls and eaves."
+  const neighbors=map.buildings.filter(b=>b.id!==host.id && footprintsOverlap(expanded,b))
+  if(!neighbors.length) return null
+  // Only the upstairs storey reaches past the tavern, and only well above the
+  // neighbouring eaves. Its jetty brackets hang over a lower roofline the way a
+  // real jetty does, so the rule guards the deck, walls and roof above them.
+  const upper={...candidate,...innPlacementLayout(map,candidate)}
+  const deck=upper.floorHeight!-INN_CLEARANCE
+  const storey=structureBounds(upper).flatMap(box => {
+    box.expandByScalar(INN_CLEARANCE)
+    box.min.y=Math.max(box.min.y,deck)
+    const beyond=box.min.x<candidate.x || box.max.x>candidate.x+candidate.w
+      || box.min.z<candidate.z || box.max.z>candidate.z+candidate.d
+    return beyond && box.min.y<box.max.y ? [box] : []
+  })
+  if(neighbors.some(b=>structureBounds(b).some(box=>box.max.y>deck && storey.some(part=>part.intersectsBox(box)))))
+    return "Leave room beside the tavern for the inn’s overhanging upper walls and eaves."
   return null
 }
 

--- a/lib/game/settlement.ts
+++ b/lib/game/settlement.ts
@@ -1,6 +1,6 @@
 import { innPlacementError } from "./inn"
 import { buildingEntrance, constructionWork, isComplete } from "./construction"
-import { placementBuildingLayout, placementRoofRotation } from "./building-placement-layout"
+import { placementBuildingLayout, placementSite } from "./building-placement-layout"
 import { rotatedFootprint, buildingEntry, buildingApproaches, type BuildingRotation } from "./building-rotation"
 import { footprintGrading, groundHeight, levelBuildingGround } from "./map/elevation"
 import { buildingKind, placementProblem, PLACEMENT_PROBLEM_LABELS, type PlacedBuilding } from "./buildings"
@@ -280,7 +280,9 @@ export function placementError(
   balance: GameBalance = DEFAULT_BALANCE,
   rotation: BuildingRotation = 0,
 ): string | null {
-  rotation = placementRoofRotation(map, def, at, rotation)
+  const site = placementSite(map, def, at, rotation)
+  rotation = site.rotation
+  at = site
   const footprintError = validateFootprint(map, def, at, balance, rotation)
   if (footprintError || !map.site) return footprintError
   let byBalance = accessVerdicts.get(map)
@@ -409,7 +411,9 @@ export function purchaseStructure(
     return { settlement, error: `Requires ${def.requiredRenown} shrine renown.` }
   if (!canAfford(settlement.resources, def.cost))
     return { settlement, error: "Not enough gold or wood." }
-  rotation=placementRoofRotation(map,def,at,rotation)
+  const site=placementSite(map,def,at,rotation)
+  rotation=site.rotation
+  at=site
   const error = placementError(map, def, at, balance, rotation)
   if (error) return { settlement, error }
   const building: BuildingDef = {


### PR DESCRIPTION
Stacking an inn on a tavern was refused by almost any neighbour — a house, a market, even a timber well — because the clearance rule compared a neighbour's whole-building ridge against the height of the jetty brackets, which hang inside the tavern footprint and so demanded a third of a tile of headroom that nothing actually needs. This replaces that with real geometry: `structureBounds` turns a placed building's authored parts into world-space boxes, so roof pitch, eaves, verges and chimney stacks come from the art the renderer already draws rather than restated constants, and only something standing up into the upper storey itself blocks the site (bounds are memoised per shape, keeping the cursor check at ~0.1 ms). Houses, markets, wells, guard posts, sheep pens, workshops and shelters now clear at every rotation, including a party-wall chimney adopted from the tavern's own hearth, while the raised store's posts, a hall or monks' shelter gable cross, a neighbouring standalone inn and a tavern whose ridge runs into the party wall still stand in the way. Upper floors also fit exactly one host, so hovering any of the tavern's tiles now snaps the whole footprint and rotation onto its roof instead of demanding the corner tile — one resolver, `placementSite`, is shared by the ghost, the placement verdict and the purchase so they cannot disagree. Verified in the running game (tavern with a house butted against it: green ghost lifted onto the roof from every tile, ordinary ground placement two tiles off) and in the buildings playground, with new tests covering the clearance matrix and the snap at all four rotations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)