### PR TITLE
Let every citizen build, with monks the slowest hands

### DIFF
--- a/components/game/game-hud.tsx
+++ b/components/game/game-hud.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { builderPaceLabel, builderRate, MONK_BUILD_RATE } from "@/lib/game/build-labour"
 import { isComplete, isHouse, isMonkShelter } from "@/lib/game/construction"
 import { BUILDING_KINDS, buildingKind } from "@/lib/game/buildings"
 import { housingBeds, monkBeds } from "@/lib/game/housing"
@@ -379,6 +380,7 @@ function TravelerPanel({ traveler, travelers, map }: { traveler: Traveler; trave
             {a.skills.length > 0 ? a.skills.join(", ") : "none"}
           </span>
         </div>
+        <BuilderPace rate={builderRate(a.skills)} />
       </div>
     </Panel>
   )
@@ -503,6 +505,14 @@ function RelicPanel({ relic }: { relic: Relic }) {
   )
 }
 
+/** How fast this pair of hands raises a building, against a plain untrained one. */
+function BuilderPace({ rate }: { rate: number }) {
+  return <div className="flex items-baseline justify-between gap-4">
+    <span className="text-[11px] italic text-ink-light">Building</span>
+    <span className="font-display text-[10px] text-ink">{builderPaceLabel(rate)} ×{rate}</span>
+  </div>
+}
+
 function ConstructionStatus({ building }: { building: BuildingDef }) {
   const read = () => building.construction ? Math.round(100 * building.construction.work / building.construction.required) : 100
   const [progress, setProgress] = useState(read)
@@ -514,7 +524,7 @@ function ConstructionStatus({ building }: { building: BuildingDef }) {
   if (progress >= 100) return null
   return <div className="mt-2">
     <StatBar label="Construction" value={progress} />
-    <p className="mt-1 max-w-56 text-[11px] italic text-ink-light">Idle residents build this site. Benefits begin when construction finishes.</p>
+    <p className="mt-1 max-w-56 text-[11px] italic text-ink-light">Anyone at the enclave with hands free helps raise this, the trades fastest and the brothers slowest. Benefits begin when construction finishes.</p>
   </div>
 }
 
@@ -604,6 +614,7 @@ function MonkPanel({ monk }: { monk: Monk }) {
             {a.skills.join(", ")}
           </span>
         </div>
+        <BuilderPace rate={MONK_BUILD_RATE} />
       </div>
     </Panel>
   )

--- a/hooks/use-settlement.ts
+++ b/hooks/use-settlement.ts
@@ -146,7 +146,7 @@ export function useSettlement(baseMap: GameMap | null, monks: Monk[], relic: Rel
         ...current,
         settlement: instantBuild ? completeConstruction(result.settlement) : result.settlement,
         buildType: result.error ? current.buildType : null,
-        message: result.error ?? (instantBuild ? "Building placed." : "Construction planned. Idle residents will build it."),
+        message: result.error ?? (instantBuild ? "Building placed." : "Construction planned. The enclave will raise it."),
       }
     }))
   }

--- a/lib/game/build-labour.ts
+++ b/lib/game/build-labour.ts
@@ -1,0 +1,45 @@
+/**
+ * Who raises a building, and how fast. Construction is paid in worker-seconds
+ * (see construction.ts): a builder's rate is the share of a second they add to
+ * the site while standing at its wall.
+ *
+ * The brothers put up the first shelters themselves, and still do whenever
+ * nobody else is free, but they are copyists and gardeners before they are
+ * wrights. Every settler outbuilds them and a trained one outbuilds them by a
+ * long way, so the enclave shifts off monk labour of its own accord as the road
+ * brings trades in.
+ */
+
+/** A willing but untrained pair of hands: the rate every other rate is read against. */
+export const SETTLER_BUILD_RATE = 1
+/**
+ * A brother's rate, flat: the slowest on any site, whatever he brought with him.
+ * Held close to plain hands so the founding years, when the brothers are all
+ * there is, are not a crawl — the relief comes from the trades, not from them.
+ */
+export const MONK_BUILD_RATE = 0.75
+/** However many trades one builder knows, they are still only one builder. */
+export const MAX_BUILD_RATE = 2
+
+/** Trades that speed a raising, and what knowing one adds to a builder's rate. */
+const BUILDING_TRADES: Record<string, number> = {
+  carpentry: 0.5,
+  masonry: 0.5,
+  thatching: 0.3,
+  labour: 0.25,
+  woodcutting: 0.2,
+  mending: 0.15,
+}
+
+/** What a settler contributes per second at a site, given the trades they know. */
+export function builderRate(skills: readonly string[] = []): number {
+  return Math.min(MAX_BUILD_RATE,
+    skills.reduce((rate, skill) => rate + (BUILDING_TRADES[skill] ?? 0), SETTLER_BUILD_RATE))
+}
+
+/** How the HUD names a builder's pace beside their trades. */
+export function builderPaceLabel(rate: number): string {
+  if (rate < SETTLER_BUILD_RATE) return "Slow"
+  if (rate >= SETTLER_BUILD_RATE + 0.5) return "Skilled"
+  return rate > SETTLER_BUILD_RATE ? "Handy" : "Ordinary"
+}

