### PR TITLE
Set the market stall at 3×2 with a side cart bay, bare when unkept, and smoke only for occupied buildings

### DIFF
--- a/components/game/building-smoke.tsx
+++ b/components/game/building-smoke.tsx
@@ -11,8 +11,8 @@ import { innHearthRoofRise, singlePlaneRoofRise } from "@/lib/game/building-art/
 import { sharedChimneyMouth, type SharedChimney } from "@/lib/game/building-art/shared-chimney"
 
 /** Smoke from the downstairs fire, with no fire or light on the sleeping floor. */
-export function InnFlueSmoke({width,depth,height,flue,cutaway=false}: {width:number;depth:number;height:number;flue?: {x:number;z:number};cutaway?:boolean}) {
-  return flue && !cutaway ? <BuildingSmoke position={[flue.x,height+innHearthRoofRise(width,depth)+.345,flue.z]} /> : null
+export function InnFlueSmoke({width,depth,height,flue,cutaway=false,smoke=true}: {width:number;depth:number;height:number;flue?: {x:number;z:number};cutaway?:boolean;smoke?:boolean}) {
+  return flue && !cutaway && smoke ? <BuildingSmoke position={[flue.x,height+innHearthRoofRise(width,depth)+.345,flue.z]} /> : null
 }
 
 /** Reusable billboard smoke emitter, positioned at any building's chimney mouth. */

--- a/components/game/buildings.tsx
+++ b/components/game/buildings.tsx
@@ -11,6 +11,7 @@ import { ConstructionCostEffects, type ConstructionCostHandle } from "./construc
 import { PixelCharacters } from "@/components/pixel-canvas"
 import { buildingYaw, rotatedFootprint } from "@/lib/game/building-rotation"
 import { useUnitInterior } from "./use-unit-interior"
+import { useOccupiedBuildings } from "./use-building-occupancy"
 
 import { StructureModel } from "@/components/building-lab/building-model"
 import { constructionParts } from "@/lib/game/building-art/construction"
@@ -18,7 +19,7 @@ import { constructionStage, isComplete } from "@/lib/game/construction"
 
 import { groundHeight } from "@/lib/game/map/elevation"
 
-import { useEffect, useMemo, useRef } from "react"
+import { useCallback, useEffect, useMemo, useRef } from "react"
 import * as THREE from "three"
 
 import { isSelected, useCameraStore } from "@/lib/game/camera-store"
@@ -49,6 +50,9 @@ export function Buildings({ map, characterScale = 1.5, showInteriors = false }: 
     if (selectElement({ kind: "building", id: building.id }, event)) costs.current?.show(building)
   }
   const unitInterior = useUnitInterior(map)
+  // Hearths only smoke for someone; a market stall carries wares and cloth only under a keeper.
+  const occupied = useOccupiedBuildings(map)
+  const stocked = useCallback((building: BuildingDef) => building.buildType !== "market" || occupied.has(building.id), [occupied])
   const selection = useCameraStore(s => s.selection)
   const foodStores = useBuildStore(s => s.foodStores)
   const piles = useBuildStore((s) => s.piles)
@@ -66,16 +70,16 @@ export function Buildings({ map, characterScale = 1.5, showInteriors = false }: 
       const footprint = rotatedFootprint(building, building.rotation)
       const joins = roofJoins.get(building.id)
       const inns = supported.get(building.id) ?? []
-      const key = JSON.stringify([index, building.buildType, footprint.w, footprint.d, building.height, building.color, building.roofColor, building.layoutSeed, building.hearthZ, building.fireplace, building.floorHeight, building.supportId, building.tavernFlue, inns.map(b=>[b.id,b.x,b.z,b.floorHeight]), joins, constructionStage(building)])
+      const key = JSON.stringify([index, building.buildType, footprint.w, footprint.d, building.height, building.color, building.roofColor, building.layoutSeed, building.hearthZ, building.fireplace, building.floorHeight, building.supportId, building.tavernFlue, inns.map(b=>[b.id,b.x,b.z,b.floorHeight]), joins, constructionStage(building), stocked(building)])
       const old = modelCache.current.get(building.id)
       const model = old?.key === key ? old : { key,
-        parts: tavernStackParts(constructionParts({ ...building, ...footprint }, joins), building, inns), idColor: new THREE.Color(...encodeObjectId(buildingObjectId(index))) }
+        parts: tavernStackParts(constructionParts({ ...building, ...footprint, stocked: stocked(building) }, joins), building, inns), idColor: new THREE.Color(...encodeObjectId(buildingObjectId(index))) }
       next.set(building.id, model)
       return model
     })
     modelCache.current = next
     return result
