### PR TITLE
Bring back 6× playback, drop 2×, and withhold 6× in a crowd

### DIFF
--- a/components/game/debug-handle.tsx
+++ b/components/game/debug-handle.tsx
@@ -35,7 +35,7 @@ import { sceneryDetailStatus } from "@/lib/game/render/scenery-detail"
 import { batchedSourceRoots } from "@/lib/game/render/batch-source-visibility"
 import { characterBatchEntry } from "@/lib/game/render/character-batch"
 import { workerRouteMemoryStats } from "@/lib/game/worker-route-memory"
-import { BENCHMARK_SIMULATION_SPEEDS, useSimulationStore } from "@/lib/game/simulation-store"
+import { BENCHMARK_SIMULATION_SPEEDS, simulationSpeedControl, useSimulationStore } from "@/lib/game/simulation-store"
 
 /**
  * Exposes a small handle on `window` so the scene can be driven deterministically
@@ -154,6 +154,9 @@ export function DebugHandle({ map, trees, travelers, speed, movement, speedScale
       setSpeed: (label: number) => {
         const speed = BENCHMARK_SIMULATION_SPEEDS.find(speed => speed.label === label)
         if (!speed) throw new Error(`Unknown playback speed: ${label}`)
+        // Measurements ask for a speed at a crowd size on purpose, including the
+        // 6× the HUD withholds; the request lifts the crowd limit for this run.
+        simulationSpeedControl.crowdLimit = false
         useSimulationStore.setState({ speed: speed.rate })
       },
       playback: () => useSimulationStore.getState(),
@@ -190,6 +193,7 @@ export function DebugHandle({ map, trees, travelers, speed, movement, speedScale
       },
       setAdaptiveQuality: (enabled: boolean) => { frameQualityControl.enabled = enabled },
       setCrowdThinning: (enabled: boolean) => { crowdRenderControl.enabled = enabled },
+      setCrowdSpeedLimit: (enabled: boolean) => { simulationSpeedControl.crowdLimit = enabled },
       figureStatus: () => ({ ...crowdRenderStatus, quality: frameQuality(scene),
         pendingUnits: namedRoot("travelers")?.userData.pendingUnits ?? 0,
         missingVisibleUnits: namedRoot("travelers")?.userData.missingVisibleUnits ?? 0 }),

--- a/components/game/game-hud.css
+++ b/components/game/game-hud.css
@@ -107,7 +107,7 @@
   box-shadow: inset 0 0 0 1px #2b2417;
   color: #f9e5af;
 }
-:is(.hud-action, .hud-building-tile):is(:disabled, [aria-disabled="true"]) {
+:is(.hud-action, .hud-building-tile, .hud-speeds button):is(:disabled, [aria-disabled="true"]) {
   background: #262218;
   border-color: #514733;
   color: #9b907a;

--- a/components/game/hud-controls.tsx
+++ b/components/game/hud-controls.tsx
@@ -16,7 +16,7 @@ import { rotatedFootprint } from "@/lib/game/building-rotation"
 import { canAfford, placementError } from "@/lib/game/settlement"
 import { useCameraStore } from "@/lib/game/camera-store"
 import { formatGameTime, simRegistry } from "@/lib/game/sim"
-import { SIMULATION_SPEEDS, useSimulationStore } from "@/lib/game/simulation-store"
+import { CROWD_SPEED_LIMIT, SIMULATION_SPEEDS, crowdSafeSpeed, speedBlockedByCrowd, useSimulationStore } from "@/lib/game/simulation-store"
 
 /** Hover and keyboard-focus help, positioned inside the viewport by Radix.
  * @see https://app.paper.design/file/01M1QTYBYHXP4H1BXFQ79N18AP/2-0/1N5-0
@@ -165,10 +165,21 @@ export function BuildControls({ economy, open, onToggle, onClose, minimapOpen, o
  */
 export function HudClock() {
   const [time, setTime] = useState<number | null>(null)
+  const [population, setPopulation] = useState(0)
   const paused = useSimulationStore((s) => s.paused)
   const speed = useSimulationStore((s) => s.speed)
   useEffect(() => {
-    const read = () => setTime(simRegistry.current?.time ?? null)
+    // The same poll that shows the date watches the crowd, so a settlement that
+    // grows past the limit while running at 6× drops to the fastest speed left.
+    const read = () => {
+      const sim = simRegistry.current
+      setTime(sim?.time ?? null)
+      const crowd = (sim?.travelers.size ?? 0) + (sim?.joinedMonks.size ?? 0)
+      setPopulation(crowd)
+      const playback = useSimulationStore.getState()
+      const allowed = crowdSafeSpeed(playback.speed, crowd)
+      if (allowed !== playback.speed) playback.setSpeed(allowed)
+    }
     read()
     const timer = setInterval(read, 250)
     return () => clearInterval(timer)
@@ -186,11 +197,15 @@ export function HudClock() {
         const choice = SIMULATION_SPEEDS.find((item) => item.rate === Number(event.target.value))
         if (choice) useSimulationStore.getState().setSpeed(choice.rate)
       }}>
-      {SIMULATION_SPEEDS.map(({ label, rate }) => <option key={rate} value={rate}>{label}×</option>)}
+      {SIMULATION_SPEEDS.map(({ label, rate }) => <option key={rate} value={rate} disabled={speedBlockedByCrowd(rate, population)}>{label}×</option>)}
     </select>
     <div className="hud-speeds" aria-label="Simulation speed">
-      {SIMULATION_SPEEDS.map(({ label, rate }) => <button type="button" key={rate} aria-label={`${label}× simulation speed`} aria-pressed={speed === rate}
-        onClick={() => useSimulationStore.getState().setSpeed(rate)}>{label}×</button>)}
+      {SIMULATION_SPEEDS.map(({ label, rate }) => {
+        const blocked = speedBlockedByCrowd(rate, population)
+        return <button type="button" key={rate} aria-label={`${label}× simulation speed`} aria-pressed={speed === rate}
+          disabled={blocked} title={blocked ? `${label}× is unavailable above ${CROWD_SPEED_LIMIT.population.toLocaleString()} people` : undefined}
+          onClick={() => useSimulationStore.getState().setSpeed(rate)}>{label}×</button>
+      })}
     </div>
   </section>
 }

--- a/docs/performance-evaluation.md
+++ b/docs/performance-evaluation.md
@@ -587,10 +587,11 @@ measurements (`.context/city-rate-3x`, `-4x`, `-5x`):
 | 4× | 50.1 | 33.4 | 3 |
 | 5× | 36.3 | 50.1 | 11 |
 
-These comparisons initially motivated a 3× cap. The requested final controls
-are 0.5×, 1×, 2×, 3× and 6×; the benchmark also retains 4× and 5×. Normal
-playback remains 1×. Displayed multipliers
-remain honest: UI 3× uses internal rate 6, three times the normal rate 2.
+These comparisons initially motivated a 3× cap. The player controls are now
+0.5×, 1×, 3× and 6×, with 6× withheld above 2,000 people; the benchmark handle
+retains 2×, 4× and 5× and ignores that crowd limit. Normal playback remains 1×.
+Displayed multipliers remain honest: UI 3× uses internal rate 6, three times
+the normal rate 2.
 Characters keep their stable individual starting phases. Increasing playback
 never queues all skipped atlas frames for later rendering. Host desktop/browser
 activity still varied between the fresh runs, so these are measured comparisons

--- a/lib/game/save/schema.test.ts
+++ b/lib/game/save/schema.test.ts
@@ -50,10 +50,10 @@ describe("game save schema", () => {
 
   it("snaps a retired playback speed to the nearest one offered", () => {
     const input = minimal()
-    input.playback.speed = 12
-    expect(parseGameSave(input).save?.playback.speed).toBe(6)
     input.playback.speed = 4
-    expect(parseGameSave(input).save?.playback.speed).toBe(4)
+    expect(parseGameSave(input).save?.playback.speed).toBe(2)
+    input.playback.speed = 12
+    expect(parseGameSave(input).save?.playback.speed).toBe(12)
   })
 
   it("keeps world identity to the generation inputs", () => {

--- a/lib/game/simulation-store.test.ts
+++ b/lib/game/simulation-store.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from "vitest"
-import { MAX_SIMULATION_STEP, BENCHMARK_SIMULATION_SPEEDS, simulationFrameStep } from "./simulation-store"
+import { CROWD_SPEED_LIMIT, MAX_SIMULATION_STEP, BENCHMARK_SIMULATION_SPEEDS, SIMULATION_SPEEDS, crowdSafeSpeed, simulationFrameStep, simulationSpeedControl, speedBlockedByCrowd } from "./simulation-store"
 
 it("preserves playback time and the background-frame clamp with bounded combined ticks", () => {
   for (const { rate } of BENCHMARK_SIMULATION_SPEEDS) for (const delta of [0, 1 / 144, 1 / 60, 1 / 30, .0334, .034, .1, 2]) {
@@ -18,4 +18,27 @@ it("preserves playback time and the background-frame clamp with bounded combined
   expect(simulationFrameStep(1 / 30, 12)).toEqual({ ticks: 1, dt: .4 })
   expect(simulationFrameStep(.0334, 12).ticks).toBe(1)
   expect(simulationFrameStep(.034, 12).ticks).toBe(1)
+})
+
+it("withholds only the top speed once the crowd passes the limit", () => {
+  expect(SIMULATION_SPEEDS.map(speed => speed.label)).toEqual([0.5, 1, 3, 6])
+  for (const { rate } of SIMULATION_SPEEDS) {
+    expect(speedBlockedByCrowd(rate, CROWD_SPEED_LIMIT.population)).toBe(false)
+    expect(crowdSafeSpeed(rate, CROWD_SPEED_LIMIT.population)).toBe(rate)
+  }
+  const crowded = CROWD_SPEED_LIMIT.population + 1
+  for (const { rate } of SIMULATION_SPEEDS) expect(speedBlockedByCrowd(rate, crowded)).toBe(rate === CROWD_SPEED_LIMIT.rate)
+  expect(crowdSafeSpeed(12, crowded)).toBe(6)
+  expect(crowdSafeSpeed(6, crowded)).toBe(6)
+  expect(crowdSafeSpeed(1, crowded)).toBe(1)
+})
+
+it("lets the benchmark handle measure the top speed at any crowd size", () => {
+  simulationSpeedControl.crowdLimit = false
+  try {
+    expect(speedBlockedByCrowd(12, CROWD_SPEED_LIMIT.population * 5)).toBe(false)
+    expect(crowdSafeSpeed(12, CROWD_SPEED_LIMIT.population * 5)).toBe(12)
+  } finally {
+    simulationSpeedControl.crowdLimit = true
+  }
 })

--- a/lib/game/simulation-store.ts
+++ b/lib/game/simulation-store.ts
@@ -4,18 +4,38 @@ import { create } from "zustand"
 export const SIMULATION_SPEEDS = [
   { label: 0.5, rate: 1 },
   { label: 1, rate: 2 },
-  { label: 2, rate: 4 },
   { label: 3, rate: 6 },
-] as const
-
-/** Keep 6× and the intermediate comparison rates available to the opt-in benchmark handle. */
-export const BENCHMARK_SIMULATION_SPEEDS = [
-  ...SIMULATION_SPEEDS,
-  { label: 4, rate: 8 },
-  { label: 5, rate: 10 },
   { label: 6, rate: 12 },
 ] as const
+
+/** Keep the retired 2× and the intermediate comparison rates available to the opt-in benchmark handle. */
+export const BENCHMARK_SIMULATION_SPEEDS = [
+  ...SIMULATION_SPEEDS,
+  { label: 2, rate: 4 },
+  { label: 4, rate: 8 },
+  { label: 5, rate: 10 },
+] as const
 export type SimulationSpeed = typeof BENCHMARK_SIMULATION_SPEEDS[number]["rate"]
+
+/** A crowd this size already fills a frame at 3×; 6× on top of it drops the sim
+ * behind real time instead of running faster, so the HUD withholds the top speed. */
+export const CROWD_SPEED_LIMIT = { rate: 12, population: 2000 } as const
+
+/** Benchmarks measure the top speed at every crowd size; their handle clears this. */
+export const simulationSpeedControl = { crowdLimit: true }
+
+/** Whether a speed is out of reach for the current crowd. Only the top speed ever is. */
+export function speedBlockedByCrowd(rate: number, population: number): boolean {
+  return simulationSpeedControl.crowdLimit && rate === CROWD_SPEED_LIMIT.rate && population > CROWD_SPEED_LIMIT.population
+}
+
+/** Playback settles on the fastest speed the crowd still allows. */
+export function crowdSafeSpeed(rate: SimulationSpeed, population: number): SimulationSpeed {
+  if (!speedBlockedByCrowd(rate, population)) return rate
+  let fallback: SimulationSpeed = SIMULATION_SPEEDS[0].rate
+  for (const speed of SIMULATION_SPEEDS) if (speed.rate > fallback && !speedBlockedByCrowd(speed.rate, population)) fallback = speed.rate
+  return fallback
+}
 
 export const MAX_SIMULATION_STEP = .1 * 12
 


### PR DESCRIPTION
Playback offers 0.5×, 1×, 3× and 6× again: 6× returns and 2× is gone. The 6× button (and its mobile option) is disabled above 2,000 people, where the extra ticks no longer buy speed, and a settlement that grows past the limit while running at 6× falls back to 3× on the HUD clock's existing poll. The benchmark handle keeps every comparison rate, including the retired 2×, and lifts the crowd limit so `BENCH_SPEEDS=…,6` at 10,000 people measures what it always did. Saved games snap through the existing nearest-speed transform, so an old 2× save loads at 1× and a 6× save now stays at 6×.

Checked in the running app: a 204-person world offers all four speeds and takes 6×; a 3,212-person city shows 6× disabled with its tooltip and demotes a running 6× back to 3×. `tsc --noEmit` clean and the playback, sim and save tests pass (the full suite times out on this machine).

@see https://app.paper.design/file/01M1QTYBYHXP4H1BXFQ79N18AP/2-0/1GB-0

🤖 Generated with [Claude Code](https://claude.com/claude-code)