--- a/lib/game/construction.test.ts
+++ b/lib/game/construction.test.ts
@@ -7,6 +7,7 @@ import { tileToWorldX, tileToWorldZ, worldToTileX, worldToTileZ, type GameMap } 
 import { monkWander } from "./monk-wander"
 import { createMonkRoutine, stepMonkRoutine } from "./monk-routine"
 import { createMonkNeeds, MONK_WAKE_AT, stepMonkWork } from "./monk-work"
+import { builderRate, MAX_BUILD_RATE, MONK_BUILD_RATE, SETTLER_BUILD_RATE } from "./build-labour"
 import { settlementRoute } from "./settlement-route"
 import { makeRng } from "./rng"
 import { woodcutterHuts } from "./settlement"
@@ -194,6 +195,58 @@ describe("resident construction", () => {
     expect(site.construction!.work).toBe(0)
   })
 
+  it("pays a brother, a plain settler and a trained one at their own rates", () => {
+    expect(builderRate([])).toBe(SETTLER_BUILD_RATE)
+    expect(builderRate(["carpentry"])).toBeGreaterThan(SETTLER_BUILD_RATE)
+    expect(builderRate(["chant", "letters"])).toBe(SETTLER_BUILD_RATE)
+    expect(builderRate(["carpentry", "masonry", "labour", "thatching"])).toBe(MAX_BUILD_RATE)
+    expect(MONK_BUILD_RATE).toBeLessThan(SETTLER_BUILD_RATE)
+    const work = (rate?: number) => {
+      const map = fixture(), site = map.buildings[2], actor = { ...worker(map), buildRate: rate }
+      assignBuildingTask(actor, map, "build")
+      while (actor.buildingTask!.route.length) stepBuildingTask(actor, map, 1, 0.1)
+      for (let i = 0; i < 10; i++) stepBuildingTask(actor, map, 1, 0.1)
+      return site.construction!.work
+    }
+    expect(work(MONK_BUILD_RATE)).toBeCloseTo(MONK_BUILD_RATE)
+    expect(work()).toBeCloseTo(SETTLER_BUILD_RATE)
+    expect(work(builderRate(["carpentry"]))).toBeCloseTo(builderRate(["carpentry"]))
+  })
+
+  it("hands a full site's place from the slowest builder to a faster one", () => {
+    const map = fixture(), site = map.buildings[2]
+    const brother = { ...worker(map), buildRate: MONK_BUILD_RATE }
+    const settler = { ...worker(map), buildRate: SETTLER_BUILD_RATE }
+    const wright = { ...worker(map), buildRate: builderRate(["carpentry"]) }
+    expect(constructionBuilders(site.w, site.d)).toBe(1)
+    expect(assignBuildingTask(brother, map, "build")).toBe(true)
+    // A settler outbuilds him, so the brother steps back and the place is theirs.
+    expect(assignBuildingTask(settler, map, "build")).toBe(true)
+    expect(brother.buildingTask).toBeUndefined()
+    expect(settler.buildingTask!.buildingId).toBe(site.id)
+    // Equals never trade places, but a trained wright takes over in turn.
+    const equal = { ...worker(map), buildRate: SETTLER_BUILD_RATE }
+    expect(assignBuildingTask(equal, map, "build")).toBe(false)
+    expect(settler.buildingTask).toBeDefined()
+    expect(assignBuildingTask(wright, map, "build")).toBe(true)
+    expect(settler.buildingTask).toBeUndefined()
+    // Nobody is slower than the brother, so he cannot win the place back.
+    expect(assignBuildingTask(brother, map, "build")).toBe(false)
+  })
+
+  it("keeps the crew whole when the faster builder cannot reach the site", () => {
+    const map = fixture(), site = map.buildings[2]
+    const brother = { ...worker(map), buildRate: MONK_BUILD_RATE }
+    expect(assignBuildingTask(brother, map, "build")).toBe(true)
+    const task = brother.buildingTask
+    // Stranded across water: the place is only released once a route is found.
+    const wright = { ...worker(map, 16, 16), buildRate: MAX_BUILD_RATE }
+    for (let z = 0; z < map.depth; z++) map.tiles[z * map.width + 12] = "water"
+    expect(assignBuildingTask(wright, map, "build")).toBe(false)
+    expect(brother.buildingTask).toBe(task)
+    expect(stepBuildingTask(brother, map, 1, 0.1)).not.toBeNull()
+  })
+
   it("shows foundations, scaffolding, walls, then the complete building", () => {
     const site = fixture().buildings[1]
     site.construction = { work: 0, required: 30 }
@@ -219,10 +272,11 @@ describe("monk fatigue and rest", () => {
       for (let i = 0; i < 300 && monk.activity !== "building"; i++) stepMonkWork(monk, map, 1, 0.1)
       expect(monk.activity).toBe("building")
     }
-    const task = monk.buildingTask, spare = worker(map)
+    // Another brother builds no faster, so he cannot take the place over.
+    const task = monk.buildingTask, spare = { ...worker(map), buildRate: MONK_BUILD_RATE }
     expect(task?.purpose).toBe("build")
     monk.stamina = 0
-    for (let i = 0; i < 1500 && !isComplete(site); i++) {
+    for (let i = 0; i < 3000 && !isComplete(site); i++) {
       stepMonkWork(monk, map, 1, 0.1)
       expect(monk.buildingTask).toBe(task)
       expect(assignBuildingTask(spare, map, "build")).toBe(false)

--- a/lib/game/construction.ts
+++ b/lib/game/construction.ts
@@ -11,6 +11,7 @@ import { tileToWorldX, tileToWorldZ, worldToTileX, worldToTileZ, type BuildingDe
 import { settlementRoute } from "./settlement-route"
 import type { WanderSpot } from "./monk-wander"
 import { buildingSupports } from "./character-support"
+import { SETTLER_BUILD_RATE } from "./build-labour"
 import { workPost } from "./work-posts"
 import { rememberedWorkerCorridor, rememberedWorkerRoute } from "./worker-route-memory"
 
@@ -50,7 +51,15 @@ export interface BuildingTask {
   /** Reroute when placement changes the obstacles. */
   buildings: readonly BuildingDef[]
 }
-export interface Worker extends WanderSpot { buildingTask?: BuildingTask; workSlot?: number; workScale?: number }
+export interface Worker extends WanderSpot {
+  buildingTask?: BuildingTask
+  workSlot?: number
+  workScale?: number
+  /** Worker-seconds added per second at a site; see build-labour.ts. Absent means plain hands. */
+  buildRate?: number
+}
+/** Every builder counts as a plain pair of hands until their trades say otherwise. */
+function buildRate(worker: Worker): number { return worker.buildRate ?? SETTLER_BUILD_RATE }
 // Construction survives map publications and is shared by monks and settlers.
 // Keep reservations out of saved game data; a cancelled/replaced task frees its place.
 const buildingCrews = new WeakMap<Construction, Map<Worker, BuildingTask>>()
@@ -122,6 +131,16 @@ function taskPosition(map: GameMap, building: BuildingDef, purpose: BuildingTask
     heading: (bed?.heading ?? (purpose === "work" ? 0 : Math.PI)) + buildingYaw(building.rotation) }
 }
 
+/** The slowest builder on a crew that a faster pair of hands may take over from. */
+function slowestBuilderUnder(crew: readonly Worker[], rate: number): Worker | null {
+  let slowest: Worker | null = null
+  for (const worker of crew) {
+    if (buildRate(worker) >= rate) continue
+    if (!slowest || buildRate(worker) < buildRate(slowest)) slowest = worker
+  }
+  return slowest
+}
+
 /** Reserve a place before walking so en-route builders count toward the site's crew. */
 export function assignBuildingTask(actor: Worker, map: GameMap, purpose: BuildingTask["purpose"], focusedBuildingId?: string): boolean {
   // Only a named building can be rested or worked in: a settler's own house,
@@ -133,8 +152,14 @@ export function assignBuildingTask(actor: Worker, map: GameMap, purpose: Buildin
       Math.hypot(tileToWorldX(map, b.x) - actor.x, tileToWorldZ(map, b.z) - actor.z))
   for (const building of candidates) {
     const crew = purpose === "build" ? constructionCrew(building) : null
-    const others = crew ? [...crew.keys()].filter(worker => worker !== actor) : []
-    if (others.length >= constructionBuilders(building.w, building.d)) continue
+    const full = crew ? [...crew.keys()].filter(worker => worker !== actor) : []
+    // A full site still takes a better builder: the slowest hand on it steps
+    // back, which is how a brother gives up the mallet once a wright turns up.
+    // Only a strictly faster rate displaces, so equals never trade places.
+    const crowded = full.length >= constructionBuilders(building.w, building.d)
+    const displaced = crowded ? slowestBuilderUnder(full, buildRate(actor)) : null
+    if (crowded && !displaced) continue
+    const others = displaced ? full.filter(worker => worker !== displaced) : full
     for (let attempt = 0; attempt < (purpose === "build" ? 4 : 1); attempt++) {
       const slot = (actor.workSlot ?? 0) + attempt
       if (others.some(worker => worker.buildingTask!.slot % 4 === slot % 4)) continue
@@ -144,6 +169,8 @@ export function assignBuildingTask(actor: Worker, map: GameMap, purpose: Buildin
       const route = purpose === "build" ? workerRoute(map, actor, frontage) : routeToDestination(map, actor, destination)
       if (!route) continue
       if (purpose === "build") route.push(destination)
+      // Only release the place once this builder can actually reach it.
+      if (displaced) { displaced.buildingTask = undefined; crew!.delete(displaced) }
       actor.buildingTask = { buildingId: building.id, purpose, slot, heading, route,
         destination: { ...destination }, buildings: map.buildings }
       crew?.set(actor, actor.buildingTask)
@@ -181,7 +208,7 @@ export function walkWorker(actor: WanderSpot, route: WanderSpot[], speed: number
   return true
 }
 
-/** Progress is paid in worker-seconds, only while standing at the site's entrance. */
+/** Progress is paid in worker-seconds at the builder's own rate, only while standing at the site's entrance. */
 export function stepBuildingTask(actor: Worker, map: GameMap, speed: number, dt: number): "walking" | "building" | "sleeping" | "posted" | null {
   const task = actor.buildingTask
   if (!task || dt <= 0) return null
@@ -231,6 +258,6 @@ export function stepBuildingTask(actor: Worker, map: GameMap, speed: number, dt:
     return "posted"
   }
   const construction = building.construction!
-  construction.work = Math.min(construction.required, construction.work + dt)
+  construction.work = Math.min(construction.required, construction.work + dt * buildRate(actor))
   return "building"
 }

--- a/lib/game/hospitality.test.ts
+++ b/lib/game/hospitality.test.ts
@@ -1,3 +1,5 @@
+import { builderRate } from "./build-labour"
+import { isComplete } from "./construction"
 import { naturalWaterStop } from "./natural-water"
 import { settlementJob, SETTLEMENT_JOBS } from "./jobs/design"
 import { shrineSeats, shrineStations, shrineLayout } from "./shrine-layout"
@@ -523,6 +525,54 @@ describe("woodcutter huts", () => {
       expect(["toHome", "sleeping"]).toContain(actor.activity)
       expect(actor[need]).toBeGreaterThan(depleted)
     }
+  })
+
+  it("sends every citizen but the head keeper to a new site, at their own pace", () => {
+    const { map, camp, traveler } = fixture()
+    const def = BUILD_CATALOG.find(b => b.id === "tavern")!
+    const tavern = { ...def, id: "tavern-0", buildType: "tavern", label: def.label, x: 13, z: 11, rotation: 0 as const }
+    const site = { ...camp, id: "construction-site", x: 5, z: 6, construction: { work: 0, required: 96 } }
+    map.buildings.push(tavern, site)
+    const people = [traveler(0), traveler(1)]
+    people[1].attributes.skills = ["carpentry"]
+    const sim = createSim(people, map)
+    sim.buildings = jobBuildings(map)
+    const keepers = people.map((t, jobSlot) => {
+      const s = sim.travelers.get(t.id)!
+      Object.assign(s, { employer: tavern.id, jobSlot, jobless: false, activity: "idle", moveSpeed: 0,
+        x: tileToWorldX(map, tavern.x + jobSlot), z: tileToWorldZ(map, tavern.z + tavern.d) })
+      return s
+    })
+    stepSim(sim, people, map, 1.5, 0.1)
+    // The counter keeps its first slot; the second keeper is free to lend a hand.
+    expect(keepers[0].activity).toBe("toPost")
+    expect(keepers[1].activity).toBe("toBuild")
+    expect(keepers[1].buildRate).toBe(builderRate(["carpentry"]))
+    run(sim, people, map, 300, () => isComplete(site))
+    expect(isComplete(site)).toBe(true)
+    expect(keepers[0].employer).toBe(tavern.id)
+    expect(keepers[1].employer).toBe(tavern.id)
+  })
+
+  it("leaves a roadside town's household to its own counter", () => {
+    const { map, camp, traveler } = fixture()
+    const def = BUILD_CATALOG.find(b => b.id === "tavern")!
+    const tavern = { ...def, id: "town-tavern", buildType: "tavern", label: def.label, owner: "independent" as const,
+      x: 13, z: 11, rotation: 0 as const }
+    const site = { ...camp, id: "construction-site", x: 5, z: 6, construction: { work: 0, required: 96 } }
+    map.buildings.push(tavern, site)
+    const people = [traveler(0), traveler(1)]
+    const sim = createSim(people, map)
+    sim.buildings = jobBuildings(map, true)
+    const keepers = people.map((t, jobSlot) => {
+      const s = sim.travelers.get(t.id)!
+      Object.assign(s, { employer: tavern.id, jobSlot, jobless: false, activity: "idle", moveSpeed: 0,
+        x: tileToWorldX(map, tavern.x + jobSlot), z: tileToWorldZ(map, tavern.z + tavern.d) })
+      return s
+    })
+    run(sim, people, map, 60)
+    for (const keeper of keepers) expect(["toPost", "posted"]).toContain(keeper.activity)
+    expect(site.construction.work).toBe(0)
   })
 
   it("sends an idle settled worker to build, then returns them to camp", () => {

--- a/lib/game/monk-work.ts
+++ b/lib/game/monk-work.ts
@@ -1,3 +1,4 @@
+import { MONK_BUILD_RATE } from "./build-labour"
 import { assignBuildingTask, stepBuildingTask, walkWorker, workerRoute, type BuildingTask } from "./construction"
 import { worldToTileX, worldToTileZ, type GameMap } from "./map/types"
 import type { MonkRoutine } from "./monk-routine"
@@ -6,8 +7,8 @@ import { buildingAt } from "./settlement"
 
 export const MONK_TIRED_AT = 25
 export const MONK_WAKE_AT = 95
-export interface MonkNeeds { home?: string; bedSlot?: number; workSlot: number; stamina: number; buildingTask?: BuildingTask; jobSearch: number }
-export function createMonkNeeds(index: number): MonkNeeds { return { workSlot: index, stamina: 100 - index * 6, jobSearch: 0 } }
+export interface MonkNeeds { home?: string; bedSlot?: number; workSlot: number; stamina: number; buildingTask?: BuildingTask; jobSearch: number; buildRate: number }
+export function createMonkNeeds(index: number): MonkNeeds { return { workSlot: index, stamina: 100 - index * 6, jobSearch: 0, buildRate: MONK_BUILD_RATE } }
 
 /** Finish assigned construction before resting; tired monks cannot take new work. */
 export function stepMonkWork(s: MonkRoutine & MonkNeeds, map: GameMap, speed: number, dt: number): boolean {

--- a/lib/game/sim.ts
+++ b/lib/game/sim.ts
@@ -27,6 +27,7 @@ import { blockedRoad, findRoadDiversion, takeRoadShortcut, retireBypassedRoad, e
 import { createFootpaths, HEAVY_PATH_WEAR, recordWalkingPath, regrowFootpaths, type Footpaths } from "./footpaths"
 import { knightMounted, knightLoadout, knightTravelSpeed, knightWalkStride, type HorseRest } from "./knights"
 import { DEFAULT_WALK_SPEED, DEFAULT_WALK_CADENCE, personWalkStride } from "./base-person/gait"
+import { builderRate } from "./build-labour"
 import { assignBuildingTask, buildingEntrance, stepBuildingTask, walkWorker, workerRoute, type BuildingTask } from "./construction"
 import { buildingEntry } from "./building-rotation"
 import { timberDestination, type FoodStock } from "./storage"
@@ -339,6 +340,8 @@ export interface SimTraveler {
   horseRest?: HorseRest & { progress: number; lane: number }
   workScale?: number
   workSlot?: number
+  /** Worker-seconds this settler adds per second at a site; their trades set it. */
+  buildRate?: number
   buildingTask?: BuildingTask
   constructionReturn?: import("./monk-wander").WanderSpot[]
   /** Prayer interrupts travel/work without discarding its route or reservations. */
@@ -1185,6 +1188,16 @@ function homeBedSlot(sim: SimState, s: SimTraveler): number {
   const housemates = [...sim.travelers.values()].filter(other => other.home === s.home)
     .map(other => other.id).sort((a, b) => a - b)
   return Math.max(0, housemates.indexOf(s.id))
+}
+
+/**
+ * Whether a settler belongs to the shrine's own settlement rather than to a
+ * roadside town, which keeps its founding household to itself. Someone with no
+ * place of their own is loose at the enclave and counts as one of its hands.
+ */
+function ofTheEnclave(map: GameMap, workplace: PlacedBuilding | undefined, home: string | null): boolean {
+  if (workplace) return workplace.owner !== "independent"
+  return !home || map.buildings.find(b => b.id === home)?.owner !== "independent"
 }
 
 /** Complete counters with a keeper working, including patrols inside a tavern. */
@@ -2477,11 +2490,24 @@ export function stepSim(
           if (s.employer) break
           s.timer = GAME_HOUR_SECONDS
         }
-        // Standing behind a counter or in a fold asks little; a settler keeps
-        // that post until they are genuinely hungry or tired.
         const hungry = Math.min(s.hunger, s.thirst) < SERVING_THRESHOLD
         const unhappy = socialBreak
         const workplace = sim.buildings.find(b => b.id === s.employer)
+        // Raising a building is the whole enclave's business, not the brothers'
+        // alone: a keeper leaves the counter for it as readily as a woodcutter
+        // leaves the woods. The first slot of a posted house stays behind so a
+        // counter never closes for a site, and the site's own crew limit keeps
+        // everyone else at their usual work. A town down the road keeps its own
+        // household, and a vendor's stall is nobody's but the vendor's.
+        const sparedFromPost = !workplace || !isPostedWork(workplace.kind) || s.jobSlot > 0
+        if (!isVendor && sparedFromPost && !unhappy && Math.min(s.hunger, s.thirst, s.stamina) >= SETTLER_FED_AT
+          && ofTheEnclave(map, workplace, s.home)) {
+          s.workSlot = s.id
+          s.buildRate = builderRate(t.attributes.skills)
+          if (assignBuildingTask(s, map, "build")) { s.activity = "toBuild"; break }
+        }
+        // Standing behind a counter or in a fold asks little; a settler keeps
+        // that post until they are genuinely hungry or tired.
         if (workplace && isPostedWork(workplace.kind) && !hungry && !unhappy && s.stamina > SETTLER_TIRED_AT) {
           if (workplace.kind === "sheep-pen" && dt > 0 && !s.herdingRetry) {
             s.herdingRetry = 5
@@ -2500,11 +2526,6 @@ export function stepSim(
           if (!s.home) s.home = findHome(sim, s, map)
           s.workSlot = homeBedSlot(sim, s)
           if (s.home && assignBuildingTask(s, map, "rest", s.home)) { s.activity = "toHome"; break }
-        }
-        s.workSlot = s.id
-        if (Math.min(s.hunger, s.thirst, s.stamina) >= SETTLER_FED_AT && assignBuildingTask(s, map, "build")) {
-          s.activity = "toBuild"
-          break
         }
         s.timer -= dt
         if (s.timer <= 0 && Math.min(s.hunger, s.thirst, s.stamina) >= SETTLER_FED_AT) {


### PR DESCRIPTION
Builders now raise a site at their own rate instead of a flat second each: a brother contributes 0.75, a plain settler 1, and trades stack to 2, so a carpenter builds twice as fast as a monk. A full crew takes a strictly faster builder in place of its slowest hand, which is how a brother gives up the mallet once a wright arrives — the place is only released once the newcomer has a route to it. Every enclave citizen is now eligible, including tavern, inn and fold keepers, with the first slot of a posted house staying behind so a counter never closes for a site, and a roadside town's founding household keeping to its own town. Both character inspectors show each person's building pace beside their trades, and the site blurb says the enclave raises it.

Verified with `tsc --noEmit`, 432 passing tests across construction, hospitality, sim, monk-work, settlement, housing, inn, town-residents, city-benchmark, travel-parties and save, plus a live run where two brothers raised a woodcutter's hut with no page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)