-  }, [buildings, roofJoins])
+  }, [buildings, roofJoins, stocked])
   const idColors = useMemo(
     // Component tuples straight into the working colour space — an ID is data,
     // not a colour, so it must dodge sRGB conversion to survive readback.
@@ -89,7 +93,7 @@ export function Buildings({ map, characterScale = 1.5, showInteriors = false }: 
   return (
     <group>
       {waterPlacements.length > 0 && <WaterSources placements={waterPlacements} />}
-      <EntranceDetails map={map} idColors={idColors} onSelect={selectSite} />
+      <EntranceDetails map={map} idColors={idColors} onSelect={selectSite} stocked={stocked} />
       <PixelCharacters><ConstructionCostEffects ref={costs} map={map} characterScale={characterScale} /></PixelCharacters>
       {buildings.map((building, index) => {
         // The hovel has its own geometry (see shrine.tsx); its ID slot stays reserved.
@@ -136,9 +140,9 @@ export function Buildings({ map, characterScale = 1.5, showInteriors = false }: 
         return (
           <group key={building.id} position={[centreX, baseY, centreZ]} rotation={[0, buildingYaw(building.rotation), 0]} onClick={(event) => selectSite(building, event)}>
             <StructureModel terrainFloors parts={models[index].parts} idColor={idColors[index]} ink={false} cutaway={cutaway} surfaceMaterial={surfaceMaterial} />
-            {isComplete(building) && building.supportId && <InnFlueSmoke width={local.w} depth={local.d} height={building.height} flue={building.tavernFlue} cutaway={cutaway} />}
+            {isComplete(building) && building.supportId && <InnFlueSmoke width={local.w} depth={local.d} height={building.height} flue={building.tavernFlue} cutaway={cutaway} smoke={occupied.has(building.supportId)} />}
             {!isComplete(building) && <ConstructionProgress building={building} characterScale={characterScale} />}
-            {isComplete(building) && !building.supportId && hasDomesticHearth(building.buildType,building.layoutSeed,building.fireplace) && <ShelterFire smoke={!map.buildings.some(b=>b.supportId===building.id)} buildType={building.buildType} layoutSeed={building.layoutSeed} hearthZ={building.hearthZ} sharedChimney={roofJoins.get(building.id)?.find(join=>join.chimney)?.chimney} width={local.w} depth={local.d} height={building.height} cutaway={cutaway} />}
+            {isComplete(building) && !building.supportId && hasDomesticHearth(building.buildType,building.layoutSeed,building.fireplace) && <ShelterFire smoke={occupied.has(building.id) && !map.buildings.some(b=>b.supportId===building.id)} buildType={building.buildType} layoutSeed={building.layoutSeed} hearthZ={building.hearthZ} sharedChimney={roofJoins.get(building.id)?.find(join=>join.chimney)?.chimney} width={local.w} depth={local.d} height={building.height} cutaway={cutaway} />}
           </group>
         )
       })}

--- a/components/game/entrance-details.tsx
+++ b/components/game/entrance-details.tsx
@@ -11,9 +11,10 @@ import { groundHeight } from "@/lib/game/map/elevation"
 import { tileToWorldX, tileToWorldZ, type BuildingDef, type GameMap } from "@/lib/game/map/types"
 import { selectElement } from "@/lib/game/selection"
 
-/** Props belong to the reserved approach square, outside the shell's occupied tiles. */
-export function EntranceDetails({map,idColors,onSelect,variationSeed}:{map:GameMap;idColors:Color[];variationSeed?:(building:BuildingDef)=>number;onSelect:(building:BuildingDef,event:Parameters<typeof selectElement>[1])=>void}) {
-  const models=useMemo(()=>map.buildings.map(b=>entranceParts(b.id===map.site?.hovelId ? "shrine" : b.buildType ?? "house",b.height,variationSeed?.(b) ?? 17)),[map.buildings,map.site?.hovelId,variationSeed])
+/** Props belong to the reserved approach square, outside the shell's occupied tiles.
+ * A market's produce only stands out front while a keeper works the stall. */
+export function EntranceDetails({map,idColors,onSelect,variationSeed,stocked}:{map:GameMap;idColors:Color[];variationSeed?:(building:BuildingDef)=>number;stocked?:(building:BuildingDef)=>boolean;onSelect:(building:BuildingDef,event:Parameters<typeof selectElement>[1])=>void}) {
+  const models=useMemo(()=>map.buildings.map(b=>entranceParts(b.id===map.site?.hovelId ? "shrine" : b.buildType ?? "house",b.height,variationSeed?.(b) ?? 17,stocked?.(b) ?? true)),[map.buildings,map.site?.hovelId,variationSeed,stocked])
   return <group name="entrance-details">
     {map.buildings.map((building,index)=>{
       const at=buildingApproach(map,building)

--- a/components/game/use-building-occupancy.ts
+++ b/components/game/use-building-occupancy.ts
@@ -1,0 +1,22 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { occupiedBuildingIds, sameIds } from "@/lib/game/building-occupancy"
+import type { GameMap } from "@/lib/game/map/types"
+import { simRegistry } from "@/lib/game/sim"
+
+/** Poll the running sim, like the HUD does, and only re-render when a building
+ * gains or loses its last resident, worker or keeper. */
+export function useOccupiedBuildings(map: GameMap): ReadonlySet<string> {
+  const [occupied, setOccupied] = useState<ReadonlySet<string>>(() => occupiedBuildingIds(simRegistry.current, map))
+  useEffect(() => {
+    const read = () => setOccupied(previous => {
+      const next = occupiedBuildingIds(simRegistry.current, map)
+      return sameIds(previous, next) ? previous : next
+    })
+    read()
+    const timer = setInterval(read, 500)
+    return () => clearInterval(timer)
+  }, [map])
+  return occupied
+}

--- a/lib/game/balance.ts
+++ b/lib/game/balance.ts
@@ -148,7 +148,7 @@ export const BUILD_CATALOG: readonly BuildDefinition[] = [
   },
   {
     id: "market", label: "Market stall", category: "buildings",
-    description: "A cloth-canopied stall with a rear cart yard. A passing vendor parks their cart and animal here and settles to sell food and wares.",
+    description: "A stall with an open cart bay beside it. A passing vendor parks their cart and animal here, rigs the cloth and settles to sell food and wares.",
     cost: { gold: 50, wood: 30 }, renown: 3, requiredRenown: 10,
     income: { gold: 0, wood: 0 }, w: MARKET_WIDTH, d: MARKET_DEPTH, height: 0.65,
     color: "#8c7658", roofColor: "#a59164",

--- a/lib/game/building-art/construction.ts
+++ b/lib/game/building-art/construction.ts
@@ -1,11 +1,11 @@
 import type { BuildingDef } from "../map/types"
 import { constructionStage } from "../construction"
 import type { BuildingPart } from "./geometry"
-import { structureParts } from "./structure"
+import { structureParts, type StructureAppearance } from "./structure"
 import type { RoofJoin } from "./roof-joins"
 
 /** Staged site artwork uses the same geometry, pixel grid and ID pass as finished buildings. */
-export function constructionParts(building: BuildingDef, roofJoins: RoofJoin[] = []): BuildingPart[] {
+export function constructionParts(building: BuildingDef & Pick<StructureAppearance, "stocked">, roofJoins: RoofJoin[] = []): BuildingPart[] {
   const stage = constructionStage(building)
   const finished = structureParts(building, roofJoins)
   if (stage === 3) return finished

--- a/lib/game/building-art/early-geometry.ts
+++ b/lib/game/building-art/early-geometry.ts
@@ -2,7 +2,7 @@ import { innParts } from "./inn"
 import { furnishFloorplan } from "./floorplan"
 import { turnFurniture } from "./furniture-placement"
 import { tavernLayout } from "../tavern-layout"
-import { marketLayout } from "../market-layout"
+import { marketLayout, MARKET_STALL_WIDTH } from "../market-layout"
 import { EARLY_MATERIALS as palette } from "./materials"
 import type { BuildingPart, Vec3 } from "./geometry"
 import type { BuildingRecipe } from "./style"
@@ -34,6 +34,8 @@ type ConstructionRecipe = Omit<BuildingRecipe, "variant"> & {
   /** The shrine's raised nave retains its bespoke gabled construction. */
   roofForm?: "single-plane" | "gable"
   roofJoins?: RoofJoin[]
+  /** A market stall only carries wares and its cloth while a keeper works it. */
+  stocked?: boolean
 }
 
 /** Small early medieval structures built directly in tile units. No plot padding. */
@@ -62,22 +64,25 @@ export function earlyBuildingParts(recipe: ConstructionRecipe): BuildingPart[] {
 
 function authoredBuildingParts(recipe: ConstructionRecipe): BuildingPart[] {
   const parts: BuildingPart[] = [], { width, depth, variant } = recipe
-  if (variant === "market" && depth > 2) {
+  if (variant === "market" && width > MARKET_STALL_WIDTH) {
+    // Author the original two-column stall, then set it beside the open bay.
+    // The wrapper mirrors the whole layout, so the bay's hand is resolved there.
     const layout = marketLayout(width, depth)
-    const stall = authoredBuildingParts({ ...recipe, depth: layout.stallDepth }).map(part => ({
-      ...part, position: [part.position[0], part.position[1], part.position[2] + layout.stallZ] as Vec3,
+    const stall = authoredBuildingParts({ ...recipe, width: layout.stallWidth }).map(part => ({
+      ...part, position: [part.position[0] + layout.stallX, part.position[1], part.position[2]] as Vec3,
     }))
-    // Open sides let the wagon pull through. The low rear rail marks the bay
-    // without enclosing the horse under the cloth or obstructing its shafts.
+    // Both ends stay open so the team pulls straight in and out. Hitching
+    // posts on the outer corners mark the bay and tie the animal at either end
+    // without a rail the cart's wheels would run through.
     const box = (name: string, position: Vec3, size: Vec3, color: string): BuildingPart =>
       ({ name, layer: "base", position, size, color, outline: false })
+    const post = layout.bayX + layout.bayWidth / 2 - .08
     return [...stall,
-      { ...box("cart-yard", [0, BUILDING_FLOOR_TOP - .025, layout.yardZ], [width - .04, .05, layout.yardDepth - .04], "#ffffff"), surface: "trail" },
-      ...[-1, 1].map(side => box(`hitching-post-${side}`, [side * (width / 2 - .2), .28, -depth / 2 + .12], [.09, .56, .09], palette.wood)),
-      box("hitching-rail", [0, .42, -depth / 2 + .12], [width - .3, .075, .075], palette.wood),
+      { ...box("cart-bay", [layout.bayX, BUILDING_FLOOR_TOP - .025, 0], [layout.bayWidth - .04, .05, depth - .04], "#ffffff"), surface: "trail" },
+      ...[-1, 1].map(end => box(`hitching-post-${end}`, [post, .28, end * (depth / 2 - .1)], [.09, .56, .09], palette.wood)),
     ]
   }
-  const floor = variant === "storehouse" ? 0.3 : 0
+  const floor = variant === "storehouse" ? 0.3 : 0, stocked = recipe.stocked !== false
   const h=recipe.wallHeight, rise=recipe.roofRise
   const w = width / 2, d = depth / 2, rampStart = depth / 2 - Math.min(.65, depth * .43)
   const lean = recipe.roofForm !== "gable", eave = floor + h
@@ -573,7 +578,8 @@ function authoredBuildingParts(recipe: ConstructionRecipe): BuildingPart[] {
       }
     } else if (variant === "market") {
       bench("stall-counter",0,depth*.23,width*.72,.38)
-      for (let i=0;i<3;i++) box(`market-sack-${i}`,"base",[(i-1)*width*.2,floor+.15,-depth*.16],[width*.16,.3,depth*.25],[palette.strawDark,"#8b8067",palette.earth][i],undefined,false)
+      // Wares arrive with the keeper; an unkept stall is a bare counter.
+      if (stocked) for (let i=0;i<3;i++) box(`market-sack-${i}`,"base",[(i-1)*width*.2,floor+.15,-depth*.16],[width*.16,.3,depth*.25],[palette.strawDark,"#8b8067",palette.earth][i],undefined,false)
     } else if (variant === "guard-post") {
       bench("watch-seat",0,-depth*.16,width*.6,.24,0)
       pole("watch-staff",[x-.08,floor,-z+.06],[x-.08,eave+.1,-z+.06],.02)
@@ -594,8 +600,8 @@ function authoredBuildingParts(recipe: ConstructionRecipe): BuildingPart[] {
     parts.push(...thatchSurface(at(0,0),at(0,1),at(1,0),at(1,1),recipe.seed,String(sign)))
   }
   if(variant === "market" && lean) {
-    parts.push(...marketCanopyParts(width,depth,eave+.48))
-
+    // The keeper rigs the cloth when they take the stall; until then the frame stands open to the sky.
+    if (stocked) parts.push(...marketCanopyParts(width,depth,eave+.48))
   } else if(closed) {
     // Leave a real opening in the low roof for the long arched door brow.
     const cuts=[...new Set([-w,w,doorX-browHalf,doorX+browHalf,...(variant === "tavern" ? [rearDoorX-rearBrowHalf,rearDoorX+rearBrowHalf] : [])])].sort((a,b)=>a-b)

--- a/lib/game/building-art/entrance.ts
+++ b/lib/game/building-art/entrance.ts
@@ -3,8 +3,9 @@ import { reflectBuildingParts } from "../building-layout"
 import { BUILDING_DOOR_HEIGHT } from "./dimensions"
 import type { BuildingPart, Vec3 } from "./geometry"
 
-/** Furniture against the building edge of the reserved path tile; the middle stays wide enough to walk through. */
-export function entranceParts(type: string, wallHeight = .78, seed = 17): BuildingPart[] {
+/** Furniture against the building edge of the reserved path tile; the middle stays wide enough to walk through.
+ * A market's produce basket belongs to its keeper and is left out of an unkept stall. */
+export function entranceParts(type: string, wallHeight = .78, seed = 17, stocked = true): BuildingPart[] {
   const random = makeRng(seed), hand = random() < .5 ? -1 : 1, furnishing = (Math.floor(random()*3)+2)%3
   const wood = ["#806b4c", "#947b55", "#71634c"][Math.floor(random()*3)]
   const parts:BuildingPart[]=[]
@@ -25,7 +26,7 @@ export function entranceParts(type: string, wallHeight = .78, seed = 17): Buildi
     for(const side of [-1,1]) box(`chair-back-post-${side}`,[x+side*.085,.36,z-.085],[.028,.27,.028],"#806b4c")
     box("chair-back",[x,.45,z-.085],[.20,.08,.025],"#968058")
     }
-  } else if(type==="market" || type==="storehouse") {
+  } else if((type==="market" && stocked) || type==="storehouse") {
     box("basket",[x,.10,z],[.20,.20,.22],"#967e58")
     for(let i=0;i<3;i++) box(`produce-${i}`,[x+(i-1)*.05,.215,z],[.055,.055,.09],type==="market" ? ["#98634f","#899157","#ac8657"][i] : "#b29a6e")
   } else if(type==="sheep-pen") {

--- a/lib/game/building-art/structure.test.ts
+++ b/lib/game/building-art/structure.test.ts
@@ -37,7 +37,7 @@ describe("settlement construction", () => {
       expect(box.max.x, part.name).toBeLessThanOrEqual(building.w / 2 + .001)
       expect(box.min.z, part.name).toBeGreaterThanOrEqual(-building.d / 2 - .001 - (part.name.startsWith("tavern-outside-") ? .6 : 0))
       expect(box.max.z, part.name).toBeLessThanOrEqual(building.d / 2 + .001 + (part.name.startsWith("tavern-outside-") ? .6 : 0))
-      const groundSurface = part.name === "cart-yard" || part.name === "floor" && building.buildType !== "storehouse"
+      const groundSurface = part.name === "cart-bay" || part.name === "floor" && building.buildType !== "storehouse"
         || part.name.startsWith("paving-") || part.name.startsWith("garden-path-") || part.name === "hall-threshold"
       expect(box.min.y, part.name).toBeGreaterThanOrEqual(groundSurface ? -.06 : -.001)
       if (groundSurface) {

--- a/lib/game/building-art/structure.ts
+++ b/lib/game/building-art/structure.ts
@@ -11,7 +11,10 @@ import { EARLY_BUILDINGS, earlyBuildingRecipe } from "./style"
 import { singlePlaneRoofRise } from "./dimensions"
 import type { RoofJoin } from "./roof-joins"
 
-export type StructureAppearance = Pick<BuildingDef, "buildType" | "w" | "d" | "height" | "color" | "roofColor" | "layoutSeed" | "hearthZ" | "fireplace" | "floorHeight" | "supportId" | "tavernFlue">
+export type StructureAppearance = Pick<BuildingDef, "buildType" | "w" | "d" | "height" | "color" | "roofColor" | "layoutSeed" | "hearthZ" | "fireplace" | "floorHeight" | "supportId" | "tavernFlue"> & {
+  /** A market stall shows its cloth and wares only while a keeper works it; previews assume one. */
+  stocked?: boolean
+}
 
 const SETTLEMENT_TYPES: readonly SettlementBuildingType[] = [
   "shelter", "workshop", "hall", "garden", "cross", "lumberCamp", "market", "guard-post", "sheep-pen",
@@ -28,7 +31,7 @@ export function structureParts(building: StructureAppearance, roofJoins: RoofJoi
   if (preset) {
     const parts = building.buildType === "inn" && building.supportId
       ? innParts(building.w,building.d,building.height,false,17+(building.layoutSeed ?? 0),true,building.tavernFlue)
-      : earlyBuildingParts({ ...earlyBuildingRecipe(preset.id), layoutSeed: building.layoutSeed, hearthZ: building.hearthZ, fireplace: building.fireplace, roofJoins, width: building.w, depth: building.d, wallHeight: building.height,
+      : earlyBuildingParts({ ...earlyBuildingRecipe(preset.id), layoutSeed: building.layoutSeed, hearthZ: building.hearthZ, fireplace: building.fireplace, roofJoins, stocked: building.stocked, width: building.w, depth: building.d, wallHeight: building.height,
       roofRise: preset.id === "enclosure" ? 0 : singlePlaneRoofRise(building.d) })
     if (building.buildType === "inn" && building.supportId && building.floorHeight) {
       // The ladder opens into the right aisle beside the middle row of beds.
@@ -65,7 +68,7 @@ export function structureParts(building: StructureAppearance, roofJoins: RoofJoi
   if (isSettlementType(building.buildType)) return earlyBuildingParts({
     ...earlyBuildingRecipe("house"),
     variant: building.buildType,
-    layoutSeed: building.layoutSeed, hearthZ: building.hearthZ, fireplace: building.fireplace, roofJoins,
+    layoutSeed: building.layoutSeed, hearthZ: building.hearthZ, fireplace: building.fireplace, roofJoins, stocked: building.stocked,
     width: building.w,
     depth: building.d,
     wallHeight: building.height,

--- a/lib/game/building-art/style.ts
+++ b/lib/game/building-art/style.ts
@@ -65,7 +65,7 @@ export const EARLY_BUILDINGS = [
   { id: "shelter", name: "Pilgrim shelter", description: "An open resting shelter with straw beds, a bench and a domestic hearth.", width: 2, depth: 2, wallHeight: 0.62, roofRise: singlePlaneRoofRise(2) },
   { id: "workshop", name: "Woodcutter’s hut", description: "An open work court beside covered timber bays and a rear workbench.", width: 3, depth: 2, wallHeight: 0.68, roofRise: singlePlaneRoofRise(2) },
   { id: "hall", name: "Shrine hall", description: "An enclosed gathering hall with a sheltered doorway, timber benches and wooden crosses.", width: 2, depth: 3, wallHeight: 0.78, roofRise: singlePlaneRoofRise(3) },
-  { id: "market", name: "Market stall", description: "A cloth-covered counter with wares and an open cart yard behind it.", width: 4, depth: 4, wallHeight: 0.65, roofRise: singlePlaneRoofRise(4) },
+  { id: "market", name: "Market stall", description: "A cloth-covered counter with wares and an open cart bay beside it.", width: 3, depth: 2, wallHeight: 0.65, roofRise: singlePlaneRoofRise(2) },
   { id: "guard-post", name: "Guard post", description: "A small sheltered watch post with a bench and staff.", width: 2, depth: 2, wallHeight: 0.65, roofRise: singlePlaneRoofRise(2) },
   { id: "sheep-pen", name: "Sheep pen", description: "A hut and hearth beside an open railed fold with a gate and trough.", width: 3, depth: 2, wallHeight: 0.70, roofRise: singlePlaneRoofRise(2) },
   { id: "lumberCamp", name: "Timber yard", description: "An open timber yard with low boundary rails and space for live timber stacks.", width: 2, depth: 2, wallHeight: 0.65, roofRise: 0 },

--- a/lib/game/building-interior.ts
+++ b/lib/game/building-interior.ts
@@ -1,4 +1,4 @@
-import { marketYardContains } from "./market-layout"
+import { marketBayContains } from "./market-layout"
 import { groundHeight } from "./map/elevation"
 import { worldToTileX, worldToTileZ, type GameMap } from "./map/types"
 
@@ -8,7 +8,7 @@ export function unitInterior(map: GameMap, unit?: { x: number; y: number; z: num
   const x = worldToTileX(map, unit.x), z = worldToTileZ(map, unit.z)
   let selected: string | null = null, highest = -Infinity
   for (const building of map.buildings) {
-    if (!(x >= building.x && x < building.x+building.w && z >= building.z && z < building.z+building.d) || marketYardContains(building,{x,z})) continue
+    if (!(x >= building.x && x < building.x+building.w && z >= building.z && z < building.z+building.d) || marketBayContains(building,{x,z})) continue
     const floor = groundHeight(map,building.x+(building.w-1)/2,building.z+(building.d-1)/2)+(building.floorHeight ?? 0)
     if (floor > highest && unit.y >= floor-.2 && unit.y < floor+building.height) { selected=building.id; highest=floor }
   }

--- a/lib/game/building-navigation.ts
+++ b/lib/game/building-navigation.ts
@@ -3,7 +3,7 @@ import { crossroadIslandAt } from "./map/crossroads"
 import { tavernFurnitureClear } from "./tavern-layout"
 import { sheepPenLayout } from "./workshop-layout"
 import { buildingEntry, buildingFoldEntry, rotatedFootprint, rotateBuildingPoint } from "./building-rotation"
-import { marketYardContains } from "./market-layout"
+import { marketBayContains } from "./market-layout"
 import { isComplete, isEnterable } from "./construction"
 import { shrineLayout } from "./shrine-layout"
 import type { BuildingDef, GameMap, TilePos } from "./map/types"
@@ -58,7 +58,7 @@ export function buildingStepAllowed(map: GameMap, buildings: readonly BuildingDe
   if (crossroadIslandAt(map, to.x, to.z)) return false
   for (const building of buildings) {
     if (building.supportId) continue
-    const a = containsTile(building, from) && !marketYardContains(building, from), b = containsTile(building, to) && !marketYardContains(building, to)
+    const a = containsTile(building, from) && !marketBayContains(building, from), b = containsTile(building, to) && !marketBayContains(building, to)
     if (!a && !b) continue
     if (enterShrine && isEnterable(building) && isComplete(building)) {
       if (building.buildType === "sheep-pen") {

--- a/lib/game/building-occupancy.test.ts
+++ b/lib/game/building-occupancy.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest"
+import { occupiedBuildingIds, sameIds } from "./building-occupancy"
+import type { GameMap } from "./map/types"
+import type { SimState, SimTraveler } from "./sim"
+
+const person = (employer: string | null, home: string | null) => ({ employer, home }) as SimTraveler
+
+describe("occupied buildings", () => {
+  const map: GameMap = { width: 10, depth: 10, tiles: Array(100).fill("grass"), buildings: [
+    { id: "cell", buildType: "monk-shelter", label: "Monks’ shelter", x: 1, z: 1, w: 3, d: 2, height: .6, color: "tan", roofColor: "tan" },
+    { id: "house", buildType: "house", label: "House", x: 5, z: 1, w: 2, d: 2, height: .7, color: "tan", roofColor: "tan" },
+    { id: "stall", buildType: "market", label: "Market stall", x: 1, z: 5, w: 3, d: 2, height: .65, color: "tan", roofColor: "tan" },
+  ] }
+  const sim = (travelers: SimTraveler[], monks: { home?: string }[] = []): Pick<SimState, "travelers" | "joinedMonks"> => ({
+    travelers: new Map(travelers.map((t, id) => [id, t])),
+    joinedMonks: new Map(monks.map((monk, id) => [id, monk as SimState["joinedMonks"] extends Map<number, infer M> ? M : never])),
+  })
+
+  it("counts workers, residents and the founding brothers' shelter", () => {
+    expect([...occupiedBuildingIds(sim([]), map)]).toEqual(["cell"])
+    expect([...occupiedBuildingIds(sim([person("stall", null), person(null, "house")]), map)].sort()).toEqual(["cell", "house", "stall"])
+    expect(occupiedBuildingIds(null, map).size).toBe(0)
+  })
+
+  it("counts a later brother's recorded home", () => {
+    const cells = { ...map, buildings: [{ ...map.buildings[0], id: "cell-2", z: 8 }] }
+    expect([...occupiedBuildingIds(sim([], [{ home: "cell-2" }]), cells)]).toEqual(["cell-2"])
+  })
+
+  it("compares membership without order", () => {
+    expect(sameIds(new Set(["a", "b"]), new Set(["b", "a"]))).toBe(true)
+    expect(sameIds(new Set(["a"]), new Set(["a", "b"]))).toBe(false)
+    expect(sameIds(new Set(["a"]), new Set(["b"]))).toBe(false)
+  })
+})

--- a/lib/game/building-occupancy.ts
+++ b/lib/game/building-occupancy.ts
@@ -1,0 +1,25 @@
+import { monkBeds } from "./housing"
+import type { GameMap } from "./map/types"
+import { MONK_COUNT } from "./monks"
+import type { SimState } from "./sim"
+
+/** Buildings somebody lives or works in. Only these keep a hearth smoking and,
+ * at a market stall, wares on the counter under a rigged cloth. */
+export function occupiedBuildingIds(sim: Pick<SimState, "travelers" | "joinedMonks"> | null, map: GameMap): Set<string> {
+  const occupied = new Set<string>()
+  if (!sim) return occupied
+  for (const person of sim.travelers.values()) {
+    if (person.employer) occupied.add(person.employer)
+    if (person.home) occupied.add(person.home)
+  }
+  // The founding brothers take the first beds; later vows record a home directly.
+  for (const bed of monkBeds(map).slice(0, MONK_COUNT)) occupied.add(bed.home)
+  for (const monk of sim.joinedMonks.values()) if (monk.home) occupied.add(monk.home)
+  return occupied
+}
+
+export function sameIds(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
+  if (a.size !== b.size) return false
+  for (const id of a) if (!b.has(id)) return false
+  return true
+}

--- a/lib/game/buildings.ts
+++ b/lib/game/buildings.ts
@@ -89,7 +89,7 @@ export const BUILDING_KINDS: Record<BuildingKind, BuildingKindDef> = {
   market: {
     id: "market",
     label: "Market stall",
-    blurb: "A stall for one keeper, with a rear yard for their cart and animal.",
+    blurb: "A stall for one keeper, with an open bay beside it for their cart and animal.",
     w: MARKET_WIDTH,
     d: MARKET_DEPTH,
     height: 0.65,

--- a/lib/game/market-layout.test.ts
+++ b/lib/game/market-layout.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest"
+import { rotatedFootprint, type BuildingRotation } from "./building-rotation"
+import { BUILDING_KINDS } from "./buildings"
+import { MARKET_DEPTH, MARKET_STALL_WIDTH, MARKET_WIDTH, marketBayContains, marketLayout } from "./market-layout"
+import { workPost } from "./work-posts"
+
+function stall(rotation: BuildingRotation, layoutSeed?: number) {
+  return { ...BUILDING_KINDS.market, ...rotatedFootprint(BUILDING_KINDS.market, rotation), id: "market", buildType: "market", x: 10, z: 10, rotation, layoutSeed }
+}
+
+describe("market layout", () => {
+  it("sets the original two-column stall beside a one-tile bay", () => {
+    expect([MARKET_WIDTH, MARKET_DEPTH, MARKET_STALL_WIDTH]).toEqual([3, 2, 2])
+    const layout = marketLayout(3, 2)
+    expect(layout).toMatchObject({ hand: 1, stallWidth: 2, stallX: -.5, bayWidth: 1, bayX: 1 })
+    expect(marketLayout(3, 2, 1)).toMatchObject({ hand: -1, stallX: .5, bayX: -1 })
+    expect(marketLayout(2, 2)).toMatchObject({ stallWidth: 2, stallX: 0, bayWidth: 0 })
+  })
+
+  it.each([0, 1, 2, 3] as const)("finds the bay tile beside the stall at rotation %s", rotation => {
+    const building = stall(rotation)
+    const tiles = []
+    for (let z = building.z; z < building.z + building.d; z++) for (let x = building.x; x < building.x + building.w; x++) {
+      if (marketBayContains(building, { x, z })) tiles.push({ x, z })
+    }
+    expect(tiles).toHaveLength(2)
+    // The bay is one tile wide along the stall's whole depth.
+    expect(new Set(tiles.map(t => rotation % 2 ? t.z : t.x)).size).toBe(1)
+    expect(marketBayContains(building, { x: building.x - 1, z: building.z })).toBe(false)
+    expect(marketBayContains({ ...building, buildType: "house" }, tiles[0])).toBe(false)
+  })
+
+  it("mirrors the bay with the layout hand", () => {
+    expect(marketBayContains(stall(0), { x: 12, z: 10 })).toBe(true)
+    expect(marketBayContains(stall(0), { x: 10, z: 10 })).toBe(false)
+    expect(marketBayContains(stall(0, 1), { x: 10, z: 10 })).toBe(true)
+    expect(marketBayContains(stall(0, 1), { x: 12, z: 10 })).toBe(false)
+  })
+
+  it("keeps the keeper's post behind the counter inside the stall", () => {
+    for (const seed of [undefined, 1]) {
+      const post = workPost("market", 0, 3, 2, seed)!, layout = marketLayout(3, 2, seed)
+      expect(Math.abs(post.x - layout.stallX)).toBeLessThan(1)
+      expect(post.x * layout.hand).toBeLessThan(.5)
+    }
+  })
+})

--- a/lib/game/market-layout.ts
+++ b/lib/game/market-layout.ts
@@ -1,22 +1,27 @@
+import { layoutHand } from "./building-layout"
 import { rotateBuildingPoint, rotatedFootprint } from "./building-rotation"
 import type { BuildingDef, TilePos } from "./map/types"
 
-export const MARKET_WIDTH = 4
-export const MARKET_DEPTH = 4
-export const MARKET_STALL_DEPTH = 2
+export const MARKET_WIDTH = 3
+export const MARKET_DEPTH = 2
+export const MARKET_STALL_WIDTH = 2
 
-/** The front two rows hold the stall; the remaining plot is an open cart yard.
- * Old two-row stalls retain their original footprint and have no parking bay. */
-export function marketLayout(width: number, depth: number) {
-  const stallDepth = Math.min(depth, MARKET_STALL_DEPTH)
-  return { width, stallDepth, stallZ: (depth - stallDepth) / 2,
-    yardDepth: depth - stallDepth, yardZ: -stallDepth / 2 }
+/** The stall keeps its original two columns; whatever width remains beside it
+ * is the open cart bay, on the layout's own hand. Old two-column stalls have no
+ * bay, so no vendor can settle there. Offsets are in the placed local frame,
+ * measured from the footprint centre. */
+export function marketLayout(width: number, depth: number, layoutSeed?: number) {
+  const hand = layoutHand("market", layoutSeed)
+  const stallWidth = Math.min(width, MARKET_STALL_WIDTH), bayWidth = width - stallWidth
+  return { hand, stallWidth, stallX: bayWidth ? -bayWidth / 2 * hand : 0, depth, bayWidth, bayX: stallWidth / 2 * hand }
 }
 
-export function marketYardContains(building: BuildingDef, point: TilePos): boolean {
+/** The bay tiles are open ground: walkers and carts cross them, buildings do not. */
+export function marketBayContains(building: BuildingDef, point: TilePos): boolean {
   if (building.buildType !== "market") return false
-  const size = rotatedFootprint(building, building.rotation)
+  const size = rotatedFootprint(building, building.rotation), layout = marketLayout(size.w, size.d, building.layoutSeed)
+  if (!layout.bayWidth) return false
   const p = rotateBuildingPoint(point.x - building.x - (building.w - 1) / 2,
     point.z - building.z - (building.d - 1) / 2, -(building.rotation ?? 0))
-  return Math.abs(p.x) < size.w / 2 && p.z >= -size.d / 2 && p.z < size.d / 2 - MARKET_STALL_DEPTH
+  return Math.abs(p.z) < size.d / 2 && Math.abs(p.x) < size.w / 2 && p.x * layout.hand >= size.w / 2 - layout.bayWidth
 }

--- a/lib/game/transport/building-parking.test.ts
+++ b/lib/game/transport/building-parking.test.ts
@@ -4,29 +4,34 @@ import { describe, expect, it } from "vitest"
 import { BUILDING_KINDS } from "../buildings"
 import { buildingYaw, rotateBuildingPoint, rotatedFootprint, type BuildingRotation } from "../building-rotation"
 import { structureParts } from "../building-art/structure"
-import { marketYardContains } from "../market-layout"
+import { entranceParts } from "../building-art/entrance"
+import { marketBayContains } from "../market-layout"
 import { tileToWorldX, tileToWorldZ, type GameMap } from "../map/types"
 import { alignCart } from "./follow"
 import { cartOffset } from "./assets"
 import { cartPath, driveSegment, marketParking } from "./building-parking"
 import { convoyBuildingsClear, convoyClear } from "./navigation"
 
-function fixture(rotation: BuildingRotation = 0) {
+function fixture(rotation: BuildingRotation = 0, layoutSeed?: number) {
   const building = { ...BUILDING_KINDS.market, ...rotatedFootprint(BUILDING_KINDS.market, rotation),
-    id: "market", buildType: "market", x: 12, z: 12, rotation }
+    id: "market", buildType: "market", x: 12, z: 12, rotation, layoutSeed }
   const map: GameMap = { width: 30, depth: 30, tiles: Array(900).fill("grass"), buildings: [building] }
   const local = (x: number, z: number) => {
     const p = rotateBuildingPoint(x, z, rotation)
-    return { x: tileToWorldX(map, building.x) + 1.5 + p.x, z: tileToWorldZ(map, building.z) + 1.5 + p.z }
+    return { x: tileToWorldX(map, building.x) + (building.w - 1) / 2 + p.x, z: tileToWorldZ(map, building.z) + (building.d - 1) / 2 + p.z }
   }
   return { map, building, local }
 }
 
-describe("market cart yard", () => {
-  it.each([0, 1, 2, 3] as const)("parks the entire convoy behind the stall at rotation %s", rotation => {
+describe("market cart bay", () => {
+  it("keeps the two-column stall with a one-tile bay beside it", () => {
+    expect([BUILDING_KINDS.market.w, BUILDING_KINDS.market.d]).toEqual([3, 2])
+  })
+
+  it.each([0, 1, 2, 3] as const)("parks the cart and hitch inside the bay beside the stall at rotation %s", rotation => {
     for (const puller of ["hand", "donkey", "horse"] as const) {
       const { map, building, local } = fixture(rotation), wheelbase = -cartOffset(puller) * 1.5
-      const initial = alignCart(local(-5, -1), Math.PI / 2 + buildingYaw(rotation), wheelbase)
+      const initial = alignCart(local(-5, -3.5), Math.PI / 2 + buildingYaw(rotation), wheelbase)
       const plan = marketParking(map, building, initial, puller, 1.5, { trees: [] })
       expect(plan).not.toBeNull()
       let pose = initial
@@ -37,27 +42,53 @@ describe("market cart yard", () => {
         pose = next!
       }
       expect(pose).toEqual(plan!.parked)
-      expect(marketYardContains(building, { x: pose.x + 14.5, z: pose.z + 14.5 })).toBe(true)
-      expect(marketYardContains(building, { x: pose.hitch.x + 14.5, z: pose.hitch.z + 14.5 })).toBe(true)
+      expect(marketBayContains(building, { x: pose.x + 14.5, z: pose.z + 14.5 })).toBe(true)
+      expect(marketBayContains(building, { x: pose.hitch.x + 14.5, z: pose.hitch.z + 14.5 })).toBe(true)
+      // Parked along the bay, in line with the stall's depth.
+      const along = rotateBuildingPoint(0, 1, rotation)
+      expect(Math.abs(Math.sin(pose.heading) * along.x + Math.cos(pose.heading) * along.z)).toBeGreaterThan(.97)
     }
   })
 
+  it("parks on the mirrored layout's bay", () => {
+    const { map, building: mirrored, local } = fixture(0, 1)
+    const initial = alignCart(local(-5, -3.5), Math.PI / 2, -cartOffset("horse") * 1.5)
+    const plan = marketParking(map, mirrored, initial, "horse", 1.5, { trees: [] })
+    expect(plan).not.toBeNull()
+    expect(marketBayContains(mirrored, { x: plan!.parked.hitch.x + 14.5, z: plan!.parked.hitch.z + 14.5 })).toBe(true)
+    expect(plan!.parked.hitch.x).toBeLessThan(local(0, 0).x)
+  })
+
   it("rejects occupied bays and old stalls without space for a cart", () => {
-    const { map, building, local } = fixture(), initial = alignCart(local(-5, -1), Math.PI / 2, -cartOffset("horse") * 1.5)
-    const blocked = { trees: [], obstacles: [{ ...local(0, -1), heading: 0, halfWidth: 2, halfLength: 1 }] }
+    const { map, building, local } = fixture(), initial = alignCart(local(-5, -3.5), Math.PI / 2, -cartOffset("horse") * 1.5)
+    const blocked = { trees: [], obstacles: [{ ...local(1, 0), heading: 0, halfWidth: .5, halfLength: 1 }] }
     expect(marketParking(map, building, initial, "horse", 1.5, blocked)).toBeNull()
     expect(marketParking(map, { ...building, w: 2, d: 2 }, initial, "horse", 1.5, { trees: [] })).toBeNull()
   })
 
-  it("leaves the yard open to the sky with a rear hitching rail", () => {
+  it("leaves the bay open to the sky with hitching posts on its outer corners", () => {
     const { building } = fixture(), parts = structureParts(building)
-    expect(parts.some(p => p.name === "cart-yard")).toBe(true)
-    expect(parts.some(p => p.name === "hitching-rail")).toBe(true)
+    expect(parts.find(p => p.name === "cart-bay")?.position[0]).toBe(1)
+    const posts = parts.filter(p => p.name.startsWith("hitching-post-"))
+    expect(posts).toHaveLength(2)
+    for (const post of posts) { expect(post.position[0]).toBeGreaterThan(1.3); expect(Math.abs(post.position[2])).toBeGreaterThan(.8) }
     for (const roof of parts.filter(p => p.layer === "roof")) {
-      const zs = roof.vertices ? roof.vertices.filter((_, i) => i % 3 === 2).map(z => z + roof.position[2])
-        : [roof.position[2] - (roof.size?.[2] ?? 0) / 2]
-      expect(Math.min(...zs)).toBeGreaterThanOrEqual(-.05)
+      const xs = roof.vertices ? roof.vertices.filter((_, i) => i % 3 === 0).map(x => x + roof.position[0])
+        : [roof.position[0] + (roof.size?.[0] ?? 0) / 2]
+      expect(Math.max(...xs)).toBeLessThanOrEqual(.55)
     }
+  })
+
+  it("only stocks and covers a kept stall", () => {
+    const { building } = fixture()
+    const kept = structureParts(building), empty = structureParts({ ...building, stocked: false })
+    expect(kept.some(p => p.name.startsWith("market-cloth-"))).toBe(true)
+    expect(kept.some(p => p.name.startsWith("market-sack-"))).toBe(true)
+    expect(empty.some(p => p.name.startsWith("market-cloth-") || p.name.startsWith("market-sack-"))).toBe(false)
+    expect(empty.some(p => p.layer === "roof")).toBe(false)
+    for (const name of ["stall-counter", "cart-bay", "hitching-post-"]) expect(empty.some(p => p.name.startsWith(name))).toBe(true)
+    expect(entranceParts("market", .65, 17).some(p => p.name === "entry-basket")).toBe(true)
+    expect(entranceParts("market", .65, 17, false).some(p => p.name.startsWith("entry-basket") || p.name.startsWith("entry-produce"))).toBe(false)
   })
 })
 

--- a/lib/game/transport/building-parking.ts
+++ b/lib/game/transport/building-parking.ts
@@ -2,7 +2,7 @@ import { buildingYaw, rotateBuildingPoint, rotatedFootprint } from "../building-
 import { marketLayout } from "../market-layout"
 import { MinHeap } from "../map/route"
 import { tileToWorldX, tileToWorldZ, type BuildingDef, type GameMap } from "../map/types"
-import { cartOffset, type Puller } from "./assets"
+import { cartOffset, RIG_TO_WORLD, type Puller } from "./assets"
 import { alignCart, followCart, type CartPose } from "./follow"
 import { parkingClear, type ParkingContext, type ShrineParking } from "./navigation"
 import { routePoint, type Point } from "./roadside"
@@ -38,6 +38,10 @@ export function driveRouteSegment(pose: CartPose, route: readonly Point[], start
   return driveSegment(pose, routePoint(route, end), wheelbase, clear)
 }
 
+/** Heuristic weights for reaching a goal at a set heading, per radian of turn,
+ * unit of sideways offset and unit the goal lies behind the hitch. */
+const GUIDE = { turn: 2, lateral: 2, behind: 4 }
+
 /** Bounded forward-only search. Heading is part of the state: a pedestrian
  * route around a corner is not necessarily traversable with a trailing axle. */
 export function cartPath(map: GameMap, initial: CartPose, goal: Point, puller: Puller, scale: number,
@@ -53,6 +57,15 @@ export function cartPath(map: GameMap, initial: CartPose, goal: Point, puller: P
   const turn = (a: number, b: number) => Math.abs(Math.atan2(Math.sin(a - b), Math.cos(a - b)))
   const key = (p: CartPose, heading: number) => `${Math.round(p.hitch.x * 2)}:${Math.round(p.hitch.z * 2)}:${Math.round(heading * 8 / Math.PI)}:${Math.round(p.heading * 8 / Math.PI)}`
   const heuristic = (p: Point) => Math.hypot(p.x - goal.x, p.z - goal.z)
+  // Arriving at a fixed heading also costs the turn, any sideways offset from
+  // the goal's line, and a loop back when the goal lies behind the cart. Without
+  // these the search burns its budget on near-goal poses that cannot straighten.
+  const guide = (p: Point, heading: number) => {
+    if (goalHeading === undefined) return 0
+    const dx = goal.x - p.x, dz = goal.z - p.z, sx = Math.sin(goalHeading), cz = Math.cos(goalHeading)
+    const along = dx * sx + dz * cz, lateral = Math.abs(dx * cz - dz * sx)
+    return turn(heading, goalHeading) * GUIDE.turn + lateral * GUIDE.lateral + Math.max(0, -along) * GUIDE.behind
+  }
   const nodes = [{ pose: initial, heading: initial.heading, parent: -1, cost: 0 }]
   const costs = new Map<string, number>([[key(initial, initial.heading), 0]])
   const queue = new MinHeap(); queue.push(0, heuristic(initial.hitch))
@@ -80,30 +93,39 @@ export function cartPath(map: GameMap, initial: CartPose, goal: Point, puller: P
       if (cost >= (costs.get(id) ?? Infinity)) continue
       costs.set(id, cost)
       nodes.push({ pose: next, heading: nextHeading, parent: index, cost })
-      queue.push(nodes.length - 1, cost + heuristic(to) * 1.15)
+      queue.push(nodes.length - 1, cost + heuristic(to) * 1.15 + guide(to, nextHeading))
     }
   }
   return null
 }
 
-/** Park lengthwise across the open rear yard, approaching from either side.
+/** The parked cart keeps this much off the stall's side, toward the open
+ * ground, so a team that is still settling straight clears the counter. */
+const MARKET_BAY_OUTWARD = .15
+
+/** Pull nose-first into the open bay beside the stall from whichever end is
+ * nearer, and stop with the convoy centred on it: a long team may overhang the
+ * open ground at either end, which the clearance checks keep free of buildings.
  * The parked pose is the actual arrival pose, never a snapped replacement. */
 export function marketParking(map: GameMap, building: BuildingDef, initial: CartPose, puller: Puller, scale: number,
   context: ParkingContext): MarketParking | null {
-  const size = rotatedFootprint(building, building.rotation), layout = marketLayout(size.w, size.d)
-  if (layout.yardDepth < 2 || size.w < 4) return null
+  const size = rotatedFootprint(building, building.rotation), layout = marketLayout(size.w, size.d, building.layoutSeed)
+  if (!layout.bayWidth) return null
   const local = (x: number, z: number) => {
     const p = rotateBuildingPoint(x, z, building.rotation)
     return { x: tileToWorldX(map, building.x) + (building.w - 1) / 2 + p.x,
       z: tileToWorldZ(map, building.z) + (building.d - 1) / 2 + p.z }
   }
-  const sides = [1, -1].sort((a, b) => {
-    const x = local(-a * size.w / 2, layout.yardZ), y = local(-b * size.w / 2, layout.yardZ)
-    return Math.hypot(x.x - initial.hitch.x, x.z - initial.hitch.z) - Math.hypot(y.x - initial.hitch.x, y.z - initial.hitch.z)
-  })
-  for (const side of sides) {
-    const goal = local(side * .6, layout.yardZ), heading = side * Math.PI / 2 + buildingYaw(building.rotation)
-    if (!parkingClear(map, alignCart(goal, heading, -cartOffset(puller) * scale), puller, scale, context)) continue
+  // The convoy's reach ahead of and behind the hitch, as convoyBounds measures it.
+  const unit = RIG_TO_WORLD * scale, wheelbase = -cartOffset(puller) * scale
+  const ahead = puller === "hand" ? 0 : 1.75 * unit, behind = wheelbase + 1.02 * unit
+  const bayX = layout.bayX + layout.hand * MARKET_BAY_OUTWARD
+  const distance = (end: number) => { const p = local(bayX, end * size.d / 2); return Math.hypot(p.x - initial.hitch.x, p.z - initial.hitch.z) }
+  for (const end of [1, -1].sort((a, b) => distance(a) - distance(b))) {
+    // Entering from the front end means driving toward the rear, and vice versa.
+    const heading = (end === 1 ? Math.PI : 0) + buildingYaw(building.rotation)
+    const goal = local(bayX, -end * (behind - ahead) / 2)
+    if (!parkingClear(map, alignCart(goal, heading, wheelbase), puller, scale, context)) continue
     const route = cartPath(map, initial, goal, puller, scale, context, heading)
     if (route) return { ...route, buildingId: building.id, pose: initial, exit: [], returnProgress: 0, distance: 0, walking: false }
   }

--- a/lib/game/transport/navigation.ts
+++ b/lib/game/transport/navigation.ts
@@ -1,6 +1,6 @@
 import { mapBuildingQuery } from "../building-spatial"
 import { buildingYaw, rotateBuildingPoint, rotatedFootprint } from "../building-rotation"
-import { marketLayout, marketYardContains } from "../market-layout"
+import { marketLayout, marketBayContains } from "../market-layout"
 import type { TreePlacement } from "../trees/placement"
 import { pastureSegmentClear, type StallObstacle } from "./stall"
 import { cartGroundContacts, onBridgeDeck } from "./bridge-guide"
@@ -87,7 +87,7 @@ export function convoyClear(map: GameMap, pose: CartPose, puller: Puller, scale:
         }
         if (!(terrain === "grass" || terrain === "clearing" || (!grassOnly && (terrain === "dirt" || terrain === "path" || terrain === "track" || terrain === "bridge" || terrain === "ford")))) return false
         const building = nearby({ x, z }).find(b => x >= b.x && x < b.x + b.w && z >= b.z && z < b.z + b.d)
-        if ((building && !marketYardContains(building, { x, z })) || (!layout.rise[z * map.width + x] && Math.abs(groundHeight(map, x, z) - height) >= 0.3)) return false
+        if ((building && !marketBayContains(building, { x, z })) || (!layout.rise[z * map.width + x] && Math.abs(groundHeight(map, x, z) - height) >= 0.3)) return false
       }
     }
   }
@@ -124,11 +124,11 @@ export function convoyBuildingsClear(map: GameMap, pose: CartPose, puller: Pulle
   const nearby = mapBuildingQuery(map, padding)
   return bounds.every(body => nearby({ x: body.x + (map.width - 1) / 2, z: body.z + (map.depth - 1) / 2 }).every(building => {
     const size = rotatedFootprint(building, building.rotation)
-    const market = building.buildType === "market" ? marketLayout(size.w, size.d) : null
-    const offset = rotateBuildingPoint(0, market?.stallZ ?? 0, building.rotation)
+    const market = building.buildType === "market" ? marketLayout(size.w, size.d, building.layoutSeed) : null
+    const offset = rotateBuildingPoint(market?.stallX ?? 0, 0, building.rotation)
     const box = { x: tileToWorldX(map, building.x) + (building.w - 1) / 2 + offset.x,
       z: tileToWorldZ(map, building.z) + (building.d - 1) / 2 + offset.z,
-      heading: buildingYaw(building.rotation), halfWidth: size.w / 2, halfLength: (market?.stallDepth ?? size.d) / 2 }
+      heading: buildingYaw(building.rotation), halfWidth: (market?.stallWidth ?? size.w) / 2, halfLength: size.d / 2 }
     return !overlaps(body, box, 0)
   }))
 }

--- a/lib/game/work-posts.ts
+++ b/lib/game/work-posts.ts
@@ -25,6 +25,6 @@ export function workPost(type: string | undefined, slot: number, w: number, d: n
   const posts = type ? WORK_POSTS[type] : undefined
   if (!posts?.length) return null
   const [x, z] = posts[((slot % posts.length) + posts.length) % posts.length]
-  const layout = type === "market" ? marketLayout(w, d) : null
-  return { x: x * w * layoutHand(type,layoutSeed), z: layout ? layout.stallZ + z * layout.stallDepth : z * d }
+  const layout = type === "market" ? marketLayout(w, d, layoutSeed) : null
+  return { x: layout ? layout.stallX + x * layout.stallWidth * layout.hand : x * w * layoutHand(type,layoutSeed), z: z * d }
 }


### PR DESCRIPTION
The market stall returns to its original two-column form with a one-tile cart bay beside it instead of the 4×4 rear yard; vendors pull nose-first into the bay from the nearer end, and the cart path search gains heading-aware heuristic terms so the narrow bay no longer exhausts its budget (96/96 realistic road approaches succeed in a probe, versus 88/96 on main). An unkept stall shows no cloth canopy, sacks or produce basket until a keeper takes it. Hearth and inn flue smoke now appear only for buildings with a worker, resident or brother at home, read from the running sim by a polling hook in the building renderer. Navigation, interior tiles, work posts, the catalogue descriptions and the building-lab preset follow the new layout, with tests for the layout, occupancy, parking and bare-stall geometry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)