### PR TITLE
Fix worker duties, party save accounting, and blocked map generation

### DIFF
--- a/lib/game/game.test.ts
+++ b/lib/game/game.test.ts
@@ -366,7 +366,7 @@ describe("site menu", () => {
 
   it("lists the asset workshops and path playgrounds under assets", () => {
     const assets = SITE_MENU.find((item) => item.label === "Assets")
-    expect(assets?.children?.map((c) => c.label)).toEqual(["Textures", "Playground", "Path playgrounds", "Map playground", "Pixel workshop"])
+    expect(assets?.children?.map((c) => c.label)).toEqual(["Textures", "Playground", "Path playgrounds", "Map playground", "Placement playground", "Pixel workshop"])
   })
 })
 

--- a/lib/game/hospitality.test.ts
+++ b/lib/game/hospitality.test.ts
@@ -582,6 +582,31 @@ describe("woodcutter huts", () => {
     expect(site.construction.work).toBe(0)
   })
 
+  it("recruits a spare keeper already at their post when a site appears", () => {
+    const { map, camp, traveler } = fixture()
+    const def = BUILD_CATALOG.find(b => b.id === "tavern")!
+    const tavern = { ...def, id: "tavern-0", buildType: "tavern", x: 13, z: 11, rotation: 0 as const }
+    map.buildings.push(tavern)
+    const people = [traveler(0), traveler(1)]
+    people[1].attributes.skills = ["carpentry"]
+    const sim = createSim(people, map)
+    sim.buildings = jobBuildings(map)
+    const keepers = people.map((t, jobSlot) => {
+      const s = sim.travelers.get(t.id)!
+      Object.assign(s, { employer: tavern.id, jobSlot, jobless: false, activity: "idle", moveSpeed: 0,
+        x: tileToWorldX(map, tavern.x + jobSlot), z: tileToWorldZ(map, tavern.z + tavern.d) })
+      return s
+    })
+    run(sim, people, map, 60, () => keepers.every(s => s.activity === "posted"))
+    expect(keepers.every(s => s.activity === "posted")).toBe(true)
+    const site = { ...camp, id: "construction-site", x: 5, z: 6, construction: { work: 0, required: 96 } }
+    map.buildings = [...map.buildings, site]
+    run(sim, people, map, 10, () => keepers[1].activity === "toBuild")
+    expect(keepers[1].activity).toBe("toBuild")
+    expect(keepers[1].buildRate).toBe(builderRate(["carpentry"]))
+    expect(["toPost", "posted"]).toContain(keepers[0].activity)
+  })
+
   it("sends an idle settled worker to build, then returns them to camp", () => {
     const { map, camp, traveler } = fixture()
     const t = traveler(0), sim = createSim([t], map), actor = sim.travelers.get(0)!
@@ -1042,6 +1067,8 @@ describe("houses, counters and posts", () => {
     run(sim, people, map, 2 * GAME_DAY_SECONDS)
     expect(sim.wagesPaid).toBe(0)
     expect(sim.treasuryGold).toBe(100)
+    expect(keeper.wageDay).toBe(Math.floor(sim.time))
+    expect(keeper.gold).toBe(Math.floor(sim.time) * sim.balance.rules.dailyWage)
   }, 20000)
 
   it("sends a fed resident to the counter for supper, and home to the larder when they cannot pay", () => {

--- a/lib/game/map/generate-map.test.ts
+++ b/lib/game/map/generate-map.test.ts
@@ -375,6 +375,21 @@ describe("generateMap", () => {
     }
   }, SWEEP_TIMEOUT)
 
+  it("routes seed 7920 around an inset that disconnects the road portals", () => {
+    const map = generateMap({ seed: 7920 })
+    expect(roadReachesEast(map)).toBe(true)
+    expect(map.road![0].x).toBe(0)
+    expect(map.road!.at(-1)!.x).toBe(map.width - 1)
+    expect(map.site!.branch.length).toBeGreaterThan(1)
+    for (let i = 1; i < map.road!.length; i++) {
+      const a = map.road![i - 1], b = map.road![i]
+      expect(Math.abs(a.x - b.x) + Math.abs(a.z - b.z)).toBe(1)
+      if (!carriesWater(map, a.x, a.z) && !carriesWater(map, b.x, b.z)) {
+        expect(Number.isFinite(elevationStep(map.elevation, a.z * map.width + a.x, b.z * map.width + b.x))).toBe(true)
+      }
+    }
+  })
+
   it("mixes open meadows with substantial, locally dense woodland", () => {
     for (const seed of SEEDS) {
       const map = mapFor(seed)

--- a/lib/game/map/generate-map.ts
+++ b/lib/game/map/generate-map.ts
@@ -475,9 +475,15 @@ export function generateMap(options: GenerateMapOptions): GameMap {
   const routeRoad = (a: TilePos, b: TilePos, wander: Float64Array): number[] => {
     const around = routeOverLand(a, b, width, depth, wander, walkable, walkable, MAX_BRIDGE_SPAN, elevation)
     if (around) return around
-    const route = routeOverLand(a, b, width, depth, wander, kind, passKind, MAX_BRIDGE_SPAN, elevation) ??
+    const bounded = routeOverLand(a, b, width, depth, wander, kind, passKind, MAX_BRIDGE_SPAN, elevation) ??
       routeOverLand(a, b, width, depth, wander, kind, passKind, Infinity, elevation) ??
       routeBlind(a, b, width, depth, wander, elevation, routeBounds(a, b, width, depth))
+    // The inset can cut a portal off from the interior even when its inward
+    // approach is clear. Relax the border only after every bounded route fails;
+    // keep the water and cliff checks so founding always receives a real road.
+    const route = bounded.length ? bounded :
+      routeOverLand(a, b, width, depth, wander, kind, passKind, Infinity, elevation, false) ??
+      routeBlind(a, b, width, depth, wander, elevation)
     // If an ancient stand seals the only legal river pass, it remains ordinary
     // woodland in this world. Never cut a through-road into its dark heart.
     const removed = new Set<number>()

--- a/lib/game/save/schema.ts
+++ b/lib/game/save/schema.ts
@@ -199,6 +199,8 @@ export const simulationSaveSchema = z.object({
   foodStores: z.array(z.tuple([z.string(), z.record(z.string(), finite.min(0))])).describe("Stored food by building id"),
   piles: z.array(z.object({ id: z.string(), campId: z.string(), slot: count, wood: finite.min(0) })).describe("Timber stacked at the camps"),
   travelers: z.array(travelerSaveSchema),
+  partyGold: z.array(z.tuple([count, finite.min(0)])).optional()
+    .describe("Shared purse baselines by party id; member balances include unreconciled transactions"),
   joinedMonks: z.array(joinedMonkSchema).describe("Friars who joined the brotherhood; they are no longer travelers"),
 }).describe("Progress of the living world on top of the settlement")
 

--- a/lib/game/save/simulation.ts
+++ b/lib/game/save/simulation.ts
@@ -4,6 +4,7 @@ import { MONK_COUNT, type Monk } from "../monks"
 import { roadPosition, type SimState, type SimTraveler } from "../sim"
 import { emptyFoodStock, type FoodStock } from "../storage"
 import type { Traveler } from "../travelers"
+import { pruneTravelParties, sharePartyNeeds, syncTravelParties } from "../travel-parties"
 import type { TreeModel } from "../trees/render-model"
 import type { SimulationSave, TravelerSave } from "./schema"
 
@@ -18,6 +19,16 @@ import type { SimulationSave, TravelerSave } from "./schema"
  * the seed; only their effects on the economy are kept.
  */
 export function captureSimulation(sim: SimState, treeModel: TreeModel): SimulationSave {
+  // A companion may have settled since the last party update. Finish the purse
+  // accounting on copies so their saved share belongs to them, without changing
+  // the live simulation or charging their companions again after a reload.
+  const travelers = new Map([...sim.travelers].map(([id, s]) => [id, { ...s }]))
+  const parties = new Map([...sim.parties].map(([id, party]) => [id, { ...party, members: [...party.members] }]))
+  for (const party of parties.values()) if (party.provisioned) {
+    const members = party.members.flatMap(id => travelers.has(id) ? [travelers.get(id)!] : [])
+    sharePartyNeeds(party, members, 0, 0, 0, 0)
+  }
+  pruneTravelParties(parties, travelers, sim.joinedMonks)
   return {
     time: sim.time,
     treeModel,
@@ -34,7 +45,8 @@ export function captureSimulation(sim: SimState, treeModel: TreeModel): Simulati
     treeResources: [...sim.treeResources].map(([index, tree]) => [index, { ...tree }]),
     foodStores: [...sim.foodStores].map(([id, stock]) => [id, { ...stock }]),
     piles: [...sim.piles.values()].map(pile => ({ ...pile })),
-    travelers: [...sim.travelers.values()].map(captureTraveler),
+    travelers: [...travelers.values()].map(captureTraveler),
+    partyGold: [...parties.values()].filter(party => party.provisioned).map(party => [party.id, party.gold]),
     joinedMonks: [...sim.joinedMonks].map(([travelerId, monk]) => ({ travelerId, monk: captureMonk(monk) })),
   }
 }
@@ -116,14 +128,47 @@ export function restoreSimulation(sim: SimState, save: SimulationSave, travelers
     if (!s || !t) continue
     restoreTraveler(sim, s, t, record, map, roadLength, workplaceIds, buildingIds)
   }
+  // Saved residents and joined brothers no longer belong to their seeded party.
+  // Rebuild before choosing the leader, without taking a second share from a
+  // resident's already saved purse.
+  syncTravelParties(sim.parties, travelers, sim.travelers)
+  const partyGold = new Map(save.partyGold)
   // Companies pick up from where their leader resumed and walk back into formation.
   for (const party of sim.parties.values()) {
     const leader = sim.travelers.get(party.members[0])
     if (!leader) continue
+    const members = party.members.map(id => sim.travelers.get(id)!)
     party.progress = leader.progress; party.direction = leader.direction
     party.headTile = Math.floor(leader.progress); party.speed = 0; party.formed = false
     party.diversion = undefined; party.provisioned = false
+    const gold = partyGold.get(party.id) ?? (save.partyGold === undefined && save.time > 0
+      ? legacyPartyGold(members) : undefined)
+    if (gold !== undefined) {
+      party.gold = gold
+      party.provisioned = true
+      party.hunger = members.reduce((sum, s) => sum + s.hunger, 0) / members.length
+      party.thirst = members.reduce((sum, s) => sum + s.thirst, 0) / members.length
+    }
   }
+}
+
+/** Older saves mirrored the purse onto every member without recording its
+ * baseline. Recover the most common balance, preferring the larger in a tie
+ * (one companion may just have paid for food). This preserves the usual shared
+ * purse; an old snapshot in which everyone transacted is inherently ambiguous.
+ * New saves carry the exact baseline, including an empty list before pooling.
+ */
+function legacyPartyGold(members: readonly SimTraveler[]): number {
+  const counts = new Map<number, number>()
+  let gold = 0, frequency = 0
+  for (const member of members) {
+    const count = (counts.get(member.gold) ?? 0) + 1
+    counts.set(member.gold, count)
+    if (count > frequency || (count === frequency && member.gold > gold)) {
+      gold = member.gold; frequency = count
+    }
+  }
+  return gold
 }
 
 function pickFood(stock: Record<string, number>): Partial<FoodStock> {
@@ -165,7 +210,7 @@ function restoreTraveler(
   s.progress = Math.min(roadLength, Math.max(0, record.progress))
   s.lane = record.lane
 
-  if (employer) {
+  if (employer || s.home) {
     // A settler resumes on the spot and asks their workplace for a task.
     s.x = record.position.x; s.y = record.position.y; s.z = record.position.z
     s.activity = "idle"

--- a/lib/game/sim.ts
+++ b/lib/game/sim.ts
@@ -1018,13 +1018,16 @@ function payWage(sim: SimState, s: SimTraveler): void {
   const day = Math.floor(sim.time)
   if (s.wageDay === day) return
   const workplace = sim.buildings.find(b => b.id === s.employer)
-  if (!workplace || workplace.owner === "independent") return
+  if (!workplace) return
   if (s.wageDay === undefined) { s.wageDay = day; return }
-  const wage = Math.max(0, Math.min(sim.balance.rules.dailyWage, sim.treasuryGold))
+  const independent = workplace.owner === "independent"
+  const wage = Math.max(0, independent ? sim.balance.rules.dailyWage : Math.min(sim.balance.rules.dailyWage, sim.treasuryGold))
   s.gold += wage
   s.wageDay = day
-  sim.wagesPaid += wage
-  sim.treasuryGold -= wage
+  if (!independent) {
+    sim.wagesPaid += wage
+    sim.treasuryGold -= wage
+  }
 }
 
 function donate(sim: SimState, giver: SimTraveler, recipient: SimTraveler): void {
@@ -1221,6 +1224,19 @@ function homeBedSlot(sim: SimState, s: SimTraveler): number {
 function ofTheEnclave(map: GameMap, workplace: PlacedBuilding | undefined, home: string | null): boolean {
   if (workplace) return workplace.owner !== "independent"
   return !home || map.buildings.find(b => b.id === home)?.owner !== "independent"
+}
+
+/** Keep the head keeper at work while other rested citizens help raise new sites. */
+function startCitizenBuild(sim: SimState, s: SimTraveler, t: Traveler, map: GameMap): boolean {
+  const workplace = sim.buildings.find(b => b.id === s.employer)
+  if (t.type.id === "vendor" || (workplace && isPostedWork(workplace.kind) && s.jobSlot === 0)
+    || !ofTheEnclave(map, workplace, s.home) || (s.happiness < HAPPINESS_THRESHOLD && s.gold >= DRINK_PRICE)
+    || Math.min(s.hunger, s.thirst) < SERVING_THRESHOLD || s.stamina < SETTLER_FED_AT) return false
+  s.workSlot = s.id
+  s.buildRate = builderRate(t.attributes.skills)
+  if (!assignBuildingTask(s, map, "build")) return false
+  s.activity = "toBuild"
+  return true
 }
 
 /** Complete counters with a keeper working, including patrols inside a tavern. */
@@ -2528,19 +2544,7 @@ export function stepSim(
         const fitForWork = !hungry && s.stamina >= SETTLER_FED_AT
         const unhappy = socialBreak
         const workplace = sim.buildings.find(b => b.id === s.employer)
-        // Raising a building is the whole enclave's business, not the brothers'
-        // alone: a keeper leaves the counter for it as readily as a woodcutter
-        // leaves the woods. The first slot of a posted house stays behind so a
-        // counter never closes for a site, and the site's own crew limit keeps
-        // everyone else at their usual work. A town down the road keeps its own
-        // household, and a vendor's stall is nobody's but the vendor's.
-        const sparedFromPost = !workplace || !isPostedWork(workplace.kind) || s.jobSlot > 0
-        if (!isVendor && sparedFromPost && !unhappy && fitForWork
-          && ofTheEnclave(map, workplace, s.home)) {
-          s.workSlot = s.id
-          s.buildRate = builderRate(t.attributes.skills)
-          if (assignBuildingTask(s, map, "build")) { s.activity = "toBuild"; break }
-        }
+        if (dt > 0 && startCitizenBuild(sim, s, t, map)) break
         // Standing behind a counter or in a fold asks little; a settler keeps
         // that post until they are genuinely hungry or tired.
         if (workplace && isPostedWork(workplace.kind) && !hungry && !unhappy && s.stamina > SETTLER_TIRED_AT) {
@@ -2625,6 +2629,9 @@ export function stepSim(
           s.timer = 0
         } else if (state === "posted" && !s.herdingRetry) {
           s.herdingRetry = 5
+          // A staffed counter may predate the site. Reconsider construction on
+          // the existing work poll instead of waiting for hunger or exhaustion.
+          if (startCitizenBuild(sim, s, t, map)) break
           seekSheep(s, sim.wildlife, map, characterScale)
         }
         break

--- a/lib/game/travel-parties.test.ts
+++ b/lib/game/travel-parties.test.ts
@@ -11,6 +11,8 @@ import { tileToWorldX, tileToWorldZ, worldToTileX, worldToTileZ, type GameMap } 
 import { shrineVisitPlan } from "./shrine-visit"
 import { generateMap } from "./map/generate-map"
 import type { TravelParty } from "./travel-parties"
+import { captureSimulation, restoreSimulation } from "./save/simulation"
+import { simulationSaveSchema } from "./save/schema"
 
 function fixture(count = 6, direction: 1 | -1 = 1) {
   const map: GameMap = { width: 80, depth: 20, seed: 42, tiles: Array(1600).fill("grass"), buildings: [],
@@ -414,6 +416,86 @@ describe("tireless travel", () => {
 })
 
 describe("shared provisions and purse", () => {
+  it.each([0, 3])("resumes an older mirrored purse with a pending expense of %i", expense => {
+    const { map, travelers, sim } = fixture(4)
+    stepSim(sim, travelers, map, 1, .1)
+    const total = sim.parties.get(0)!.gold
+    const saved = captureSimulation(sim, "sprites")
+    delete saved.partyGold
+    saved.travelers[0].gold -= expense
+    const fresh = createSim(travelers, map)
+    restoreSimulation(fresh, simulationSaveSchema.parse(saved), travelers, map)
+    fresh.parties.get(0)!.transportInitialized = true
+    stepSim(fresh, travelers, map, 1, .1)
+    expect(fresh.parties.get(0)!.gold).toBe(total - expense)
+  })
+
+  it("pools individual purses once when resuming before the first simulation step", () => {
+    const { map, travelers, sim } = fixture(4)
+    const total = [...sim.travelers.values()].reduce((sum, s) => sum + s.gold, 0)
+    const saved = simulationSaveSchema.parse(JSON.parse(JSON.stringify(captureSimulation(sim, "sprites"))))
+    const fresh = createSim(travelers, map)
+    restoreSimulation(fresh, saved, travelers, map)
+    fresh.parties.get(0)!.transportInitialized = true
+    stepSim(fresh, travelers, map, 1, .1)
+    expect(fresh.parties.get(0)!.gold).toBe(total)
+  })
+
+  it("saves a departing companion's share without changing the live party", () => {
+    const { map, travelers, sim } = fixture(4)
+    const def = BUILD_CATALOG.find(b => b.id === "house")!
+    map.buildings.push({ ...def, id: "house-0", buildType: "house", x: 20, z: 9 })
+    stepSim(sim, travelers, map, 1, .1)
+    const party = sim.parties.get(0)!, resident = sim.travelers.get(0)!
+    const total = party.gold
+    // Recruitment happens after party upkeep; autosave can run before the next tick.
+    resident.home = "house-0"
+    resident.gold -= 4
+    const saved = simulationSaveSchema.parse(JSON.parse(JSON.stringify(captureSimulation(sim, "sprites"))))
+    expect(party.members).toEqual([0, 1, 2, 3])
+    expect(party.gold).toBe(total)
+    expect(resident.gold).toBe(total - 4)
+    const fresh = createSim(travelers, map)
+    restoreSimulation(fresh, saved, travelers, map)
+    expect(fresh.travelers.get(0)!.gold).toBe((total - 4) / 4)
+    expect(fresh.parties.get(0)!.gold).toBe((total - 4) * 3 / 4)
+  })
+
+  it("preserves the shared purse across repeated save and resume cycles", () => {
+    const { map, travelers, sim } = fixture(4)
+    stepSim(sim, travelers, map, 1, .1)
+    const gold = sim.parties.get(0)!.gold
+    // Include a transaction since the last reconciliation of the shared purse.
+    sim.travelers.get(1)!.gold -= 3
+    let current = sim
+    for (let reload = 0; reload < 3; reload++) {
+      const save = simulationSaveSchema.parse(JSON.parse(JSON.stringify(captureSimulation(current, "sprites"))))
+      current = createSim(travelers, map)
+      restoreSimulation(current, save, travelers, map)
+      current.parties.get(0)!.transportInitialized = true
+      stepSim(current, travelers, map, 1, .1)
+      expect(current.parties.get(0)!.gold).toBeCloseTo(gold - 3)
+    }
+  })
+
+  it("resumes a housed companion without a job as a resident outside the traveling party", () => {
+    const { map, travelers, sim } = fixture(4)
+    const def = BUILD_CATALOG.find(b => b.id === "house")!
+    const house = { ...def, id: "house-0", buildType: "house", x: 20, z: 9 }
+    map.buildings.push(house)
+    const resident = sim.travelers.get(0)!
+    Object.assign(resident, { home: house.id, employer: null, jobless: true, activity: "idle",
+      x: tileToWorldX(map, house.x), z: tileToWorldZ(map, house.z + house.d) })
+    stepSim(sim, travelers, map, 1, .1)
+    const saved = simulationSaveSchema.parse(JSON.parse(JSON.stringify(captureSimulation(sim, "sprites"))))
+    const fresh = createSim(travelers, map)
+    restoreSimulation(fresh, saved, travelers, map)
+    expect(fresh.travelers.get(0)).toMatchObject({ home: house.id, employer: null, activity: "idle",
+      partyId: undefined, x: resident.x, y: resident.y, z: resident.z })
+    expect(fresh.parties.get(0)!.members).toEqual([1, 2, 3])
+    expect(fresh.parties.get(0)!.progress).toBe(fresh.travelers.get(1)!.progress)
+  })
+
   it("eases the drain with company size and charges every animal", () => {
     expect(partyNeedDrain(1)).toBe(1)
     expect(partyNeedDrain(20)).toBeCloseTo(PARTY_NEED_FLOOR, 9)


### PR DESCRIPTION
Reviewing recent Opus changes exposed workers ignoring construction, missing town wages, and save/resume errors that put residents back on the road and multiplied party money. A related generator failure also crashed seed 7920 before a map could load.

- Reconsider construction for spare posted keepers on the existing work poll, preserving the head keeper and independent town crews.
- Pay independent workers from their town without charging the player's treasury.
- Restore housed residents in place, rebuild traveling rosters, and persist shared-purse baselines. Snapshot pending departures on copies so saving cannot alter live balances or duplicate a departing resident's share.
- Retry road routing outside the border inset after all bounded routes fail, preserving terrain checks. Seed 7920 now has a continuous road and reachable founding site.
- Update the stale menu assertion for the existing Placement playground.

Reviewed the ten September 9–11 PRs with explicit Opus co-author credits: #187, #188, #189, #190, #206, #248, #249, #250, #251, #253, including the travel-party persistence integration in #193/#194. The fixes have regression cases that failed before their changes.

New saves preserve exact shared-purse accounting, including transactions and recruitment between ticks. Older saves did not record the baseline; their most common mirrored balance is used. An old snapshot where everyone changed their balance cannot be reconstructed exactly.

Validation:
- `npm run typecheck` and `git diff --check` pass; Vercel preview deployment succeeds.
- Final runs cover 2,187 passing tests: 2,103 outside the generator suite (one 5-second road-lane timeout passed on an isolated rerun), plus 84 generator tests, including the new seed 7920 case. All 23 bridge tests pass.
- The remaining generator test, “prefers open ground when elevation does not constrain the road,” exceeds its existing 90-second timeout on both the baseline and review runs. It was excluded from the final generator run; its budget and assertions were left unchanged.
- Regression coverage includes posted-worker recruitment, independent payroll, resident/party restoration, exact shared gold across repeated reloads, old-save recovery, pre-first-tick saves, and capture immediately after recruitment without mutating live state.
