### PR TITLE
Reveal the map when an asset boundary never settles

### DIFF
--- a/lib/game/render/map-reveal.test.ts
+++ b/lib/game/render/map-reveal.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { MapRevealState } from "./map-reveal"
+import { MapRevealState, REVEAL_TIMEOUT } from "./map-reveal"
 
 function warm(state: MapRevealState, reducedMotion = false) {
   for (let frame = 0; frame < 3; frame++) state.advance(1 / 60, false, reducedMotion)
@@ -60,5 +60,54 @@ describe("map reveal readiness", () => {
     warm(second)
     second.advance(1 / 60, false, true)
     expect(second.phase).toBe("complete")
+  })
+
+  it("reveals a map whose assets never settle rather than stranding the player", () => {
+    const state = new MapRevealState()
+    state.begin() // A boundary that never resolves: the disposer is never called.
+    for (let second = 0; second < REVEAL_TIMEOUT - 1; second++)
+      for (let frame = 0; frame < 60; frame++) state.advance(1 / 60, true, false)
+    expect(state.phase).toBe("loading")
+    expect(state.timedOut).toBe(false)
+    for (let frame = 0; frame < 120; frame++) state.advance(1 / 60, true, false)
+    expect(state.phase).toBe("revealing")
+    expect(state.timedOut).toBe(true)
+    expect(state.pending).toBe(1)
+  })
+
+  it("completes a timed-out reveal under reduced motion", () => {
+    const state = new MapRevealState()
+    state.begin()
+    for (let frame = 0; frame < 60 * (REVEAL_TIMEOUT + 1); frame++) state.advance(1 / 60, true, true)
+    expect(state.phase).toBe("complete")
+    expect(state.progress).toBe(1)
+  })
+
+  it("does not let a stall between frames trip the timeout on its own", () => {
+    const state = new MapRevealState()
+    const finish = state.begin()
+    // A backgrounded tab reports one enormous delta; it must not count as the whole wait.
+    state.advance(600, true, false)
+    expect(state.phase).toBe("loading")
+    expect(state.timedOut).toBe(false)
+    finish()
+    warm(state)
+    expect(state.phase).toBe("revealing")
+    expect(state.timedOut).toBe(false)
+  })
+
+  it("runs the ordinary reveal to completion without the timeout interfering", () => {
+    const state = new MapRevealState()
+    const terrain = state.begin(), sprites = state.begin()
+    // A realistic load: assets settle after about two seconds of frames.
+    for (let frame = 0; frame < 120; frame++) state.advance(1 / 60, false, false)
+    expect(state.phase).toBe("loading")
+    terrain(); sprites()
+    warm(state)
+    expect(state.phase).toBe("revealing")
+    for (let frame = 0; frame < 120; frame++) state.advance(1 / 60, false, false)
+    expect(state.phase).toBe("complete")
+    expect(state.progress).toBe(1)
+    expect(state.timedOut).toBe(false)
   })
 })

--- a/lib/game/render/map-reveal.ts
+++ b/lib/game/render/map-reveal.ts
@@ -1,10 +1,25 @@
 export type MapRevealPhase = "loading" | "revealing" | "complete"
 
+/**
+ * Seconds of loading after which the map is revealed regardless of outstanding
+ * assets. A Suspense boundary that never settles — a texture decode that fails
+ * silently, a fetch stalled on a flaky connection — would otherwise hold
+ * `pending` above zero and strand the player on the loading screen forever.
+ */
+export const REVEAL_TIMEOUT = 20
+
+/** A single frame contributes at most this much, so a long stall between frames cannot trip the timeout on its own. */
+const MAX_FRAME_WAIT = .25
+
 /** Wait for committed assets and two warm frames before exposing the scene. */
 export class MapRevealState {
   pending = 0
   phase: MapRevealPhase = "loading"
   progress = 0
+  /** Seconds spent loading, capped per frame; drives the failure timeout. */
+  waited = 0
+  /** True when the reveal was forced by the timeout rather than by assets settling. */
+  timedOut = false
   private warmFrames = 0
 
   begin() {
@@ -21,7 +36,13 @@ export class MapRevealState {
 
   advance(delta: number, preparing: boolean, reducedMotion: boolean) {
     if (this.phase === "loading") {
-      if (this.pending || preparing) this.warmFrames = 0
+      this.waited += Math.min(delta, MAX_FRAME_WAIT)
+      // Never let an asset that cannot settle outlast the player's patience.
+      // Revealing early costs some pop-in; waiting forever costs the session.
+      if (this.waited >= REVEAL_TIMEOUT) {
+        this.timedOut = true
+        this.phase = reducedMotion ? "complete" : "revealing"
+      } else if (this.pending || preparing) this.warmFrames = 0
       else if (++this.warmFrames >= 3) this.phase = reducedMotion ? "complete" : "revealing"
     } else if (this.phase === "revealing") {
       // Shader compilation or a background tab must not swallow the reveal.


### PR DESCRIPTION
## Problem

`MapRevealState` held the loading screen for as long as `pending` was above zero, and nothing bounded that wait. A Suspense boundary that never resolves — a texture decode that fails silently, a fetch stalled on a flaky connection — pinned the count and stranded the player on "generating map" indefinitely.

The map itself was already generated behind it: `generateMap` is a synchronous `useMemo` in `game-shell.tsx` gated only on `booted`/`started`, neither of which depends on assets. So the symptom reads as "maps aren't generating" when the actual stall is asset readiness.

## Change

Give the loading phase a twenty second ceiling. Past it the reveal runs as it normally would — timing out into `revealing`, or straight to `complete` under reduced motion — so a map that cannot finish loading its assets is shown with some pop-in rather than never shown at all.

Each frame contributes at most a quarter second to that total, so a long stall between frames (a backgrounded tab reporting one enormous delta) cannot trip the ceiling on its own.

Scoped to the reveal/loading path; the generator is untouched.

## Tests

Four added to `map-reveal.test.ts`, all three failing before the change and passing after:

- a boundary that never settles still reveals, and reports `timedOut`
- a timed-out reveal completes immediately under reduced motion
- a single enormous frame delta does not trip the ceiling
- the ordinary reveal runs to completion with `timedOut` false

The four pre-existing tests in that file are unchanged and still pass.

## Note on CI

`main` is already red independently of this change: a clean checkout of `origin/main` fails 5 tests (`game.test.ts` site-menu assertion, `bridges`, `crossroads`, `road-lane`, `relic-line`). None of them reference `map-reveal`. Full suite on this branch: 2174 passed, with the same pre-existing failures plus the load-flaky `trees/foliage/instances.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)